### PR TITLE
Include .gitignore #80

### DIFF
--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/pom.xml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/pom.xml
@@ -45,6 +45,7 @@
                         <delimiter>@*@</delimiter>
                     </delimiters>
                     <useDefaultDelimiters>false</useDefaultDelimiters>
+                    <addDefaultExcludes>false</addDefaultExcludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -21,6 +21,7 @@
         <fileSet filtered="true" encoding="UTF-8">
             <directory/>
             <includes>
+                <include>.gitignore</include>
                 <include>README.md</include>
                 <include>docker-compose.yml</include>
                 <include>docker-compose.linux.yml</include>

--- a/maven-java/akkaserverless-maven-archetype-value-entity/pom.xml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/pom.xml
@@ -45,6 +45,7 @@
                         <delimiter>@*@</delimiter>
                     </delimiters>
                     <useDefaultDelimiters>false</useDefaultDelimiters>
+                    <addDefaultExcludes>false</addDefaultExcludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -21,6 +21,7 @@
         <fileSet filtered="true" encoding="UTF-8">
             <directory/>
             <includes>
+                <include>.gitignore</include>
                 <include>README.md</include>
                 <include>docker-compose.yml</include>
                 <include>docker-compose.linux.yml</include>


### PR DESCRIPTION
This is two-step problem.

Following the SO link @ennru [provided](https://github.com/lightbend/akkaserverless-java-sdk/issues/80#issuecomment-850314413), I managed to have `.gitignore` in  `target/classes/archetype-resources`. But,  the `.gitignore` is not listed in `target/META-INF/maven/archetype-metadata.xml` and it doesn't end up in the jar file.

So, we must:

- [x] tune the `maven-resources-plugin`
- [x] something else (been trying several things and didn't find what...)