### PR TITLE
chore: rename docs module from java-services to java

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # Make Akka Serverless Java SDK documentation
 
-module   := java-services
+module   := java
 upstream := lightbend/akkaserverless-java-sdk
 branch   := docs/current
 sources  := src build/src/managed
@@ -20,6 +20,9 @@ clean:
 managed: attributes apidocs examples
 	mkdir -p "${src_managed}"
 	cp src/antora.yml "${src_managed}/antora.yml"
+	# FIXME: remove after module renaming transition
+	# Copy the module to the old `java-services` as well
+	cp -r ${src_managed}/modules/${module} ${src_managed}/modules/java-services
 
 attributes:
 	mkdir -p "${managed_partials}"


### PR DESCRIPTION
Rename from `java-services` to `java`. Keep a copy at the old location during the transition. Already published to the [`docs/current` branch](https://github.com/lightbend/akkaserverless-java-sdk/tree/docs/current/docs/build/src/managed/modules).