### PR TITLE
fix: formatting protos

### DIFF
--- a/samples/java-valueentity-shopping-cart/src/main/proto/shoppingcart/shoppingcart_api.proto
+++ b/samples/java-valueentity-shopping-cart/src/main/proto/shoppingcart/shoppingcart_api.proto
@@ -26,62 +26,62 @@ import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 
 message AddLineItem {
-    string cart_id = 1 [(akkaserverless.field).entity_key = true];
-    string product_id = 2;
-    string name = 3;
-    int32 quantity = 4;
+  string cart_id = 1 [(akkaserverless.field).entity_key = true];
+  string product_id = 2;
+  string name = 3;
+  int32 quantity = 4;
 }
 
 message RemoveLineItem {
-    string cart_id = 1 [(akkaserverless.field).entity_key = true];
-    string product_id = 2;
+  string cart_id = 1 [(akkaserverless.field).entity_key = true];
+  string product_id = 2;
 }
 
 message GetShoppingCart {
-    string cart_id = 1 [(akkaserverless.field).entity_key = true];
+  string cart_id = 1 [(akkaserverless.field).entity_key = true];
 }
 
 message RemoveShoppingCart {
-    string cart_id = 1 [(akkaserverless.field).entity_key = true];
+  string cart_id = 1 [(akkaserverless.field).entity_key = true];
 }
 
 message LineItem {
-    string product_id = 1;
-    string name = 2;
-    int32 quantity = 3;
+  string product_id = 1;
+  string name = 2;
+  int32 quantity = 3;
 }
 
 message Cart {
-    repeated LineItem items = 1;
+  repeated LineItem items = 1;
 }
 
 service ShoppingCartService {
-    option (akkaserverless.service) = {
+  option (akkaserverless.service) = {
     type: SERVICE_TYPE_ENTITY
     component: ".domain.ShoppingCart"
   };
 
-    rpc AddItem (AddLineItem) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
+  rpc AddItem (AddLineItem) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
             post: "/cart/{cart_id}/items/add"
             body: "*"
         };
-    }
+  }
 
-    rpc RemoveItem (RemoveLineItem) returns (google.protobuf.Empty) {
-        option (google.api.http).post = "/cart/{cart_id}/items/{product_id}/remove";
-    }
+  rpc RemoveItem (RemoveLineItem) returns (google.protobuf.Empty) {
+    option (google.api.http).post = "/cart/{cart_id}/items/{product_id}/remove";
+  }
 
-    rpc GetCart (GetShoppingCart) returns (Cart) {
-        option (google.api.http) = {
+  rpc GetCart (GetShoppingCart) returns (Cart) {
+    option (google.api.http) = {
             get: "/carts/{cart_id}"
             additional_bindings: {
                 get: "/carts/{cart_id}/items"
                 response_body: "items"
             } };
-    }
-    rpc RemoveCart (RemoveShoppingCart) returns (google.protobuf.Empty) {
-        option (google.api.http).post = "/carts/{cart_id}/remove";
-    }
+  }
+  rpc RemoveCart (RemoveShoppingCart) returns (google.protobuf.Empty) {
+    option (google.api.http).post = "/carts/{cart_id}/remove";
+  }
 }
 // end::api[]

--- a/samples/java-valueentity-shopping-cart/src/main/proto/shoppingcart/shoppingcart_domain.proto
+++ b/samples/java-valueentity-shopping-cart/src/main/proto/shoppingcart/shoppingcart_domain.proto
@@ -31,13 +31,13 @@ option (akkaserverless.file).value_entity = {
 };
 
 message LineItem {
-    string productId = 1;
-    string name = 2;
-    int32 quantity = 3;
+  string productId = 1;
+  string name = 2;
+  int32 quantity = 3;
 }
 
 // The shopping cart state.
 message Cart {
-    repeated LineItem items = 1;
+  repeated LineItem items = 1;
 }
 // end::domain[]

--- a/samples/valueentity-counter/src/main/proto/value-entities/counter_api.proto
+++ b/samples/valueentity-counter/src/main/proto/value-entities/counter_api.proto
@@ -10,35 +10,35 @@ package com.example; // <2>
 option java_outer_classname = "CounterApi"; // <3>
 
 message IncreaseValue { // <4>
-    string counter_id = 1 [(akkaserverless.field).entity_key = true]; // <5>
-    int32 value = 2;
+  string counter_id = 1 [(akkaserverless.field).entity_key = true]; // <5>
+  int32 value = 2;
 }
 
 message DecreaseValue {
-    string counter_id = 1 [(akkaserverless.field).entity_key = true];
-    int32 value = 2;
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
 }
 
 message ResetValue {
-    string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
 }
 
 message GetCounter {
-    string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
 }
 
 message CurrentCounter { // <6>
-    int32 value = 1;
+  int32 value = 1;
 }
 
 service CounterService { // <7>
-    option (akkaserverless.service) = { // <8>
-        type : SERVICE_TYPE_ENTITY
-        component : ".domain.Counter"
-    };
+  option (akkaserverless.service) = { // <8>
+    type : SERVICE_TYPE_ENTITY
+     component : ".domain.Counter"
+  };
 
-    rpc Increase(IncreaseValue) returns (google.protobuf.Empty);
-    rpc Decrease(DecreaseValue) returns (google.protobuf.Empty);
-    rpc Reset(ResetValue) returns (google.protobuf.Empty);
-    rpc GetCurrentCounter(GetCounter) returns (CurrentCounter);
+  rpc Increase (IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease (DecreaseValue) returns (google.protobuf.Empty);
+  rpc Reset (ResetValue) returns (google.protobuf.Empty);
+  rpc GetCurrentCounter (GetCounter) returns (CurrentCounter);
 }

--- a/samples/valueentity-counter/src/main/proto/value-entities/counter_domain.proto
+++ b/samples/valueentity-counter/src/main/proto/value-entities/counter_domain.proto
@@ -13,5 +13,5 @@ option (akkaserverless.file).value_entity = { // <4>
 };
 
 message CounterState { // <8>
-    int32 value = 1;
+  int32 value = 1;
 }


### PR DESCRIPTION
Formats Shopping Cart VE and Counter VE protos with indent 2. 

This seems to be tricky when using intellij and antora callouts `// <1>`, as the formatter will align with the callout, like in:

```proto
message IncreaseValue { // <4>
  						string counter_id = 1 [(akkaserverless.field).entity_key = true];
  						int32 value = 2;
}
```

The best would be to have a formatter that does what we want at build time, so we don't run the risk of inadvertently format the protos, miss the bad formatting and messing up with the docs. 

