### PR TITLE
tck: add view source entity

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   val tck = deps ++= Seq(
         akkaslsTckProtocol % "protobuf-src",
         "com.akkaserverless" % "akkaserverless-tck-protocol" % AkkaServerless.FrameworkVersion % "protobuf-src",
-        "ch.qos.logback" % "logback-classic" % LogbackVersion % Test
+        "ch.qos.logback" % "logback-classic" % LogbackVersion
       )
 
   val testkit = deps ++= Seq(

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/JavaSdkTck.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/JavaSdkTck.java
@@ -116,7 +116,10 @@ public final class JavaSdkTck {
               com.akkaserverless.javasdk.tck.model.view.ViewTckModelBehavior.class,
               View.getDescriptor().findServiceByName("ViewTckModel"),
               "tck-view",
-              View.getDescriptor());
+              View.getDescriptor())
+          .registerValueEntity(
+              com.akkaserverless.javasdk.tck.model.view.ViewTckSourceEntity.class,
+              View.getDescriptor().findServiceByName("ViewTckSource"));
 
   public static void main(String[] args) throws Exception {
     SERVICE.start().toCompletableFuture().get();

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/view/ViewTckSourceEntity.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/view/ViewTckSourceEntity.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akkaserverless.javasdk.tck.model.view;
+
+import com.akkaserverless.javasdk.valueentity.ValueEntity;
+
+@ValueEntity(entityType = "view-source")
+public class ViewTckSourceEntity {}


### PR DESCRIPTION
The proxy will have eventing source validation, so the view in the TCK needs an existing entity as its source now.

See https://github.com/lightbend/akkaserverless-framework/pull/774 and https://github.com/lightbend/akkaserverless-framework/pull/773