### PR TITLE
sdk codegen: remove 'setState' from value entity context, always use effects

### DIFF
--- a/sdk/src/main/java/com/akkaserverless/javasdk/lowlevel/ValueEntityHandler.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/lowlevel/ValueEntityHandler.java
@@ -16,7 +16,7 @@
 
 package com.akkaserverless.javasdk.lowlevel;
 
-import com.akkaserverless.javasdk.Reply;
+import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl;
 import com.akkaserverless.javasdk.valueentity.CommandContext;
 import com.akkaserverless.javasdk.valueentity.CommandHandler;
 import com.google.protobuf.Any;
@@ -36,5 +36,5 @@ public interface ValueEntityHandler {
    * @param context The command context.
    * @return The reply to the command, if the command isn't being forwarded elsewhere.
    */
-  Reply<Any> handleCommand(Any command, CommandContext<Any> context);
+  ValueEntityEffectImpl<Any> handleCommand(Any command, CommandContext<Any> context);
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/lowlevel/ValueEntityHandler.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/lowlevel/ValueEntityHandler.java
@@ -19,6 +19,7 @@ package com.akkaserverless.javasdk.lowlevel;
 import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl;
 import com.akkaserverless.javasdk.valueentity.CommandContext;
 import com.akkaserverless.javasdk.valueentity.CommandHandler;
+import com.akkaserverless.javasdk.valueentity.ValueEntityBase;
 import com.google.protobuf.Any;
 
 /**
@@ -36,5 +37,5 @@ public interface ValueEntityHandler {
    * @param context The command context.
    * @return The reply to the command, if the command isn't being forwarded elsewhere.
    */
-  ValueEntityEffectImpl<Any> handleCommand(Any command, CommandContext<Any> context);
+  ValueEntityBase.Effect<Any> handleCommand(Any command, CommandContext<Any> context);
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/valueentity/CommandContext.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/valueentity/CommandContext.java
@@ -28,6 +28,8 @@ import java.util.Optional;
  * <p>Methods annotated with {@link CommandHandler} may take this is a parameter. It allows updating
  * or deleting the entity state in response to a command, along with forwarding the result to other
  * entities, and performing side effects on other entities.
+ *
+ * @param <T> type for the state of the entity
  */
 public interface CommandContext<T>
     extends ValueEntityContext, ClientActionContext, SideEffectContext, MetadataContext {
@@ -56,12 +58,4 @@ public interface CommandContext<T>
    */
   @Deprecated
   Optional<T> getState();
-
-  /**
-   * Delete the entity state.
-   *
-   * @deprecated Use ValueEntityEffect.deleteState instead.
-   */
-  @Deprecated
-  void deleteState();
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/valueentity/CommandContext.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/valueentity/CommandContext.java
@@ -58,15 +58,6 @@ public interface CommandContext<T>
   Optional<T> getState();
 
   /**
-   * Update the entity with the new state. The state will be persisted.
-   *
-   * @param state The state to persist.
-   * @deprecated Use ValueEntityEffect.updateState instead.
-   */
-  @Deprecated
-  void updateState(T state);
-
-  /**
    * Delete the entity state.
    *
    * @deprecated Use ValueEntityEffect.deleteState instead.

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedEntitySupport.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedEntitySupport.scala
@@ -170,11 +170,6 @@ private class AdaptedCommandContext(val delegate: CommandContext[JavaPbAny], any
     result.map(anySupport.decode(_).asInstanceOf[AnyRef])
   }
 
-  override def updateState(state: AnyRef): Unit = {
-    val encoded = anySupport.encodeJava(state)
-    delegate.updateState(encoded)
-  }
-
   override def deleteState(): Unit = delegate.deleteState()
 
   override def commandName(): String = delegate.commandName()

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedEntitySupport.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedEntitySupport.scala
@@ -86,7 +86,7 @@ private[impl] class AnnotationBasedEntitySupport(
     }
 
     override def handleCommand(command: JavaPbAny,
-                               context: CommandContext[JavaPbAny]): ValueEntityEffectImpl[JavaPbAny] = unwrap {
+                               context: CommandContext[JavaPbAny]): ValueEntityBase.Effect[JavaPbAny] = unwrap {
       behavior.commandHandlers.get(context.commandName()).map { handler =>
         val adaptedContext =
           new AdaptedCommandContext(context, anySupport)
@@ -129,7 +129,7 @@ private class ValueEntityCommandHandlerInvoker(
 
   def valueEntityInvoke(obj: AnyRef,
                         command: JavaPbAny,
-                        context: CommandContext[AnyRef]): ValueEntityEffectImpl[JavaPbAny] = {
+                        context: CommandContext[AnyRef]): ValueEntityBase.Effect[JavaPbAny] = {
     val decodedCommand = mainArgumentDecoder(command)
     val ctx = InvocationContext(decodedCommand, context)
     try {

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedEntitySupport.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedEntitySupport.scala
@@ -18,13 +18,34 @@ package com.akkaserverless.javasdk.impl.valueentity
 
 import com.akkaserverless.javasdk.valueentity.ValueEntityContext
 import com.akkaserverless.javasdk.impl.EntityExceptions.EntityException
-import com.akkaserverless.javasdk.impl.ReflectionHelper.{InvocationContext, MainArgumentParameterHandler}
-import com.akkaserverless.javasdk.impl.{AnySupport, ReflectionHelper, ResolvedEntityFactory, ResolvedServiceMethod}
+import com.akkaserverless.javasdk.impl.ReflectionHelper.{
+  getFirstParameter,
+  getOutputParameterMapper,
+  InvocationContext,
+  MainArgumentParameterHandler,
+  MethodParameter,
+  ParameterHandler
+}
+import com.akkaserverless.javasdk.impl.effect.{
+  ErrorReplyImpl,
+  ForwardReplyImpl,
+  MessageReplyImpl,
+  NoReply,
+  NoSecondaryEffectImpl
+}
+import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl.UpdateState
+import com.akkaserverless.javasdk.impl.{
+  AnySupport,
+  FailInvoked,
+  ReflectionHelper,
+  ResolvedEntityFactory,
+  ResolvedServiceMethod
+}
 import com.akkaserverless.javasdk.{Metadata, Reply, ServiceCall, ServiceCallFactory}
 import com.google.protobuf.{Descriptors, Any => JavaPbAny}
-import java.lang.reflect.{Constructor, InvocationTargetException}
-import java.util.Optional
 
+import java.lang.reflect.{Constructor, InvocationTargetException, Method}
+import java.util.Optional
 import com.akkaserverless.javasdk.lowlevel.ValueEntityFactory
 import com.akkaserverless.javasdk.lowlevel.ValueEntityHandler
 import com.akkaserverless.javasdk.valueentity._
@@ -64,11 +85,12 @@ private[impl] class AnnotationBasedEntitySupport(
       })
     }
 
-    override def handleCommand(command: JavaPbAny, context: CommandContext[JavaPbAny]): Reply[JavaPbAny] = unwrap {
+    override def handleCommand(command: JavaPbAny,
+                               context: CommandContext[JavaPbAny]): ValueEntityEffectImpl[JavaPbAny] = unwrap {
       behavior.commandHandlers.get(context.commandName()).map { handler =>
         val adaptedContext =
           new AdaptedCommandContext(context, anySupport)
-        handler.invoke(entity, command, adaptedContext)
+        handler.valueEntityInvoke(entity, command, adaptedContext)
       } getOrElse {
         throw EntityException(
           context,
@@ -94,8 +116,60 @@ private[impl] class AnnotationBasedEntitySupport(
   }
 }
 
+private class ValueEntityCommandHandlerInvoker(
+    method: Method,
+    serviceMethod: ResolvedServiceMethod[_, _],
+    anySupport: AnySupport,
+    extraParameters: PartialFunction[MethodParameter, ParameterHandler[AnyRef, CommandContext[AnyRef]]] =
+      PartialFunction.empty
+) extends ReflectionHelper.CommandHandlerInvoker[CommandContext[AnyRef]](method,
+                                                                           serviceMethod,
+                                                                           anySupport,
+                                                                           extraParameters) {
+
+  def valueEntityInvoke(obj: AnyRef,
+                        command: JavaPbAny,
+                        context: CommandContext[AnyRef]): ValueEntityEffectImpl[JavaPbAny] = {
+    val decodedCommand = mainArgumentDecoder(command)
+    val ctx = InvocationContext(decodedCommand, context)
+    try {
+      method.invoke(obj, parameters.map(_.apply(ctx)): _*) match {
+        case effect: ValueEntityEffectImpl[_] =>
+          serializePrimaryEffect(serializeSecondaryEffect(effect))
+        case _ =>
+          throw new IllegalStateException(s"${method} should return an effect now")
+      }
+    } catch {
+      case e: InvocationTargetException =>
+        e.getCause match {
+          case FailInvoked => throw e
+          case x => throw e.getCause()
+        }
+    }
+  }
+
+  def serializePrimaryEffect(effect: ValueEntityEffectImpl[_]): ValueEntityEffectImpl[JavaPbAny] =
+    effect.primaryEffect match {
+      case UpdateState(newState) =>
+        effect
+          .asInstanceOf[ValueEntityEffectImpl[JavaPbAny]]
+          .updateState(anySupport.encodeJava(newState))
+          .asInstanceOf[ValueEntityEffectImpl[JavaPbAny]]
+      case other => effect.asInstanceOf[ValueEntityEffectImpl[JavaPbAny]]
+    }
+  def serializeSecondaryEffect[T](effect: ValueEntityEffectImpl[T]): ValueEntityEffectImpl[T] =
+    effect.secondaryEffect match {
+      case MessageReplyImpl(message, metadata, sideEffects) =>
+        effect
+          .reply(serialize(message), metadata)
+          .addSideEffects(sideEffects: _*)
+          .asInstanceOf[ValueEntityEffectImpl[T]]
+      case other => effect
+    }
+}
+
 private class EntityBehaviorReflection(
-    val commandHandlers: Map[String, ReflectionHelper.CommandHandlerInvoker[CommandContext[AnyRef]]]
+    val commandHandlers: Map[String, ValueEntityCommandHandlerInvoker]
 ) {}
 
 private object EntityBehaviorReflection {
@@ -121,9 +195,7 @@ private object EntityBehaviorReflection {
           }
         )
 
-        new ReflectionHelper.CommandHandlerInvoker[CommandContext[AnyRef]](ReflectionHelper.ensureAccessible(method),
-                                                                           serviceMethod,
-                                                                           anySupport)
+        new ValueEntityCommandHandlerInvoker(ReflectionHelper.ensureAccessible(method), serviceMethod, anySupport)
       }
       .groupBy(_.serviceMethod.name)
       .map {
@@ -169,8 +241,6 @@ private class AdaptedCommandContext(val delegate: CommandContext[JavaPbAny], any
     val result = delegate.getState
     result.map(anySupport.decode(_).asInstanceOf[AnyRef])
   }
-
-  override def deleteState(): Unit = delegate.deleteState()
 
   override def commandName(): String = delegate.commandName()
   override def commandId(): Long = delegate.commandId()

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedEntitySupport.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedEntitySupport.scala
@@ -136,6 +136,8 @@ private class ValueEntityCommandHandlerInvoker(
       method.invoke(obj, parameters.map(_.apply(ctx)): _*) match {
         case effect: ValueEntityEffectImpl[_] =>
           serializePrimaryEffect(serializeSecondaryEffect(effect))
+        case null =>
+          throw new NullPointerException(s"${method} returned null")
         case _ =>
           throw new IllegalStateException(s"${method} should return an effect now")
       }
@@ -162,7 +164,6 @@ private class ValueEntityCommandHandlerInvoker(
       case MessageReplyImpl(message, metadata, sideEffects) =>
         effect
           .reply(serialize(message), metadata)
-          .addSideEffects(sideEffects: _*)
           .asInstanceOf[ValueEntityEffectImpl[T]]
       case other => effect
     }

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -245,16 +245,6 @@ final class ValueEntitiesImpl(_system: ActorSystem,
       _state.map(ScalaPbAny.toJavaProto(_)).asJava
     }
 
-    override def updateState(state: JavaPbAny): Unit = {
-      checkActive()
-      if (state == null)
-        throw EntityException("Value entity cannot update a 'null' state")
-
-      val encoded = anySupport.encodeScala(state)
-      _state = Some(encoded)
-      action = Some(ValueEntityAction(Update(ValueEntityUpdate(_state))))
-    }
-
     override def deleteState(): Unit = {
       checkActive()
 

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -35,12 +35,13 @@ import com.akkaserverless.protocol.value_entity.ValueEntityStreamOut.Message.{Fa
 import com.akkaserverless.protocol.value_entity._
 import com.google.protobuf.any.{Any => ScalaPbAny}
 import com.google.protobuf.{Descriptors, Any => JavaPbAny}
-import java.util.Optional
 
+import java.util.Optional
 import scala.compat.java8.OptionConverters._
 import scala.util.control.NonFatal
-
 import akka.stream.scaladsl.Source
+import com.akkaserverless.javasdk.impl.effect.{EffectSupport, ErrorReplyImpl}
+import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl.{DeleteState, UpdateState}
 import com.akkaserverless.javasdk.lowlevel.ValueEntityFactory
 import com.akkaserverless.javasdk.reply.ErrorReply
 
@@ -141,10 +142,10 @@ final class ValueEntitiesImpl(_system: ActorSystem,
             service.anySupport,
             log
           )
-          val reply: Reply[JavaPbAny] = try {
+          val effect: ValueEntityEffectImpl[JavaPbAny] = try {
             handler.handleCommand(cmd, context)
           } catch {
-            case FailInvoked => Reply.noReply() //Option.empty[JavaPbAny].asJava
+            case FailInvoked => new ValueEntityEffectImpl() //Option.empty[JavaPbAny].asJava
             case e: EntityException => throw e
             case NonFatal(error) => {
               throw EntityException(
@@ -157,42 +158,27 @@ final class ValueEntitiesImpl(_system: ActorSystem,
             context.deactivate() // Very important!
           }
 
-          val clientAction = context.replyToClientAction(reply, allowNoReply = false, restartOnFailure = false)
+          val clientAction =
+            context.replyToClientAction(effect.secondaryEffect, allowNoReply = false, restartOnFailure = false)
 
-          // FIXME use the new effects instead of reply, something like:
-//          val effect: ValueEntityEffect[JavaPbAny] = try {
-//            handler.handleCommand(cmd, context)
-//          } catch {
-//            case FailInvoked => new ValueEntityEffectImpl[JavaPbAny].noReply()
-//            case e: EntityException => throw e
-//            case NonFatal(error) => {
-//              throw EntityException(
-//                command,
-//                s"Value entity unexpected failure: ${error}",
-//                Some(error)
-//              )
-//            }
-//          } finally {
-//            context.deactivate() // Very important!
-//          }
-//
-//          val effectImpl = effect.asInstanceOf[ValueEntityEffectImpl[JavaPbAny]]
-//
-//          // FIXME handle effectImpl.primaryEffect
-//
-//          val clientAction =
-//            context.replyToClientAction(effectImpl.secondaryEffect, allowNoReply = false, restartOnFailure = false)
-
-          if (!context.hasError && !reply.isInstanceOf[ErrorReply[_]]) {
-            val nextState = context.currentState()
+          if (!context.hasError && !effect.secondaryEffect.isInstanceOf[ErrorReplyImpl[_]]) {
+            val (nextState: Option[ScalaPbAny], action: Option[ValueEntityAction]) = effect.primaryEffect match {
+              case DeleteState =>
+                (None, Some(ValueEntityAction(Delete(ValueEntityDelete()))))
+              case UpdateState(newState) =>
+                val newStateScala = ScalaPbAny.fromJavaProto(newState)
+                (Some(newStateScala), Some(ValueEntityAction(Update(ValueEntityUpdate(Some(newStateScala))))))
+              case _ =>
+                (context.currentState(), None)
+            }
             (nextState,
              Some(
                OutReply(
                  ValueEntityReply(
                    command.id,
                    clientAction,
-                   context.sideEffects ++ ReplySupport.effectsFrom(reply),
-                   context.action
+                   context.sideEffects ++ EffectSupport.sideEffectsFrom(effect.secondaryEffect),
+                   action
                  )
                )
              ))
@@ -237,19 +223,11 @@ final class ValueEntitiesImpl(_system: ActorSystem,
       with AbstractSideEffectContext
       with ActivatableContext {
 
-    final var action: Option[ValueEntityAction] = None
-    private var _state: Option[ScalaPbAny] = state
+    private val _state: Option[ScalaPbAny] = state
 
     override def getState(): Optional[JavaPbAny] = {
       checkActive()
       _state.map(ScalaPbAny.toJavaProto(_)).asJava
-    }
-
-    override def deleteState(): Unit = {
-      checkActive()
-
-      _state = None
-      action = Some(ValueEntityAction(Delete(ValueEntityDelete())))
     }
 
     override protected def logError(message: String): Unit =

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -143,7 +143,7 @@ final class ValueEntitiesImpl(_system: ActorSystem,
             log
           )
           val effect: ValueEntityEffectImpl[JavaPbAny] = try {
-            handler.handleCommand(cmd, context)
+            handler.handleCommand(cmd, context).asInstanceOf[ValueEntityEffectImpl[JavaPbAny]]
           } catch {
             case FailInvoked => new ValueEntityEffectImpl() //Option.empty[JavaPbAny].asJava
             case e: EntityException => throw e

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntityEffectImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntityEffectImpl.scala
@@ -34,19 +34,19 @@ import Effect.Builder
 import Effect.OnSuccessBuilder
 
 object ValueEntityEffectImpl {
-  sealed trait PrimaryEffectImpl
-  final case class UpdateState[S](newState: S) extends PrimaryEffectImpl
-  case object DeleteState extends PrimaryEffectImpl
-  case object NoPrimaryEffect extends PrimaryEffectImpl
+  sealed trait PrimaryEffectImpl[+S]
+  final case class UpdateState[S](newState: S) extends PrimaryEffectImpl[S]
+  case object DeleteState extends PrimaryEffectImpl[Nothing]
+  case object NoPrimaryEffect extends PrimaryEffectImpl[Nothing]
 }
 
 class ValueEntityEffectImpl[S] extends Builder[S] with OnSuccessBuilder[S] with Effect[Any] {
   import ValueEntityEffectImpl._
 
-  private var _primaryEffect: PrimaryEffectImpl = NoPrimaryEffect
+  private var _primaryEffect: PrimaryEffectImpl[S] = NoPrimaryEffect
   private var _secondaryEffect: SecondaryEffectImpl = NoSecondaryEffectImpl
 
-  def primaryEffect: PrimaryEffectImpl = _primaryEffect
+  def primaryEffect: PrimaryEffectImpl[S] = _primaryEffect
 
   def secondaryEffect: SecondaryEffectImpl = _secondaryEffect
 

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntityEffectImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntityEffectImpl.scala
@@ -40,7 +40,7 @@ object ValueEntityEffectImpl {
   case object NoPrimaryEffect extends PrimaryEffectImpl[Nothing]
 }
 
-class ValueEntityEffectImpl[S] extends Builder[S] with OnSuccessBuilder[S] with Effect[Any] {
+class ValueEntityEffectImpl[S] extends Builder[S] with OnSuccessBuilder[S] with Effect[S] {
   import ValueEntityEffectImpl._
 
   private var _primaryEffect: PrimaryEffectImpl[S] = NoPrimaryEffect
@@ -101,12 +101,12 @@ class ValueEntityEffectImpl[S] extends Builder[S] with OnSuccessBuilder[S] with 
     this.asInstanceOf[Effect[T]]
   }
 
-  override def addSideEffects(sideEffects: util.Collection[SideEffect]): Effect[Any] = {
+  override def addSideEffects(sideEffects: util.Collection[SideEffect]): Effect[S] = {
     _secondaryEffect = _secondaryEffect.addSideEffects(sideEffects.asScala)
     this
   }
 
-  override def addSideEffects(sideEffects: SideEffect*): Effect[Any] = {
+  override def addSideEffects(sideEffects: SideEffect*): Effect[S] = {
     _secondaryEffect = _secondaryEffect.addSideEffects(sideEffects)
     this
   }

--- a/sdk/src/test/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedValueEntitySupportSpec.scala
+++ b/sdk/src/test/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedValueEntitySupportSpec.scala
@@ -92,14 +92,14 @@ class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
   def command(str: String) =
     ScalaPbAny.toJavaProto(ScalaPbAny(StringResolvedType.typeUrl, StringResolvedType.toByteString(str)))
 
-  def decodeWrapped(effect: ValueEntityEffectImpl[JavaPbAny]): Wrapped =
-    effect.secondaryEffect match {
+  def decodeWrapped(effect: ValueEntityBase.Effect[JavaPbAny]): Wrapped =
+    effect.asInstanceOf[ValueEntityEffectImpl[JavaPbAny]].secondaryEffect match {
       case MessageReplyImpl(any, _, _) => decodeWrapped(any.asInstanceOf[JavaPbAny])
     }
 
-  def decodeUpdatedState[S](effect: ValueEntityEffectImpl[S]): S =
-    effect.primaryEffect match {
-      case UpdateState(any) => any
+  def decodeUpdatedState[S](effect: ValueEntityBase.Effect[S]): S =
+    effect.asInstanceOf[ValueEntityEffectImpl[JavaPbAny]].primaryEffect match {
+      case UpdateState(any) => any.asInstanceOf[S]
     }
 
   def decodeWrapped(any: JavaPbAny): Wrapped = {
@@ -242,7 +242,7 @@ class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
         val ctx = new MockCommandContext("RemoveCart")
         val effect = handler.handleCommand(command("blah"), ctx)
         decodeWrapped(effect) should ===(Wrapped("blah"))
-        effect.primaryEffect should ===(DeleteState)
+        effect.asInstanceOf[ValueEntityEffectImpl[JavaPbAny]].primaryEffect should ===(DeleteState)
       }
 
       "fail if there's a bad context type" in {

--- a/sdk/src/test/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedValueEntitySupportSpec.scala
+++ b/sdk/src/test/scala/com/akkaserverless/javasdk/impl/valueentity/AnnotationBasedValueEntitySupportSpec.scala
@@ -16,7 +16,8 @@
 
 package com.akkaserverless.javasdk.impl.valueentity
 
-import com.akkaserverless.javasdk.impl.reply.MessageReplyImpl
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl
+import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl.{DeleteState, UpdateState}
 import com.akkaserverless.javasdk.valueentity._
 import com.akkaserverless.javasdk.impl.{AnySupport, ResolvedServiceMethod, ResolvedType}
 import com.akkaserverless.javasdk.{Reply, EntityContext => _, _}
@@ -30,6 +31,7 @@ import java.util.Optional
 import scala.compat.java8.OptionConverters._
 import com.akkaserverless.javasdk.lowlevel.ValueEntityHandler
 import com.akkaserverless.javasdk.reply.MessageReply
+import com.akkaserverless.javasdk.valueentity.ValueEntityBase.Effect
 
 class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
   trait BaseContext extends Context {
@@ -46,10 +48,9 @@ class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
   class MockCommandContext(override val commandName: String = "AddItem", state: Option[JavaPbAny] = None)
       extends CommandContext[JavaPbAny]
       with BaseContext {
-    var currentState: Option[JavaPbAny] = state
+    private val currentState: Option[JavaPbAny] = state
     override def commandId(): Long = 20
     override def getState(): Optional[JavaPbAny] = currentState.asJava
-    override def deleteState(): Unit = currentState = None
     override def entityId(): String = "foo"
     override def metadata(): Metadata = ???
     override def fail(errorMessage: String): RuntimeException = ???
@@ -91,10 +92,14 @@ class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
   def command(str: String) =
     ScalaPbAny.toJavaProto(ScalaPbAny(StringResolvedType.typeUrl, StringResolvedType.toByteString(str)))
 
-  def decodeWrapped(reply: Reply[JavaPbAny]): Wrapped =
-    reply match {
-      case MessageReplyImpl(any, _, _) =>
-        decodeWrapped(any)
+  def decodeWrapped(effect: ValueEntityEffectImpl[JavaPbAny]): Wrapped =
+    effect.secondaryEffect match {
+      case MessageReplyImpl(any, _, _) => decodeWrapped(any.asInstanceOf[JavaPbAny])
+    }
+
+  def decodeUpdatedState[S](effect: ValueEntityEffectImpl[S]): S =
+    effect.primaryEffect match {
+      case UpdateState(any) => any
     }
 
   def decodeWrapped(any: JavaPbAny): Wrapped = {
@@ -132,38 +137,52 @@ class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
     "support command handlers" when {
 
       "no arg command handler" in {
-        val handler = create(new {
+        val handler = create(new ValueEntityBase[String] {
           @CommandHandler
-          def addItem() = Wrapped("blah")
+          def addItem() = effects().reply(Wrapped("blah"))
+
+          override protected def emptyState(): String = ""
         }, method())
         decodeWrapped(handler.handleCommand(command("nothing"), new MockCommandContext)) should ===(Wrapped("blah"))
       }
 
       "no arg command handler with Reply" in {
-        val handler = create(new {
-          @CommandHandler
-          def addItem(): Reply[Wrapped] = Reply.message(Wrapped("blah"))
-        }, method())
+        val handler = create(
+          new ValueEntityBase[String] {
+            @CommandHandler
+            def addItem(): Effect[Wrapped] = effects().reply(Wrapped("blah"))
+
+            override protected def emptyState(): String = ""
+          },
+          method()
+        )
         decodeWrapped(handler.handleCommand(command("nothing"), new MockCommandContext)) should ===(Wrapped("blah"))
       }
 
       "single arg command handler" in {
-        val handler = create(new {
-          @CommandHandler
-          def addItem(msg: String) = Wrapped(msg)
-        }, method())
+        val handler = create(
+          new ValueEntityBase[JavaPbAny] {
+            @CommandHandler
+            def addItem(msg: String) = effects().reply(Wrapped(msg))
+
+            override protected def emptyState(): JavaPbAny = JavaPbAny.getDefaultInstance
+          },
+          method()
+        )
         decodeWrapped(handler.handleCommand(command("blah"), new MockCommandContext)) should ===(Wrapped("blah"))
       }
 
       "multi arg command handler" in {
         val handler = create(
-          new {
+          new ValueEntityBase[JavaPbAny] {
             @CommandHandler
-            def addItem(msg: String, @EntityId eid: String, ctx: CommandContext[JavaPbAny]): Wrapped = {
+            def addItem(msg: String, @EntityId eid: String, ctx: CommandContext[JavaPbAny]): Effect[Wrapped] = {
               eid should ===("foo")
               ctx.commandName() should ===("AddItem")
-              Wrapped(msg)
+              effects().reply(Wrapped(msg))
             }
+
+            override protected def emptyState(): JavaPbAny = JavaPbAny.getDefaultInstance
           },
           method()
         )
@@ -172,13 +191,15 @@ class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
 
       "read state" in {
         val handler = create(
-          new {
+          new ValueEntityBase[JavaPbAny] {
             @CommandHandler
-            def getCart(msg: String, ctx: CommandContext[JavaPbAny]): Wrapped = {
+            def getCart(msg: String, ctx: CommandContext[JavaPbAny]): Effect[Wrapped] = {
               ctx.getState().asScala.get.asInstanceOf[String] should ===("state")
               ctx.commandName() should ===("GetCart")
-              Wrapped(msg)
+              effects().reply(Wrapped(msg))
             }
+
+            override protected def emptyState(): JavaPbAny = JavaPbAny.getDefaultInstance
           },
           method("GetCart")
         )
@@ -190,7 +211,7 @@ class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
         val handler = create(
           new ValueEntityBase[JavaPbAny] {
             @CommandHandler
-            def addItem(msg: String, ctx: CommandContext[JavaPbAny]): MessageReply[Wrapped] = {
+            def addItem(msg: String, ctx: CommandContext[JavaPbAny]): Effect[Wrapped] = {
               ctx.commandName() should ===("AddItem")
               effects().updateState(state(msg + " state")).thenReply(Wrapped(msg))
             }
@@ -200,25 +221,28 @@ class AnnotationBasedValueEntitySupportSpec extends AnyWordSpec with Matchers {
           method()
         )
         val ctx = new MockCommandContext
-        decodeWrapped(handler.handleCommand(command("blah"), ctx)) should ===(Wrapped("blah"))
-        ctx.currentState.get should ===(state("blah state"))
+        val effect = handler.handleCommand(command("blah"), ctx)
+        decodeWrapped(effect) should ===(Wrapped("blah"))
+        decodeUpdatedState(effect) should ===(state("blah state"))
       }
 
       "delete state" in {
         val handler = create(
-          new {
+          new ValueEntityBase[JavaPbAny] {
             @CommandHandler
-            def removeCart(msg: String, ctx: CommandContext[JavaPbAny]): Wrapped = {
-              ctx.deleteState()
+            def removeCart(msg: String, ctx: CommandContext[JavaPbAny]): Effect[Wrapped] = {
               ctx.commandName() should ===("RemoveCart")
-              Wrapped(msg)
+              effects().deleteState().thenReply(Wrapped(msg))
             }
+
+            override protected def emptyState(): JavaPbAny = JavaPbAny.getDefaultInstance
           },
           method("RemoveCart")
         )
         val ctx = new MockCommandContext("RemoveCart")
-        decodeWrapped(handler.handleCommand(command("blah"), ctx)) should ===(Wrapped("blah"))
-        ctx.currentState should ===(None)
+        val effect = handler.handleCommand(command("blah"), ctx)
+        decodeWrapped(effect) should ===(Wrapped("blah"))
+        effect.primaryEffect should ===(DeleteState)
       }
 
       "fail if there's a bad context type" in {

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/localpersistenceeventing/ValueEntityOne.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/localpersistenceeventing/ValueEntityOne.java
@@ -16,22 +16,29 @@
 
 package com.akkaserverless.javasdk.tck.model.localpersistenceeventing;
 
+import com.akkaserverless.javasdk.impl.reply.MessageReplyImpl;
+import com.akkaserverless.javasdk.reply.MessageReply;
 import com.akkaserverless.javasdk.valueentity.CommandContext;
 import com.akkaserverless.javasdk.valueentity.CommandHandler;
 import com.akkaserverless.javasdk.valueentity.ValueEntity;
+import com.akkaserverless.javasdk.valueentity.ValueEntityBase;
 import com.akkaserverless.tck.model.eventing.LocalPersistenceEventing;
 import com.google.protobuf.Empty;
 
 @ValueEntity(entityType = "valuechangeseventing-one")
-public class ValueEntityOne {
+public class ValueEntityOne extends ValueEntityBase<Object> {
   @CommandHandler
-  public Empty updateValue(
+  public MessageReply<Empty> updateValue(
       LocalPersistenceEventing.UpdateValueRequest value, CommandContext<Object> ctx) {
     if (value.hasValueOne()) {
-      ctx.updateState(value.getValueOne());
+      return effects().updateState(value.getValueOne()).thenReply(Empty.getDefaultInstance());
     } else {
-      ctx.updateState(value.getValueTwo());
+      return effects().updateState(value.getValueTwo()).thenReply(Empty.getDefaultInstance());
     }
-    return Empty.getDefaultInstance();
+  }
+
+  @Override
+  protected Object emptyState() {
+    return null;
   }
 }

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/localpersistenceeventing/ValueEntityOne.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/localpersistenceeventing/ValueEntityOne.java
@@ -16,8 +16,6 @@
 
 package com.akkaserverless.javasdk.tck.model.localpersistenceeventing;
 
-import com.akkaserverless.javasdk.impl.reply.MessageReplyImpl;
-import com.akkaserverless.javasdk.reply.MessageReply;
 import com.akkaserverless.javasdk.valueentity.CommandContext;
 import com.akkaserverless.javasdk.valueentity.CommandHandler;
 import com.akkaserverless.javasdk.valueentity.ValueEntity;
@@ -28,7 +26,7 @@ import com.google.protobuf.Empty;
 @ValueEntity(entityType = "valuechangeseventing-one")
 public class ValueEntityOne extends ValueEntityBase<Object> {
   @CommandHandler
-  public MessageReply<Empty> updateValue(
+  public Effect<Empty> updateValue(
       LocalPersistenceEventing.UpdateValueRequest value, CommandContext<Object> ctx) {
     if (value.hasValueOne()) {
       return effects().updateState(value.getValueOne()).thenReply(Empty.getDefaultInstance());

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/localpersistenceeventing/ValueEntityTwo.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/localpersistenceeventing/ValueEntityTwo.java
@@ -16,7 +16,6 @@
 
 package com.akkaserverless.javasdk.tck.model.localpersistenceeventing;
 
-import com.akkaserverless.javasdk.reply.MessageReply;
 import com.akkaserverless.javasdk.valueentity.CommandContext;
 import com.akkaserverless.javasdk.valueentity.CommandHandler;
 import com.akkaserverless.javasdk.valueentity.ValueEntity;
@@ -27,7 +26,7 @@ import com.google.protobuf.Empty;
 @ValueEntity(entityType = "valuechangeseventing-two")
 public class ValueEntityTwo extends ValueEntityBase<Object> {
   @CommandHandler
-  public MessageReply<Empty> updateJsonValue(
+  public Effect<Empty> updateJsonValue(
       LocalPersistenceEventing.JsonValue value, CommandContext<Object> ctx) {
     return effects()
         .updateState(new JsonMessage(value.getMessage()))

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/localpersistenceeventing/ValueEntityTwo.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/localpersistenceeventing/ValueEntityTwo.java
@@ -16,18 +16,26 @@
 
 package com.akkaserverless.javasdk.tck.model.localpersistenceeventing;
 
+import com.akkaserverless.javasdk.reply.MessageReply;
 import com.akkaserverless.javasdk.valueentity.CommandContext;
 import com.akkaserverless.javasdk.valueentity.CommandHandler;
 import com.akkaserverless.javasdk.valueentity.ValueEntity;
+import com.akkaserverless.javasdk.valueentity.ValueEntityBase;
 import com.akkaserverless.tck.model.eventing.LocalPersistenceEventing;
 import com.google.protobuf.Empty;
 
 @ValueEntity(entityType = "valuechangeseventing-two")
-public class ValueEntityTwo {
+public class ValueEntityTwo extends ValueEntityBase<Object> {
   @CommandHandler
-  public Empty updateJsonValue(
+  public MessageReply<Empty> updateJsonValue(
       LocalPersistenceEventing.JsonValue value, CommandContext<Object> ctx) {
-    ctx.updateState(new JsonMessage(value.getMessage()));
-    return Empty.getDefaultInstance();
+    return effects()
+        .updateState(new JsonMessage(value.getMessage()))
+        .thenReply(Empty.getDefaultInstance());
+  }
+
+  @Override
+  protected Object emptyState() {
+    return null;
   }
 }

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/valueentity/ValueEntityConfiguredEntity.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/valueentity/ValueEntityConfiguredEntity.java
@@ -18,14 +18,20 @@ package com.akkaserverless.javasdk.tck.model.valueentity;
 
 import com.akkaserverless.javasdk.valueentity.CommandHandler;
 import com.akkaserverless.javasdk.valueentity.ValueEntity;
+import com.akkaserverless.javasdk.valueentity.ValueEntityBase;
 import com.akkaserverless.tck.model.ValueEntity.Request;
 import com.akkaserverless.tck.model.ValueEntity.Response;
 
 @ValueEntity(entityType = "value-entity-configured")
-public class ValueEntityConfiguredEntity {
+public class ValueEntityConfiguredEntity extends ValueEntityBase<String> {
 
   @CommandHandler
-  public Response call(Request request) {
-    return Response.getDefaultInstance();
+  public Effect<Response> call(Request request) {
+    return effects().reply(Response.getDefaultInstance());
+  }
+
+  @Override
+  protected String emptyState() {
+    return null;
   }
 }

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/valueentity/ValueEntityTckModelEntity.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/valueentity/ValueEntityTckModelEntity.java
@@ -45,32 +45,32 @@ public class ValueEntityTckModelEntity extends ValueEntityBase<Persisted> {
   }
 
   @CommandHandler
-  public Reply<Response> process(Request request, CommandContext<Persisted> context) {
-    Reply<Response> reply = null;
-    List<SideEffect> e = new ArrayList<>();
-    String newState = state;
-    for (RequestAction action : request.getActionsList()) {
-      switch (action.getActionCase()) {
-        case UPDATE:
-          newState = action.getUpdate().getValue();
-          context.updateState(Persisted.newBuilder().setValue(state).build());
-          break;
-        case DELETE:
-          newState = "";
-          break;
-        case FORWARD:
-          reply = effects().forward(serviceTwoRequest(action.getForward().getId()));
-          break;
-        case EFFECT:
-          com.akkaserverless.tck.model.ValueEntity.Effect effect = action.getEffect();
-          e.add(SideEffect.of(serviceTwoRequest(effect.getId()), effect.getSynchronous()));
-          break;
-        case FAIL:
-          return effects().error(action.getFail().getMessage());
-      }
-    }
-
-    effects().updateState(null).
+  public Effect<Response> process(Request request, CommandContext<Persisted> context) {
+    // FIXME the effect API doesn't support all combinations, and that might be fine?
+    //    Effect<Response> reply = null;
+    //    List<SideEffect> e = new ArrayList<>();
+    //    String newState = state;
+    //    for (RequestAction action : request.getActionsList()) {
+    //      switch (action.getActionCase()) {
+    //        case UPDATE:
+    //          newState = action.getUpdate().getValue();
+    //          break;
+    //        case DELETE:
+    //          newState = "";
+    //          break;
+    //        case FORWARD:
+    //          reply = effects().forward(serviceTwoRequest(action.getForward().getId()));
+    //          break;
+    //        case EFFECT:
+    //          com.akkaserverless.tck.model.ValueEntity.Effect effect = action.getEffect();
+    //          e.add(SideEffect.of(serviceTwoRequest(effect.getId()), effect.getSynchronous()));
+    //          break;
+    //        case FAIL:
+    //          return effects().error(action.getFail().getMessage());
+    //      }
+    //    }
+    //    effects().updateState(Persisted.newBuilder().setValue(state).build());
+    return null;
   }
 
   private ServiceCall serviceTwoRequest(String id) {

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/valueentity/ValueEntityTwoEntity.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/valueentity/ValueEntityTwoEntity.java
@@ -18,14 +18,20 @@ package com.akkaserverless.javasdk.tck.model.valueentity;
 
 import com.akkaserverless.javasdk.valueentity.CommandHandler;
 import com.akkaserverless.javasdk.valueentity.ValueEntity;
+import com.akkaserverless.javasdk.valueentity.ValueEntityBase;
 import com.akkaserverless.tck.model.ValueEntity.Request;
 import com.akkaserverless.tck.model.ValueEntity.Response;
 
 @ValueEntity(entityType = "value-entity-tck-model-two")
-public class ValueEntityTwoEntity {
+public class ValueEntityTwoEntity extends ValueEntityBase<String> {
 
   @CommandHandler
-  public Response call(Request request) {
-    return Response.getDefaultInstance();
+  public Effect<Response> call(Request request) {
+    return effects().reply(Response.getDefaultInstance());
+  }
+
+  @Override
+  protected String emptyState() {
+    return null;
   }
 }

--- a/tck/src/test/resources/logback-test.xml
+++ b/tck/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="INFO"/>
+    <logger name="com.akkaserverless" level="DEBUG"/>
+    <logger name="io.grpc" level="INFO"/>
+    <logger name="org.testcontainers" level="INFO"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Since we now have the effect system. This now also requires
returning an effect rather than a value even for the
annotation-based implementation.

Haven't updated the sample projects yet.