### PR TITLE
build: fix scalafmtOnCompile setting

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -2,13 +2,14 @@ import sbt._
 import sbt.Keys._
 import akka.grpc.sbt.AkkaGrpcPlugin
 import de.heikoseeberger.sbtheader.{AutomateHeaderPlugin, HeaderPlugin}
+import org.scalafmt.sbt.ScalafmtPlugin
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import sbtprotoc.ProtocPlugin
 import scala.collection.breakOut
 
 object CommonSettings extends AutoPlugin {
 
-  override def requires = plugins.JvmPlugin
+  override def requires = plugins.JvmPlugin && ScalafmtPlugin
   override def trigger = allRequirements
 
   override def globalSettings =


### PR DESCRIPTION
The `scalafmtOnCompile` setting in the `CommonSettings` auto-plugin isn't always enabled, as the `ScalafmtPlugin` also defines its default for this in global settings, and either plugin could have its settings applied last. Add a dependency on the scalafmt plugin to make sure we override the setting to enabled.