### PR TITLE
publishM2 before publishing maven artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,11 @@ jobs:
     steps:
       - checkout
       - restore_deps_cache
+      - setup_sbt
       - set-sdk-version
+      - run:
+          name: publish m2
+          command: sbt publishM2
       - run:
           name: Publish maven plugin and archetype
           command: |


### PR DESCRIPTION
0.7.0-beta.12 release failed because when publishing the maven plugin, we need the codegen artifact. Although we have published the codegen, this is not yet visible in maven central. 

Therefore, we need to publish locally 