### PR TITLE
doc: switch back to publishing to docs/current branch

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 
 module   := java
 upstream := lightbend/akkaserverless-java-sdk
-branch   := docs/tmp/current
+branch   := docs/current
 sources  := src build/src/managed
 
 src_managed := build/src/managed


### PR DESCRIPTION
Now that https://github.com/lightbend/akkaserverless-docs/pull/746 is merged, we should be able to switch back to `docs/current` branch again, and then also update in akkaserverless-docs.