### PR TITLE
feat: add some logging to codegen

### DIFF
--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Log.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Log.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.akkasls.codegen
+
+trait Log {
+  def debug(message: String): Unit
+  def info(message: String): Unit
+  def warning(message: String): Unit
+  def error(message: String): Unit
+}

--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/ModelBuilder.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/ModelBuilder.scala
@@ -143,9 +143,10 @@ object ModelBuilder {
    */
   def introspectProtobufClasses(
       descriptors: Iterable[Descriptors.FileDescriptor]
-  ): Model =
+  )(implicit log: Log): Model =
     descriptors.foldLeft(Model(Map.empty, Map.empty)) {
       case (Model(existingServices, existingEntities), descriptor) =>
+        log.debug("Looking at descriptor " + descriptor.getName)
         val services = for {
           serviceDescriptor <- descriptor.getServices.asScala
           options = serviceDescriptor
@@ -271,11 +272,12 @@ object ModelBuilder {
    */
   private def extractValueEntityDefinition(
       descriptor: Descriptors.FileDescriptor
-  ): Option[ValueEntity] = {
+  )(implicit log: Log): Option[ValueEntity] = {
     val rawEntity =
       descriptor.getOptions
         .getExtension(com.akkaserverless.Annotations.file)
         .getValueEntity
+    log.debug("Raw value entity name: " + rawEntity.getName)
 
     val protoReference = PackageNaming.from(descriptor)
 

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
@@ -24,10 +24,19 @@ import java.nio.file.Paths
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 import com.google.protobuf.ExtensionRegistry
+import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 
 class ModelBuilderSuite extends munit.FunSuite {
+  val log = LoggerFactory.getLogger(getClass)
+  implicit val codegenLog = new Log {
+    override def debug(message: String): Unit = log.debug(message)
+    override def info(message: String): Unit = log.info(message)
+    override def warning(message: String): Unit = log.warn(message)
+    override def error(message: String): Unit = log.error(message)
+  }
+
   test("EventSourcedEntity introspection") {
     val testFilesPath = Paths.get(getClass.getClassLoader.getResource("test-files").toURI)
     val descriptorFilePath =

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
@@ -18,10 +18,18 @@ package com.lightbend.akkasls.codegen
 package java
 
 import org.apache.commons.io.FileUtils
+import org.slf4j.LoggerFactory
 
 import _root_.java.nio.file.Files
 
 class SourceGeneratorSuite extends munit.FunSuite {
+  val log = LoggerFactory.getLogger(getClass)
+  implicit val codegenLog = new Log {
+    override def debug(message: String): Unit = log.debug(message)
+    override def info(message: String): Unit = log.info(message)
+    override def warning(message: String): Unit = log.warn(message)
+    override def error(message: String): Unit = log.error(message)
+  }
 
   test("generate") {
     val sourceDirectory = Files.createTempDirectory("source-generator-test")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,6 +90,7 @@ object Dependencies {
 
   val codegenCore = deps ++= Seq(
         protobufJava,
+        logback % Test,
         munit % Test,
         munitScalaCheck % Test
       )
@@ -97,8 +98,9 @@ object Dependencies {
   val codegenJava = deps ++= Seq(
         kiama,
         commonsIo,
-        munit % "test",
-        munitScalaCheck % "test"
+        logback % Test,
+        munit % Test,
+        munitScalaCheck % Test
       )
 
   val excludeTheseDependencies: Seq[ExclusionRule] = Seq(


### PR DESCRIPTION
Notably for the case where there is an entity service, but no entity
component configuration that matches by the component name - in which case
nothing would be generated, silently.

backport of #165