### PR TITLE
bump: update akka-grpc to 2.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,8 +10,6 @@ object Dependencies {
   // changing the Scala version of the Java SDK affects end users
   val ScalaVersion = "2.13.5"
 
-  // Note: sync with Protobuf version in Akka gRPC and ScalaPB
-  // https://github.com/akka/akka-grpc/blob/v2.0.0/project/Dependencies.scala#L26
   val ProtobufVersion = akka.grpc.gen.BuildInfo.googleProtobufVersion
 
   val AkkaVersion = "2.6.14"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   // Note: sync with Protobuf version in Akka gRPC and ScalaPB
   // https://github.com/akka/akka-grpc/blob/v2.0.0/project/Dependencies.scala#L26
-  val ProtobufVersion = "3.17.1"
+  val ProtobufVersion = akka.grpc.gen.BuildInfo.googleProtobufVersion
 
   val AkkaVersion = "2.6.14"
   val AkkaHttpVersion = "10.2.4" // Note: should at least the Akka HTTP version required by Akka gRPC

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,8 +11,8 @@ object Dependencies {
   val ScalaVersion = "2.13.5"
 
   // Note: sync with Protobuf version in Akka gRPC and ScalaPB
-  // https://github.com/akka/akka-grpc/blob/v1.1.1/project/Dependencies.scala#L77
-  val ProtobufVersion = "3.15.1"
+  // https://github.com/akka/akka-grpc/blob/v2.0.0/project/Dependencies.scala#L26
+  val ProtobufVersion = "3.17.1"
 
   val AkkaVersion = "2.6.14"
   val AkkaHttpVersion = "10.2.4" // Note: should at least the Akka HTTP version required by Akka gRPC

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.4")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-// Note: check synced Protobuf version in Dependencies.scala when updating sbt-akka-grpc
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.0.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.6.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.4")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "1.1.1")
+// Note: check synced Protobuf version in Dependencies.scala when updating sbt-akka-grpc
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.0.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.6.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")


### PR DESCRIPTION
I haven't bumped the akka-grpc version in the samples. They fail to build with the java-sdk on beta.10 and akka-grpc plugin on 2.0.0. While it seems fine with newer java-sdk (built against akka-grpc 2.0.0) and the older akka-grpc plugin — and this should be tested in CI as well.

So probably best to wait with bumping the samples until next java-sdk release, and bump both versions together. And also do this in the maven archetypes.
