### PR TITLE
feat: samples uses project.version as sdk version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,14 +176,14 @@ jobs:
             cd maven-java
             mvn -B archetype:generate -DgroupId=com.example -DartifactId=counter-value-entity -DarchetypeGroupId=com.akkaserverless -DarchetypeArtifactId=akkaserverless-maven-archetype -DarchetypeVersion=$SDK_VERSION
             cd counter-value-entity
-            mvn -B -Dakkaserverless-sdk.version=$SDK_VERSION compile
+            mvn -B compile
       - run: 
           name: Run integration tests for Event Sourced Entity Archetype
           command: |
             cd maven-java
             mvn -B archetype:generate  -DgroupId=com.example -DartifactId=counter-event-sourced-entity -DarchetypeGroupId=com.akkaserverless -DarchetypeArtifactId=akkaserverless-maven-archetype-event-sourced-entity -DarchetypeVersion=$SDK_VERSION
             cd counter-event-sourced-entity
-            mvn -B -Dakkaserverless-sdk.version=$SDK_VERSION compile
+            mvn -B compile
       - save_deps_cache
 
   samples-tests:
@@ -200,25 +200,25 @@ jobs:
           command: |
             cd samples/java-valueentity-shopping-cart
             echo "Running mvn with SDK version: '$SDK_VERSION'"
-            mvn -Dakkaserverless-sdk.version=$SDK_VERSION -Dakkaserverless-maven-plugin.version=$SDK_VERSION verify -Pit
+            mvn versions:set -DnewVersion=$SDK_VERSION verify -Pit
       - run: 
           name: Run integration tests for Shopping Cart Event Sourced Entity sample
           command: |
             cd samples/java-eventsourced-shopping-cart
             echo "Running mvn with SDK version: '$SDK_VERSION'"
-            mvn -Dakkaserverless-sdk.version=$SDK_VERSION -Dakkaserverless-maven-plugin.version=$SDK_VERSION verify -Pit
+            mvn versions:set -DnewVersion=$SDK_VERSION verify -Pit
       - run: 
           name: Run integration tests for Counter Value Entity sample
           command: |
             cd samples/valueentity-counter
             echo "Running mvn with SDK version: '$SDK_VERSION'"
-            mvn -Dakkaserverless-sdk.version=$SDK_VERSION -Dakkaserverless-maven-plugin.version=$SDK_VERSION verify -Pit
+            mvn versions:set -DnewVersion=$SDK_VERSION verify -Pit
       - run:
           name: Run integration tests for Counter Replicated Entity sample
           command: |
             cd samples/replicatedentity-counter
             echo "Running mvn with SDK version: '$SDK_VERSION'"
-            mvn -Dakkaserverless-sdk.version=$SDK_VERSION -Dakkaserverless-maven-plugin.version=$SDK_VERSION verify -Pit
+            mvn versions:set -DnewVersion=$SDK_VERSION verify -Pit
       - save_deps_cache
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,25 +200,29 @@ jobs:
           command: |
             cd samples/java-valueentity-shopping-cart
             echo "Running mvn with SDK version: '$SDK_VERSION'"
-            mvn versions:set -DnewVersion=$SDK_VERSION verify -Pit
+            mvn versions:set -DnewVersion=$SDK_VERSION 
+            mvn verify -Pit
       - run: 
           name: Run integration tests for Shopping Cart Event Sourced Entity sample
           command: |
             cd samples/java-eventsourced-shopping-cart
             echo "Running mvn with SDK version: '$SDK_VERSION'"
-            mvn versions:set -DnewVersion=$SDK_VERSION verify -Pit
+            mvn versions:set -DnewVersion=$SDK_VERSION 
+            mvn verify -Pit
       - run: 
           name: Run integration tests for Counter Value Entity sample
           command: |
             cd samples/valueentity-counter
             echo "Running mvn with SDK version: '$SDK_VERSION'"
-            mvn versions:set -DnewVersion=$SDK_VERSION verify -Pit
+            mvn versions:set -DnewVersion=$SDK_VERSION 
+            mvn verify -Pit
       - run:
           name: Run integration tests for Counter Replicated Entity sample
           command: |
             cd samples/replicatedentity-counter
             echo "Running mvn with SDK version: '$SDK_VERSION'"
-            mvn versions:set -DnewVersion=$SDK_VERSION verify -Pit
+            mvn versions:set -DnewVersion=$SDK_VERSION 
+            mvn verify -Pit
       - save_deps_cache
 
   publish:

--- a/samples/java-customer-registry/pom.xml
+++ b/samples/java-customer-registry/pom.xml
@@ -17,8 +17,7 @@
     <akkasls.dockerTag>${project.version}</akkasls.dockerTag>
     <akkasls.mainClass>customer.Main</akkasls.mainClass>
     <jdk.target>11</jdk.target>
-    <akkaserverless-sdk.version>0.7.0-beta.10</akkaserverless-sdk.version>
-    <akkaserverless-maven-plugin.version>0.7.0-beta.10</akkaserverless-maven-plugin.version>
+    <akkaserverless-sdk.version>${project.version}</akkaserverless-sdk.version>
     <akka-grpc.version>1.1.1</akka-grpc.version>
   </properties>
 
@@ -50,6 +49,16 @@
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <!-- 
+          this plugin allow us to change the version of this projects and submodules
+          we use it in CI to align the project with the current SDK version
+        -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.8.1</version>
       </plugin>
 
       <plugin>
@@ -203,7 +212,7 @@
       <plugin>
         <groupId>com.akkaserverless</groupId>
         <artifactId>akkaserverless-maven-plugin</artifactId>
-	<version>${akkaserverless-maven-plugin.version}</version>
+	      <version>${akkaserverless-sdk.version}</version>
         <executions>
           <execution>
             <goals>

--- a/samples/java-eventing-shopping-cart/pom.xml
+++ b/samples/java-eventing-shopping-cart/pom.xml
@@ -18,8 +18,7 @@
     <akkasls.dockerTag>${project.version}</akkasls.dockerTag>
     <akkasls.mainClass>shopping.Main</akkasls.mainClass>
     <jdk.target>11</jdk.target>
-    <akkaserverless-sdk.version>0.7.0-beta.10</akkaserverless-sdk.version>
-    <akkaserverless-maven-plugin.version>0.7.0-beta.10</akkaserverless-maven-plugin.version>
+    <akkaserverless-sdk.version>${project.version}</akkaserverless-sdk.version>
     <akka-grpc.version>1.1.1</akka-grpc.version>
   </properties>
 
@@ -51,6 +50,16 @@
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>
         </configuration>
+      </plugin>
+      
+      <plugin>
+        <!-- 
+          this plugin allow us to change the version of this projects and submodules
+          we use it in CI to align the project with the current SDK version
+        -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.8.1</version>
       </plugin>
 
       <plugin>
@@ -204,7 +213,7 @@
       <plugin>
         <groupId>com.akkaserverless</groupId>
         <artifactId>akkaserverless-maven-plugin</artifactId>
-	<version>${akkaserverless-maven-plugin.version}</version>
+	      <version>${akkaserverless-sdk.version}</version>
         <executions>
           <execution>
             <goals>

--- a/samples/java-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-eventsourced-shopping-cart/pom.xml
@@ -19,8 +19,7 @@
         <jdk.target>11</jdk.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <akkaserverless-sdk.version>0.7.0-beta.10</akkaserverless-sdk.version>
-        <akkaserverless-maven-plugin.version>0.7.0-beta.10</akkaserverless-maven-plugin.version>
+        <akkaserverless-sdk.version>${project.version}</akkaserverless-sdk.version>
         <akka-grpc.version>1.1.1</akka-grpc.version>
     </properties>
 
@@ -52,6 +51,16 @@
                     <source>${jdk.target}</source>
                     <target>${jdk.target}</target>
                 </configuration>
+            </plugin>
+      
+            <plugin>
+              <!-- 
+                this plugin allow us to change the version of this projects and submodules
+                we use it in CI to align the project with the current SDK version
+              -->
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>versions-maven-plugin</artifactId>
+              <version>2.8.1</version>
             </plugin>
 
             <plugin>
@@ -209,7 +218,7 @@
             <plugin>
                 <groupId>com.akkaserverless</groupId>
                 <artifactId>akkaserverless-maven-plugin</artifactId>
-                <version>${akkaserverless-maven-plugin.version}</version>
+                <version>${akkaserverless-sdk.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/samples/java-valueentity-shopping-cart/pom.xml
+++ b/samples/java-valueentity-shopping-cart/pom.xml
@@ -19,8 +19,7 @@
       <jdk.target>11</jdk.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-      <akkaserverless-sdk.version>0.7.0-beta.10</akkaserverless-sdk.version>
-      <akkaserverless-maven-plugin.version>0.7.0-beta.10</akkaserverless-maven-plugin.version>
+      <akkaserverless-sdk.version>${project.version}</akkaserverless-sdk.version>
       <akka-grpc.version>1.1.1</akka-grpc.version>
   </properties>
 
@@ -52,6 +51,16 @@
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>
         </configuration>
+      </plugin>
+      
+      <plugin>
+        <!-- 
+          this plugin allow us to change the version of this projects and submodules
+          we use it in CI to align the project with the current SDK version
+        -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.8.1</version>
       </plugin>
 
       <plugin>
@@ -205,7 +214,7 @@
       <plugin>
         <groupId>com.akkaserverless</groupId>
         <artifactId>akkaserverless-maven-plugin</artifactId>
-        <version>${akkaserverless-maven-plugin.version}</version>
+        <version>${akkaserverless-sdk.version}</version>
         <executions>
           <execution>
             <goals>

--- a/samples/replicatedentity-counter/pom.xml
+++ b/samples/replicatedentity-counter/pom.xml
@@ -19,8 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <akkaserverless-sdk.version>0.7.0-beta.10</akkaserverless-sdk.version>
-    <akkaserverless-maven-plugin.version>0.7.0-beta.10</akkaserverless-maven-plugin.version>
+    <akkaserverless-sdk.version>${project.version}</akkaserverless-sdk.version>
     <akka-grpc.version>1.1.1</akka-grpc.version>
   </properties>
 
@@ -52,6 +51,16 @@
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>
         </configuration>
+      </plugin>
+      
+      <plugin>
+        <!-- 
+          this plugin allow us to change the version of this projects and submodules
+          we use it in CI to align the project with the current SDK version
+        -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.8.1</version>
       </plugin>
 
       <plugin>
@@ -206,7 +215,7 @@
       <plugin>
         <groupId>com.akkaserverless</groupId>
         <artifactId>akkaserverless-maven-plugin</artifactId>
-	<version>${akkaserverless-maven-plugin.version}</version>
+	      <version>${akkaserverless-sdk.version}</version>
         <executions>
           <execution>
             <goals>

--- a/samples/valueentity-counter/pom.xml
+++ b/samples/valueentity-counter/pom.xml
@@ -19,8 +19,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <akkaserverless-sdk.version>0.7.0-beta.10</akkaserverless-sdk.version>
-    <akkaserverless-maven-plugin.version>0.7.0-beta.10</akkaserverless-maven-plugin.version>
+    <akkaserverless-sdk.version>${project.version}</akkaserverless-sdk.version>
     <akka-grpc.version>1.1.1</akka-grpc.version>
   </properties>
 
@@ -52,6 +51,16 @@
           <source>${jdk.target}</source>
           <target>${jdk.target}</target>
         </configuration>
+      </plugin>
+      
+      <plugin>
+        <!-- 
+          this plugin allow us to change the version of this projects and submodules
+          we use it in CI to align the project with the current SDK version
+        -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.8.1</version>
       </plugin>
 
       <plugin>
@@ -205,7 +214,7 @@
       <plugin>
         <groupId>com.akkaserverless</groupId>
         <artifactId>akkaserverless-maven-plugin</artifactId>
-	<version>${akkaserverless-maven-plugin.version}</version>
+	      <version>${akkaserverless-sdk.version}</version>
         <executions>
           <execution>
             <goals>

--- a/updatePomVersions.sh
+++ b/updatePomVersions.sh
@@ -1,0 +1,33 @@
+# this script updates all maven projects versions (maven-java and samples) to align with the current sdk version
+# if SDK_VERSION env var is defined, it will use it, otherwise it will take the version from sbt
+# after running this script, you may run local tests or simply send a PR with the updates. 
+# the script can also run publishM2 and mvn install to generate the artifacts with the new version.
+
+
+if [ -z ${SDK_VERSION+x} ]; then 
+  SDK_VERSION=$(sbt "print sdk/version" | tail -1)
+fi
+
+if [ $1 ]; then 
+  sbt publishM2
+fi 
+
+cd maven-java
+mvn versions:set -DnewVersion=$SDK_VERSION
+
+if [ $1 ]; then 
+  mvn install
+fi 
+
+# cleanup
+rm pom.xml.versionsBackup
+rm */pom.xml.versionsBackup
+
+for i in samples
+do
+  (
+    cd $i
+    mvn versions:set -DnewVersion=$SDK_VERSION
+    rm pom.xml.versionsBackup
+  )
+done


### PR DESCRIPTION
Those changes will allows us to:

* change the sdk version in all mvn projects in one shot (changes can be pushed or not)
* samples use its own project.version as sdk version
* remove passing -D in CI, it suffice to use `mvn versions:set` 