### PR TITLE
feat: move write consistency to overall replicated entity settings

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object AkkaServerless {
     val ProtocolVersionMajor = 0
     val ProtocolVersionMinor = 7
-    val FrameworkVersion = "0.7.0-beta.13"
+    val FrameworkVersion = "0.7.0-beta.13-3-df548aa6-SNAPSHOT"
   }
 
   // changing the Scala version of the Java SDK affects end users

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object AkkaServerless {
     val ProtocolVersionMajor = 0
     val ProtocolVersionMinor = 7
-    val FrameworkVersion = "0.7.0-beta.13-3-df548aa6-SNAPSHOT"
+    val FrameworkVersion = "0.7.0-beta.13-4-790acfa4-SNAPSHOT"
   }
 
   // changing the Scala version of the Java SDK affects end users

--- a/sdk/src/main/java/com/akkaserverless/javasdk/EntityOptions.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/EntityOptions.java
@@ -16,8 +16,6 @@
 
 package com.akkaserverless.javasdk;
 
-import java.util.Set;
-
 /** Options used for configuring an entity. */
 public interface EntityOptions extends ComponentOptions {
 

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedEntityContext.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedEntityContext.java
@@ -31,18 +31,4 @@ public interface ReplicatedEntityContext extends EntityContext {
    *     <code>dataClass</code> type.
    */
   <T extends ReplicatedData> Optional<T> state(Class<T> dataClass) throws IllegalStateException;
-
-  /**
-   * Get the current write consistency setting for replication of the replicated entity state.
-   *
-   * @return the current write consistency
-   */
-  WriteConsistency getWriteConsistency();
-
-  /**
-   * Set the write consistency setting for replication of the replicated entity state.
-   *
-   * @param writeConsistency the new write consistency to use
-   */
-  void setWriteConsistency(WriteConsistency writeConsistency);
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedEntityOptions.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedEntityOptions.java
@@ -29,12 +29,27 @@ public interface ReplicatedEntityOptions extends EntityOptions {
   ReplicatedEntityOptions withPassivationStrategy(PassivationStrategy strategy);
 
   /**
+   * Get the current write consistency setting for replication of the replicated entity state.
+   *
+   * @return the write consistency setting for a replicated entity
+   */
+  WriteConsistency writeConsistency();
+
+  /**
+   * Set the write consistency setting for replication of the replicated entity state.
+   *
+   * @param writeConsistency write consistency to use
+   * @returns new replicated entity options with write consistency setting
+   */
+  ReplicatedEntityOptions withWriteConsistency(WriteConsistency writeConsistency);
+
+  /**
    * Create default Replicated Entity options.
    *
    * @return the entity options
    */
   static ReplicatedEntityOptions defaults() {
     return new ReplicatedEntityOptionsImpl(
-        PassivationStrategy.defaultTimeout(), Collections.emptySet());
+        PassivationStrategy.defaultTimeout(), Collections.emptySet(), WriteConsistency.LOCAL);
   }
 }

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/AnnotationBasedReplicatedEntitySupport.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/AnnotationBasedReplicatedEntitySupport.scala
@@ -260,9 +260,6 @@ private final class AdaptedStreamedCommandContext(val delegate: StreamedCommandC
   override def newReplicatedRegisterMap[K, V](): ReplicatedRegisterMap[K, V] = delegate.newReplicatedRegisterMap()
   override def newReplicatedMap[K, V <: ReplicatedData](): ReplicatedMap[K, V] = delegate.newReplicatedMap()
   override def newVote(): Vote = delegate.newVote()
-
-  override def getWriteConsistency: WriteConsistency = delegate.getWriteConsistency
-  override def setWriteConsistency(consistency: WriteConsistency): Unit = delegate.setWriteConsistency(consistency)
 }
 
 private final class EntityConstructorInvoker(constructor: Constructor[_])

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedEntityImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedEntityImpl.scala
@@ -426,20 +426,6 @@ class ReplicatedEntityImpl(system: ActorSystem,
       override final def entityId(): String = EntityRunner.this.entityId
 
       override def serviceCallFactory(): ServiceCallFactory = rootContext.serviceCallFactory()
-
-      private var writeConsistency = WriteConsistency.LOCAL
-
-      override final def getWriteConsistency: WriteConsistency = writeConsistency
-
-      override final def setWriteConsistency(writeConsistency: WriteConsistency): Unit =
-        this.writeConsistency = writeConsistency
-
-      def replicatedEntityWriteConsistency: ReplicatedEntityWriteConsistency = writeConsistency match {
-        case WriteConsistency.LOCAL =>
-          ReplicatedEntityWriteConsistency.REPLICATED_ENTITY_WRITE_CONSISTENCY_LOCAL_UNSPECIFIED
-        case WriteConsistency.MAJORITY => ReplicatedEntityWriteConsistency.REPLICATED_ENTITY_WRITE_CONSISTENCY_MAJORITY
-        case WriteConsistency.ALL => ReplicatedEntityWriteConsistency.REPLICATED_ENTITY_WRITE_CONSISTENCY_ALL
-      }
     }
 
     trait CapturingReplicatedEntityFactory
@@ -474,16 +460,15 @@ class ReplicatedEntityImpl(system: ActorSystem,
         case Some(c) =>
           if (deleted) {
             Some(
-              ReplicatedEntityStateAction(action = ReplicatedEntityStateAction.Action.Delete(ReplicatedEntityDelete()),
-                                          replicatedEntityWriteConsistency)
+              ReplicatedEntityStateAction(action = ReplicatedEntityStateAction.Action.Delete(ReplicatedEntityDelete()))
             )
           } else if (c.hasDelta) {
             val delta = c.delta
             c.resetDelta()
             Some(
-              ReplicatedEntityStateAction(action =
-                                            ReplicatedEntityStateAction.Action.Update(ReplicatedEntityDelta(delta)),
-                                          replicatedEntityWriteConsistency)
+              ReplicatedEntityStateAction(
+                action = ReplicatedEntityStateAction.Action.Update(ReplicatedEntityDelta(delta))
+              )
             )
           } else {
             None

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedEntityOptionsImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedEntityOptionsImpl.scala
@@ -17,18 +17,22 @@
 package com.akkaserverless.javasdk.impl.replicatedentity
 
 import com.akkaserverless.javasdk.PassivationStrategy
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedEntityOptions
+import com.akkaserverless.javasdk.replicatedentity.{ReplicatedEntityOptions, WriteConsistency}
 
 import java.util.Collections
 import java.util
 
 private[impl] case class ReplicatedEntityOptionsImpl(
     override val passivationStrategy: PassivationStrategy,
-    override val forwardHeaders: java.util.Set[String]
+    override val forwardHeaders: java.util.Set[String],
+    override val writeConsistency: WriteConsistency
 ) extends ReplicatedEntityOptions {
 
   override def withPassivationStrategy(strategy: PassivationStrategy): ReplicatedEntityOptions =
     copy(passivationStrategy = strategy)
+
+  override def withWriteConsistency(writeConsistency: WriteConsistency): ReplicatedEntityOptions =
+    copy(writeConsistency = writeConsistency)
 
   override def withForwardHeaders(headers: util.Set[String]): ReplicatedEntityOptions =
     copy(forwardHeaders = Collections.unmodifiableSet(new util.HashSet(headers)));

--- a/sdk/src/test/scala/com/akkaserverless/javasdk/impl/replicatedentity/AnnotationBasedReplicatedEntitySupportSpec.scala
+++ b/sdk/src/test/scala/com/akkaserverless/javasdk/impl/replicatedentity/AnnotationBasedReplicatedEntitySupportSpec.scala
@@ -57,8 +57,6 @@ class AnnotationBasedReplicatedEntitySupportSpec extends AnyWordSpec with Matche
           s"The current ${wrongType} replicated data doesn't match requested type of ${dataType.getSimpleName}"
         )
     }
-    override def getWriteConsistency: WriteConsistency = WriteConsistency.LOCAL
-    override def setWriteConsistency(writeConsistency: WriteConsistency): Unit = ()
   }
 
   object WrappedResolvedType extends ResolvedType[Wrapped] {

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/JavaSdkTck.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/JavaSdkTck.java
@@ -19,6 +19,7 @@ package com.akkaserverless.javasdk.tck;
 import com.akkaserverless.javasdk.AkkaServerless;
 import com.akkaserverless.javasdk.PassivationStrategy;
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedEntityOptions;
+import com.akkaserverless.javasdk.replicatedentity.WriteConsistency;
 import com.akkaserverless.javasdk.tck.model.view.ViewTckModelBehavior;
 import com.akkaserverless.javasdk.valueentity.ValueEntityOptions;
 import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityOptions;
@@ -77,7 +78,8 @@ public final class JavaSdkTck {
               ConfiguredReplicatedEntity.class,
               ReplicatedEntity.getDescriptor().findServiceByName("ReplicatedEntityConfigured"),
               ReplicatedEntityOptions.defaults() // required timeout of 100 millis for TCK tests
-                  .withPassivationStrategy(PassivationStrategy.timeout(Duration.ofMillis(100))))
+                  .withPassivationStrategy(PassivationStrategy.timeout(Duration.ofMillis(100)))
+                  .withWriteConsistency(WriteConsistency.ALL))
           .registerEventSourcedEntity(
               EventSourcedTckModelEntity.class,
               EventSourcedEntity.getDescriptor().findServiceByName("EventSourcedTckModel"),

--- a/tck/src/main/java/com/akkaserverless/javasdk/tck/model/replicatedentity/TckModelReplicatedEntity.java
+++ b/tck/src/main/java/com/akkaserverless/javasdk/tck/model/replicatedentity/TckModelReplicatedEntity.java
@@ -102,17 +102,6 @@ public class TckModelReplicatedEntity {
       switch (action.getActionCase()) {
         case UPDATE:
           applyUpdate(replicatedData, action.getUpdate());
-          switch (action.getUpdate().getWriteConsistency()) {
-            case UPDATE_WRITE_CONSISTENCY_LOCAL_UNSPECIFIED:
-              context.setWriteConsistency(WriteConsistency.LOCAL);
-              break;
-            case UPDATE_WRITE_CONSISTENCY_MAJORITY:
-              context.setWriteConsistency(WriteConsistency.MAJORITY);
-              break;
-            case UPDATE_WRITE_CONSISTENCY_ALL:
-              context.setWriteConsistency(WriteConsistency.ALL);
-              break;
-          }
           break;
         case DELETE:
           context.delete();


### PR DESCRIPTION
Depends on https://github.com/lightbend/akkaserverless-framework/pull/795 being published first.

Move write consistency from a per-update setting to an overall replicated entity setting.