### PR TITLE
fix: preserve execution dir

### DIFF
--- a/updatePomVersions.sh
+++ b/updatePomVersions.sh
@@ -12,16 +12,18 @@ if [ $1 ]; then
   sbt publishM2
 fi 
 
-cd maven-java
-mvn versions:set -DnewVersion=$SDK_VERSION
+(
+  cd maven-java
+  mvn versions:set -DnewVersion=$SDK_VERSION
 
-if [ $1 ]; then 
-  mvn install
-fi 
+  if [ $1 ]; then 
+    mvn install
+  fi
 
-# cleanup
-rm pom.xml.versionsBackup
-rm */pom.xml.versionsBackup
+  # cleanup
+  rm pom.xml.versionsBackup
+  rm */pom.xml.versionsBackup
+)
 
 for i in samples
 do

--- a/updatePomVersions.sh
+++ b/updatePomVersions.sh
@@ -25,7 +25,7 @@ fi
   rm */pom.xml.versionsBackup
 )
 
-for i in samples
+for i in samples/*
 do
   (
     cd $i


### PR DESCRIPTION
There is a small mistake on the updatePomVersions.sh script. We should not permanently move in `maven-java` directory.