### PR TITLE
fix: build maven project using jdk11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
 
   publish-maven:
     docker:
-      - image: circleci/openjdk:8
+      - image: circleci/openjdk:11
     steps:
       - checkout
       - restore_deps_cache

--- a/maven-java/pom.xml
+++ b/maven-java/pom.xml
@@ -31,6 +31,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <maven.version>3.3.9</maven.version>
   </properties>
 


### PR DESCRIPTION
For unknown reason, we were building the maven projects using jdk8. It turns out that since we first need to publish the codegen locally and the [sbt is configured](https://github.com/lightbend/akkaserverless-java-sdk/blob/main/build.sbt#L48-L49) with `--release` flag, we get the following error:

```java
-release is only supported on Java 9 and higher
```
(https://app.circleci.com/pipelines/github/lightbend/akkaserverless-java-sdk/503/workflows/fcbd35cb-21e1-44a9-a9fe-a36ef028d7f2/jobs/3088)


For the record, when I say for unknown reason I mean, I don't know why the old maven-java project was using jdk8. What we have now here is a copy-n-paste from that previous project. Anyway, my understanding is that we only build with jdk11 (not only on this project, but every akka serverless project) therefore align with jdk11 is the way to go.
