### PR TITLE
feature: rely on some codegen in the Customer Registry sample

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,32 +195,39 @@ jobs:
       - restore_deps_cache
       - set-sdk-version
       - build-maven-java
-      - run: 
-          name: Run integration tests for Shopping Cart Value Entity sample
+      - run:
+          name: Views "Customer Registry" sample
+          command: |
+            cd samples/java-customer-registry
+            echo "Running mvn with SDK version: '$SDK_VERSION'"
+            # TODO: enable integration tests with -Pit
+            mvn -Dakkaserverless-sdk.version=$SDK_VERSION verify
+      - run:
+          name: Value Entity "Shopping Cart" sample
           command: |
             cd samples/java-valueentity-shopping-cart
             echo "Running mvn with SDK version: '$SDK_VERSION'"
             mvn -Dakkaserverless-sdk.version=$SDK_VERSION verify -Pit
       - run: 
-          name: Run integration tests for Shopping Cart Event Sourced Entity sample
+          name: Event Sourced Entity "Shopping Cart" sample
           command: |
             cd samples/java-eventsourced-shopping-cart
             echo "Running mvn with SDK version: '$SDK_VERSION'"
             mvn -Dakkaserverless-sdk.version=$SDK_VERSION verify -Pit
       - run: 
-          name: Run integration tests for Counter Value Entity sample
+          name: Value Entity "Counter" sample
           command: |
             cd samples/valueentity-counter
             echo "Running mvn with SDK version: '$SDK_VERSION'"
             mvn -Dakkaserverless-sdk.version=$SDK_VERSION verify -Pit
       - run:
-          name: Run integration tests for Counter Replicated Entity sample
+          name: Replicated Entity "Counter" sample
           command: |
             cd samples/replicatedentity-counter
             echo "Running mvn with SDK version: '$SDK_VERSION'"
             mvn -Dakkaserverless-sdk.version=$SDK_VERSION verify -Pit
       - run:
-          name: Run integration tests for the Eventing Shopping Cart sample
+          name: Eventing "Shopping Cart" sample
           command: |
             cd samples/java-eventing-shopping-cart
             echo "Running mvn with SDK version: '$SDK_VERSION'"

--- a/build.sbt
+++ b/build.sbt
@@ -119,9 +119,8 @@ lazy val codegenJava =
 
 lazy val samples = project
   .in(file("samples"))
-  .aggregate(
-    `java-eventing-shopping-cart`,
-    `java-customer-registry`
+  .aggregate( // samples relying on codegen must use Maven
+    `java-eventing-shopping-cart`
   )
 
 lazy val `java-eventing-shopping-cart` = project

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
@@ -249,7 +249,7 @@ object EntityServiceSourceGenerator {
                     case ModelBuilder.ValueEntity(_, _, state) =>
                       "CommandContext" <> angles(qualifiedType(state.fqn))
                     case _ => text("CommandContext")
-                  }) <+> "ctx"
+                  }) <+> "context"
                 ),
                 emptyDoc
               ) {
@@ -314,7 +314,8 @@ object EntityServiceSourceGenerator {
         )
       case _: ModelBuilder.ValueEntity =>
         Seq(
-          "com.akkaserverless.javasdk.valueentity.*"
+          "com.akkaserverless.javasdk.valueentity.CommandContext",
+          "com.akkaserverless.javasdk.valueentity.ValueEntity"
         )
     })).distinct.sorted
 
@@ -371,7 +372,7 @@ object EntityServiceSourceGenerator {
                   case ModelBuilder.ValueEntity(_, _, state) =>
                     "CommandContext" <> angles(qualifiedType(state.fqn))
                   case _ => text("CommandContext")
-                }) <+> "ctx"
+                }) <+> "context"
               )
             ) <> semi
           },

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
@@ -315,6 +315,7 @@ object EntityServiceSourceGenerator {
       case _: ModelBuilder.ValueEntity =>
         Seq(
           "com.akkaserverless.javasdk.valueentity.CommandContext",
+          "com.akkaserverless.javasdk.valueentity.CommandHandler",
           "com.akkaserverless.javasdk.valueentity.ValueEntity"
         )
     })).distinct.sorted

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGenerator.scala
@@ -97,7 +97,7 @@ object ViewServiceSourceGenerator {
     val imports = (messageTypes
       .filterNot(_.parent.javaPackage == packageName)
       .map(typeImport) ++ Seq(
-      "com.akkaserverless.javasdk.view.*",
+      "com.akkaserverless.javasdk.view.View",
       "java.util.Optional"
     )).distinct.sorted
 

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGeneratorSuite.scala
@@ -76,12 +76,12 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
       |    }
       |    
       |    @Override
-      |    public Reply<Empty> set(ServiceOuterClass.SetValue command, CommandContext ctx) {
+      |    public Reply<Empty> set(ServiceOuterClass.SetValue command, CommandContext context) {
       |        return Reply.failure("The command handler for `Set` is not implemented, yet");
       |    }
       |    
       |    @Override
-      |    public Reply<ServiceOuterClass.MyState> get(ServiceOuterClass.GetValue command, CommandContext ctx) {
+      |    public Reply<ServiceOuterClass.MyState> get(ServiceOuterClass.GetValue command, CommandContext context) {
       |        return Reply.failure("The command handler for `Get` is not implemented, yet");
       |    }
       |    
@@ -138,12 +138,12 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
       |    }
       |    
       |    @Override
-      |    public Reply<Empty> set(ServiceOuterClass.SetValue command, CommandContext<EntityOuterClass.MyState> ctx) {
+      |    public Reply<Empty> set(ServiceOuterClass.SetValue command, CommandContext<EntityOuterClass.MyState> context) {
       |        return Reply.failure("The command handler for `Set` is not implemented, yet");
       |    }
       |    
       |    @Override
-      |    public Reply<ServiceOuterClass.MyState> get(ServiceOuterClass.GetValue command, CommandContext<EntityOuterClass.MyState> ctx) {
+      |    public Reply<ServiceOuterClass.MyState> get(ServiceOuterClass.GetValue command, CommandContext<EntityOuterClass.MyState> context) {
       |        return Reply.failure("The command handler for `Get` is not implemented, yet");
       |    }
       |}""".stripMargin
@@ -183,10 +183,10 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
       |    public abstract void handleSnapshot(EntityOuterClass.MyState snapshot);
       |    
       |    @CommandHandler
-      |    public abstract Reply<Empty> set(ServiceOuterClass.SetValue command, CommandContext ctx);
+      |    public abstract Reply<Empty> set(ServiceOuterClass.SetValue command, CommandContext context);
       |    
       |    @CommandHandler
-      |    public abstract Reply<ServiceOuterClass.MyState> get(ServiceOuterClass.GetValue command, CommandContext ctx);
+      |    public abstract Reply<ServiceOuterClass.MyState> get(ServiceOuterClass.GetValue command, CommandContext context);
       |    
       |    @EventHandler
       |    public abstract void setEvent(EntityOuterClass.SetEvent event);
@@ -213,7 +213,9 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
       |
       |import com.akkaserverless.javasdk.EntityId;
       |import com.akkaserverless.javasdk.Reply;
-      |import com.akkaserverless.javasdk.valueentity.*;
+      |import com.akkaserverless.javasdk.valueentity.CommandContext;
+      |import com.akkaserverless.javasdk.valueentity.CommandHandler;
+      |import com.akkaserverless.javasdk.valueentity.ValueEntity;
       |import com.example.service.persistence.EntityOuterClass;
       |import com.external.Empty;
       |
@@ -221,10 +223,10 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
       |public abstract class AbstractMyService {
       |    
       |    @CommandHandler
-      |    public abstract Reply<Empty> set(ServiceOuterClass.SetValue command, CommandContext<EntityOuterClass.MyState> ctx);
+      |    public abstract Reply<Empty> set(ServiceOuterClass.SetValue command, CommandContext<EntityOuterClass.MyState> context);
       |    
       |    @CommandHandler
-      |    public abstract Reply<ServiceOuterClass.MyState> get(ServiceOuterClass.GetValue command, CommandContext<EntityOuterClass.MyState> ctx);
+      |    public abstract Reply<ServiceOuterClass.MyState> get(ServiceOuterClass.GetValue command, CommandContext<EntityOuterClass.MyState> context);
       |}""".stripMargin
     )
   }

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGeneratorSuite.scala
@@ -43,7 +43,7 @@ class ViewServiceSourceGeneratorSuite extends munit.FunSuite {
         |
         |package com.example.service;
         |
-        |import com.akkaserverless.javasdk.view.*;
+        |import com.akkaserverless.javasdk.view.View;
         |import com.example.service.persistence.EntityOuterClass;
         |import java.util.Optional;
         |

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -34,6 +34,8 @@ This example assumes the following `customer` state is defined in a `customer_do
 include::java:example$java-customer-registry/src/main/proto/customer/customer_domain.proto[tags=declarations;domain]
 ----
 
+<1> The `(akkaserverless.file).value_entity` option configures code generation to provide base classes and initial implementations for a Value Entity.
+
 === Define the View service descriptor
 
 To get a View of multiple customers by their name, define the View as a `service` in Protobuf:
@@ -97,10 +99,10 @@ The following lines in the `.proto` file define a View to consume the `CustomerC
 include::java:example$java-customer-registry/src/main/proto/customer/customer_view.proto[tags=declarations;service-event-sourced]
 ----
 
-<1> Define an update method for each event.
-<2> The source of the View is from the journal of the `"customers"` Event Sourced Entity. This identifier is defined in the `@EventSourcedEntity(entityType = "customers")` annotation of the Event Sourced Entity.
-<3> Enable `transform_updates` to build the View state from the events.
-<4> One method for each event.
+<1> The `akkaserverless.service` option configures code generation to provide base classes and an initial implementation for the class transforming events to updates of the state.
+<2> Define an update method for each event.
+<3> The source of the View is from the journal of the `"customers"` Event Sourced Entity. This identifier is defined in the `@EventSourcedEntity(entityType = "customers")` annotation of the Event Sourced Entity.
+<4> Enable `transform_updates` to build the View state from the events.
 <5> The same `event_sourced_entity` for all update methods. Note the required `table` attribute. Use any name, which you will reference in the query `SELECT` statement.
 <6> Enable `transform_updates` for all update methods.
 
@@ -113,16 +115,16 @@ all events, you need to ignore unneeded events as shown in the `IgnoreOtherEvent
 
 [source,java,indent=0]
 ----
-include::java:example$java-customer-registry/src/main/java/customer/CustomerView.java[tag=process-events]
+include::java:example$java-customer-registry/src/main/java/customer/view/CustomerByNameView.java[tag=process-events]
 ----
 
 <1> The class must have the link:{attachmentsdir}/api/com/akkaserverless/javasdk/view/View.html[`@View`] annotation.
-<2> Each update method in the Protobuf definition should have a corresponding method in the Java class. The methods must have the link:{attachmentsdir}/api/com/akkaserverless/javasdk/view/UpdateHandler.html[`@UpdateHandler`] annotation.
+<2> It extends the generated `AbstractCustomerByNameView` which requires all link:{attachmentsdir}/api/com/akkaserverless/javasdk/view/UpdateHandler.html[`@UpdateHandler`] methods.
 <3> One method for each event.
 
-The first method parameter should correspond to the parameter in the Protobuf service call, the event.
+The first method parameter is the parameter in the Protobuf service call, the event.
 
-A second parameter can optionally be defined for the previous state. Its type corresponds to the return type of the Protobuf service call. It can be defined as `Optional`. For the first event of an Event Sourced Entity or for the first change of a Value Entity there is no previous state and then `Optional.empty` or `null` is used for the state parameter.
+A second parameter corresponds to the state of a customer entity. It is wrapped in an `Optional` as there is no state before the first event, thus the `Optional` will be empty.
 
 The method may also take an link:{attachmentsdir}/api/com/akkaserverless/javasdk/view/UpdateHandlerContext.html[`UpdateHandlerContext`] parameter.
 

--- a/samples/java-customer-registry/README.md
+++ b/samples/java-customer-registry/README.md
@@ -5,14 +5,22 @@ This example includes the code snippets that are used in the Views documentation
 To run the example locally:
 
 * Start the example:
-  * from sbt: `sbt java-customer-registry/run`
-  * or mvn
+  * publish relevant projects for use from Maven
     ```
-    sbt sdk/publishM2
-    export AKKASERVERLESS_JAVA_SDK_VERSION="0.7.0-beta....-SNAPSHOT"
+    sbt publishM2
+    ```
+  * build the latest Maven plugin and archetypes
+    ```
+    cd maven-java
+    mvn versions:set -DnewVersion="0.7.0-beta....-SNAPSHOT"
+    mvn install
+    ```
+  * trigger codegen, compile and run form Maven
+    ```
     cd samples/java-customer-registry
-    mvn compile exec:java
+    mvn -Dakkaserverless-sdk.verion="0.7.0-beta....-SNAPSHOT" compile exec:java
     ```
+
 * Start the proxy
   * with in-memory store: `sbt proxy-core/run`
   * or with local Spanner emulator:

--- a/samples/java-customer-registry/pom.xml
+++ b/samples/java-customer-registry/pom.xml
@@ -10,13 +10,14 @@
   <name>Customer Registry</name>
 
   <properties>
+    <!-- TODO Update to your own Docker repository or Docker Hub scope -->
+    <dockerImage>my-docker-repo/${project.artifactId}</dockerImage>
+    <dockerTag>${project.version}</dockerTag>
+    <mainClass>customer.Main</mainClass>
+
+    <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <!-- TODO Update to your own Docker repository or Docker Hub scope -->
-    <akkasls.dockerImage>my-docker-repo/${project.artifactId}</akkasls.dockerImage>
-    <akkasls.dockerTag>${project.version}</akkasls.dockerTag>
-    <akkasls.mainClass>customer.Main</akkasls.mainClass>
-    <jdk.target>11</jdk.target>
     <akkaserverless-sdk.version>0.7.0-beta.18</akkaserverless-sdk.version>
     <akka-grpc.version>1.1.1</akka-grpc.version>
   </properties>
@@ -113,7 +114,7 @@
                   <resource>reference.conf</resource>
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${akkasls.mainClass}</mainClass>
+                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>
@@ -183,7 +184,7 @@
           </execution>
         </executions>
         <configuration>
-          <mainClass>${akkasls.mainClass}</mainClass>
+          <mainClass>${mainClass}</mainClass>
         </configuration>
       </plugin>
 
@@ -213,7 +214,7 @@
         </executions>
         <configuration>
           <dockerImage>${dockerImage}:${dockerTag}</dockerImage>
-          <mainClass>${akkasls.mainClass}</mainClass>
+          <mainClass>${mainClass}</mainClass>
           <integrationTestSourceDirectory>src/it/java</integrationTestSourceDirectory>
         </configuration>
       </plugin>

--- a/samples/java-customer-registry/src/main/java/customer/Main.java
+++ b/samples/java-customer-registry/src/main/java/customer/Main.java
@@ -19,6 +19,8 @@ package customer;
 import com.akkaserverless.javasdk.AkkaServerless;
 import customer.api.CustomerApi;
 import customer.domain.CustomerDomain;
+import customer.domain.CustomerValueEntity;
+import customer.view.CustomerByNameView;
 import customer.view.CustomerViewModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +51,7 @@ public final class Main {
       // tag::register-with-class[]
       new AkkaServerless()
           .registerView(
-              CustomerView.class,
+              CustomerByNameView.class,
               CustomerViewModel.getDescriptor().findServiceByName("CustomerByNameView"),
               "customerByName",
               CustomerDomain.getDescriptor())

--- a/samples/java-customer-registry/src/main/java/customer/domain/CustomerValueEntity.java
+++ b/samples/java-customer-registry/src/main/java/customer/domain/CustomerValueEntity.java
@@ -14,57 +14,63 @@
  * limitations under the License.
  */
 
-package customer;
+package customer.domain;
 
+import com.akkaserverless.javasdk.EntityId;
+import com.akkaserverless.javasdk.Reply;
 import com.akkaserverless.javasdk.valueentity.CommandContext;
-import com.akkaserverless.javasdk.valueentity.CommandHandler;
 import com.akkaserverless.javasdk.valueentity.ValueEntity;
 import com.google.protobuf.Empty;
 import customer.api.CustomerApi;
-import customer.domain.CustomerDomain;
 
 @ValueEntity(entityType = "customers")
-public class CustomerValueEntity {
+public class CustomerValueEntity extends AbstractCustomerValueEntity {
+  @SuppressWarnings("unused")
+  private final String entityId;
 
-  @CommandHandler
-  public CustomerApi.Customer getCustomer(
-      CustomerApi.GetCustomerRequest request,
-      CommandContext<CustomerDomain.CustomerState> context) {
-    CustomerDomain.CustomerState state =
-        context.getState().orElseGet(CustomerDomain.CustomerState::getDefaultInstance);
-    return convertToApi(state);
+  public CustomerValueEntity(@EntityId String entityId) {
+    this.entityId = entityId;
   }
 
-  @CommandHandler
-  public Empty create(
-      CustomerApi.Customer customer, CommandContext<CustomerDomain.CustomerState> context) {
-    CustomerDomain.CustomerState state = convertToDomain(customer);
+  @Override
+  public Reply<Empty> create(
+      CustomerApi.Customer command, CommandContext<CustomerDomain.CustomerState> context) {
+    CustomerDomain.CustomerState state = convertToDomain(command);
     context.updateState(state);
-    return Empty.getDefaultInstance();
+    return Reply.noReply();
   }
 
-  @CommandHandler
-  public Empty changeName(
-      CustomerApi.ChangeNameRequest request, CommandContext<CustomerDomain.CustomerState> context) {
+  @Override
+  public Reply<Empty> changeName(
+      CustomerApi.ChangeNameRequest command, CommandContext<CustomerDomain.CustomerState> context) {
     if (context.getState().isEmpty())
       throw context.fail("Customer must be created before name can be changed.");
     CustomerDomain.CustomerState updatedState =
-        context.getState().get().toBuilder().setName(request.getNewName()).build();
+        context.getState().get().toBuilder().setName(command.getNewName()).build();
     context.updateState(updatedState);
-    return Empty.getDefaultInstance();
+    return Reply.noReply();
   }
 
-  @CommandHandler
-  public Empty changeAddress(
-      CustomerApi.ChangeAddressRequest request,
+  @Override
+  public Reply<Empty> changeAddress(
+      CustomerApi.ChangeAddressRequest command,
       CommandContext<CustomerDomain.CustomerState> context) {
     if (context.getState().isEmpty())
       throw context.fail("Customer must be created before address can be changed.");
     CustomerDomain.CustomerState state = context.getState().get();
     CustomerDomain.CustomerState updatedState =
-        state.toBuilder().setAddress(convertAddressToDomain(request.getNewAddress())).build();
+        state.toBuilder().setAddress(convertAddressToDomain(command.getNewAddress())).build();
     context.updateState(updatedState);
-    return Empty.getDefaultInstance();
+    return Reply.noReply();
+  }
+
+  @Override
+  public Reply<CustomerApi.Customer> getCustomer(
+      CustomerApi.GetCustomerRequest command,
+      CommandContext<CustomerDomain.CustomerState> context) {
+    CustomerDomain.CustomerState state =
+        context.getState().orElseGet(CustomerDomain.CustomerState::getDefaultInstance);
+    return Reply.message(convertToApi(state));
   }
 
   private CustomerApi.Customer convertToApi(CustomerDomain.CustomerState state) {

--- a/samples/java-customer-registry/src/main/java/customer/view/CustomerByNameView.java
+++ b/samples/java-customer-registry/src/main/java/customer/view/CustomerByNameView.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customer.view;
+
+// tag::process-events[]
+import com.akkaserverless.javasdk.view.View;
+import com.google.protobuf.Any;
+import customer.domain.CustomerDomain;
+import java.util.Optional;
+
+@View // <1>
+public class CustomerByNameView extends AbstractCustomerByNameView { // <2>
+
+  @Override // <3>
+  public CustomerDomain.CustomerState processCustomerCreated(
+      CustomerDomain.CustomerCreated event, Optional<CustomerDomain.CustomerState> state) {
+    if (state.isPresent()) {
+      return state.get(); // already created
+    } else {
+      return event.getCustomer();
+    }
+  }
+
+  @Override // <3>
+  public CustomerDomain.CustomerState processCustomerNameChanged(
+      CustomerDomain.CustomerNameChanged event, Optional<CustomerDomain.CustomerState> state) {
+    if (state.isPresent()) {
+      return state.get().toBuilder().setName(event.getNewName()).build();
+    } else {
+      throw new RuntimeException("Received `CustomerNameChanged`, but no state exists.");
+    }
+  }
+
+  @Override // <3>
+  public CustomerDomain.CustomerState ignoreOtherEvents(
+      Any event, Optional<CustomerDomain.CustomerState> state) {
+    return state.orElseThrow(
+        () ->
+            new RuntimeException(
+                "Received `" + event.getClass().getSimpleName() + "`, but no state exists."));
+  }
+}
+// end::process-events[]

--- a/samples/java-customer-registry/src/main/proto/customer/customer_api.proto
+++ b/samples/java-customer-registry/src/main/proto/customer/customer_api.proto
@@ -48,6 +48,11 @@ message ChangeAddressRequest {
 }
 
 service CustomerService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "customer.domain.CustomerValueEntity"
+  };
+
   rpc Create(Customer) returns (google.protobuf.Empty) {}
 
   rpc ChangeName(ChangeNameRequest) returns (google.protobuf.Empty) {}

--- a/samples/java-customer-registry/src/main/proto/customer/customer_domain.proto
+++ b/samples/java-customer-registry/src/main/proto/customer/customer_domain.proto
@@ -22,6 +22,14 @@ option java_outer_classname = "CustomerDomain";
 //end::declarations[]
 
 // tag::domain[]
+import "akkaserverless/annotations.proto";
+
+option (akkaserverless.file).value_entity = { // <1>
+  name: "CustomerValueEntity"
+  entity_type: "customers"
+  state: "CustomerState"
+};
+
 message CustomerState {
   string customer_id = 1;
   string email = 2;

--- a/samples/java-customer-registry/src/main/proto/customer/customer_view.proto
+++ b/samples/java-customer-registry/src/main/proto/customer/customer_view.proto
@@ -120,17 +120,21 @@ service CustomersResponseByName {
 
 // tag::service-event-sourced[]
 service CustomerByNameView {
-  rpc ProcessCustomerCreated(domain.CustomerCreated) returns (domain.CustomerState) { // <1>
+  option (akkaserverless.service) = { // <1>
+    type: SERVICE_TYPE_VIEW
+  };
+
+  rpc ProcessCustomerCreated(domain.CustomerCreated) returns (domain.CustomerState) { // <2>
     option (akkaserverless.method).eventing.in = {
-      event_sourced_entity: "customers" // <2>
+      event_sourced_entity: "customers" // <3>
     };
     option (akkaserverless.method).view.update = {
       table: "customers"
-      transform_updates: true // <3>
+      transform_updates: true // <4>
     };
   }
 
-  rpc ProcessCustomerNameChanged(domain.CustomerNameChanged) returns (domain.CustomerState) { // <4>
+  rpc ProcessCustomerNameChanged(domain.CustomerNameChanged) returns (domain.CustomerState) { // <2>
     option (akkaserverless.method).eventing.in = {
       event_sourced_entity: "customers" // <5>
     };
@@ -142,11 +146,11 @@ service CustomerByNameView {
 
   rpc IgnoreOtherEvents(google.protobuf.Any) returns (domain.CustomerState) {
     option (akkaserverless.method).eventing.in = {
-      event_sourced_entity: "customers"
+      event_sourced_entity: "customers" // <5>
      };
      option (akkaserverless.method).view.update = {
        table: "customers"
-       transform_updates: true
+       transform_updates: true // <6>
      };
   };
 


### PR DESCRIPTION
The current "Customer Registry" contains both a Value Entity and an Event-sourced Entity both are required for doc-snippets.

This PR enables codegen for the Value Entity and for the View and reflects that (a bit) in the documentation.

Similar to #198 

Discovered #199 during this.