### PR TITLE
Add doc links for entity eventing error codes

### DIFF
--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/DocLinks.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/DocLinks.scala
@@ -23,7 +23,10 @@ object DocLinks {
   private val errorCodes = Map(
     "AS-00112" -> s"$baseUrl/java/views.html#changing",
     "AS-00402" -> s"$baseUrl/java/topic-eventing.html",
-    "AS-00406" -> s"$baseUrl/java/topic-eventing.html"
+    "AS-00406" -> s"$baseUrl/java/topic-eventing.html",
+    "AS-00414" -> s"$baseUrl/java/entity-eventing.html"
+    // TODO: docs for value entity eventing (https://github.com/lightbend/akkaserverless-java-sdk/issues/121)
+    // "AS-00415" -> s"$baseUrl/java/entity-eventing.html"
   )
 
   // fallback if not defined in errorCodes


### PR DESCRIPTION
Add doc links for the new error codes for eventing validation for entity types (https://github.com/lightbend/akkaserverless-framework/pull/773). Note that the docs currently only cover subscribing to event sourced entities (doc issue #121).