### PR TITLE
feat: add some logging to codegen

### DIFF
--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Log.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Log.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.akkasls.codegen
+
+trait Log {
+  def debug(message: String): Unit
+  def info(message: String): Unit
+  def warning(message: String): Unit
+  def error(message: String): Unit
+}

--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/ModelBuilder.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/ModelBuilder.scala
@@ -143,9 +143,10 @@ object ModelBuilder {
    */
   def introspectProtobufClasses(
       descriptors: Iterable[Descriptors.FileDescriptor]
-  ): Model =
+  )(implicit log: Log): Model =
     descriptors.foldLeft(Model(Map.empty, Map.empty)) {
       case (Model(existingServices, existingEntities), descriptor) =>
+        log.debug("Looking at descriptor " + descriptor.getName)
         val services = for {
           serviceDescriptor <- descriptor.getServices.asScala
           options = serviceDescriptor
@@ -271,11 +272,12 @@ object ModelBuilder {
    */
   private def extractValueEntityDefinition(
       descriptor: Descriptors.FileDescriptor
-  ): Option[ValueEntity] = {
+  )(implicit log: Log): Option[ValueEntity] = {
     val rawEntity =
       descriptor.getOptions
         .getExtension(com.akkaserverless.Annotations.file)
         .getValueEntity
+    log.debug("Raw value entity name: " + rawEntity.getName)
 
     val protoReference = PackageNaming.from(descriptor)
 

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
@@ -24,10 +24,19 @@ import java.nio.file.Paths
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 import com.google.protobuf.ExtensionRegistry
+import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 
 class ModelBuilderSuite extends munit.FunSuite {
+  val log = LoggerFactory.getLogger(getClass)
+  implicit val codegenLog = new Log {
+    override def debug(message: String): Unit = log.debug(message)
+    override def info(message: String): Unit = log.info(message)
+    override def warning(message: String): Unit = log.warn(message)
+    override def error(message: String): Unit = log.error(message)
+  }
+
   test("EventSourcedEntity introspection") {
     val testFilesPath = Paths.get(getClass.getClassLoader.getResource("test-files").toURI)
     val descriptorFilePath =

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
@@ -53,28 +53,32 @@ object SourceGenerator extends PrettyPrinter {
       integrationTestSourceDirectory: Path,
       generatedSourceDirectory: Path,
       mainClass: String
-  ): Iterable[Path] = {
+  )(implicit log: Log): Iterable[Path] = {
 
     val (mainClassPackageName, mainClassName) = disassembleClassName(mainClass)
 
     model.services.values.flatMap {
       case service: ModelBuilder.EntityService =>
-        model.entities
-          .get(service.componentFullName)
-          .toSeq
-          .flatMap(
-            entity =>
-              EntityServiceSourceGenerator.generate(
-                entity,
-                service,
-                sourceDirectory,
-                testSourceDirectory,
-                integrationTestSourceDirectory,
-                generatedSourceDirectory,
-                mainClassPackageName,
-                mainClassName
-              )
-          )
+        model.entities.get(service.componentFullName) match {
+          case None =>
+            // TODO perhaps we even want to make this an error, to really go all-in on codegen?
+            log.warning(
+              "Service [" + service.fqn.fullName + "] refers to entity [" + service.componentFullName +
+              "], but no entity configuration is found for that component name"
+            )
+            Seq.empty
+          case Some(entity) =>
+            EntityServiceSourceGenerator.generate(
+              entity,
+              service,
+              sourceDirectory,
+              testSourceDirectory,
+              integrationTestSourceDirectory,
+              generatedSourceDirectory,
+              mainClassPackageName,
+              mainClassName
+            )
+        }
       case service: ModelBuilder.ViewService if service.transformedUpdates.nonEmpty =>
         ViewServiceSourceGenerator.generate(
           service,

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
@@ -18,10 +18,18 @@ package com.lightbend.akkasls.codegen
 package java
 
 import org.apache.commons.io.FileUtils
+import org.slf4j.LoggerFactory
 
 import _root_.java.nio.file.Files
 
 class SourceGeneratorSuite extends munit.FunSuite {
+  val log = LoggerFactory.getLogger(getClass)
+  implicit val codegenLog = new Log {
+    override def debug(message: String): Unit = log.debug(message)
+    override def info(message: String): Unit = log.info(message)
+    override def warning(message: String): Unit = log.warn(message)
+    override def error(message: String): Unit = log.error(message)
+  }
 
   test("generate") {
     val sourceDirectory = Files.createTempDirectory("source-generator-test")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,6 +90,7 @@ object Dependencies {
 
   val codegenCore = deps ++= Seq(
         protobufJava,
+        logback % Test,
         munit % Test,
         munitScalaCheck % Test
       )
@@ -97,8 +98,9 @@ object Dependencies {
   val codegenJava = deps ++= Seq(
         kiama,
         commonsIo,
-        munit % "test",
-        munitScalaCheck % "test"
+        logback % Test,
+        munit % Test,
+        munitScalaCheck % Test
       )
 
   val excludeTheseDependencies: Seq[ExclusionRule] = Seq(

--- a/publishLocalM2.sh
+++ b/publishLocalM2.sh
@@ -1,5 +1,21 @@
-# publish sbt and maven artifacts
-sbt publishM2
+#!/bin/bash
+
+set -e
+
+ONLY_MAVEN=0
+
+for arg in "$@"; do case $arg in
+  -o|--only-maven)
+    ONLY_MAVEN=1
+    shift
+    ;;
+  esac
+done
+
+if [ $ONLY_MAVEN == "0" ]; then
+  sbt publishM2
+fi
+
 SDK_VERSION=$(sbt "print sdk/version" | tail -1)
 cd maven-java
 mvn versions:set -DnewVersion=$SDK_VERSION


### PR DESCRIPTION
Notably for the case where there is an entity service,
but no entity component configuration that matches by
the component name - in which case nothing would be
generated, silently.