### PR TITLE
Make generated ValueEntityProvider a builder

### DIFF
--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
@@ -203,7 +203,7 @@ object SourceGenerator extends PrettyPrinter {
                 |)""".stripMargin
 
           case entity: ModelBuilder.ValueEntity =>
-            s".register(new ${entity.fqn.name}Provider(create${entity.fqn.name}))"
+            s".register(${entity.fqn.name}Provider.of(create${entity.fqn.name}))"
         }
 
       case service: ModelBuilder.ViewService =>

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
@@ -193,6 +193,7 @@ object ValueEntitySourceGenerator {
       packageName,
       otherImports = Seq(
           "com.akkaserverless.javasdk.valueentity.ValueEntityContext",
+          "com.akkaserverless.javasdk.valueentity.ValueEntityOptions",
           "com.akkaserverless.javasdk.valueentity.ValueEntityProvider",
           "com.google.protobuf.Descriptors",
           "java.util.function.Function"
@@ -214,9 +215,27 @@ object ValueEntitySourceGenerator {
         |public class ${className}Provider implements ValueEntityProvider {
         |
         |  private final Function<ValueEntityContext, ${className}> entityFactory;
+        |  private final ValueEntityOptions options;
         |
-        |  public ${className}Provider(Function<ValueEntityContext, ${className}> entityFactory) {
+        |  /** Factory method of ${className}Provider */
+        |  public static ${className}Provider of(Function<ValueEntityContext, ${className}> entityFactory) {
+        |    return new ${className}Provider(entityFactory, ValueEntityOptions.defaults());
+        |  }
+        | 
+        |  private ${className}Provider(
+        |      Function<ValueEntityContext, ${className}> entityFactory,
+        |      ValueEntityOptions options) {
         |    this.entityFactory = entityFactory;
+        |    this.options = options;
+        |  }
+        |
+        |  @Override
+        |  public final ValueEntityOptions options() {
+        |    return options;
+        |  }
+        | 
+        |  public final ${className}Provider withOptions(ValueEntityOptions options) {
+        |    return new ${className}Provider(entityFactory, options);
         |  }
         |
         |  @Override

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
@@ -219,7 +219,7 @@ class SourceGeneratorSuite extends munit.FunSuite {
         |        EntityOuterClass1.getDescriptor(),
         |        ExternalDomain.getDescriptor()
         |      )
-        |      .register(new MyValueEntity2Provider(createMyValueEntity2))
+        |      .register(MyValueEntity2Provider.of(createMyValueEntity2))
         |      .registerEventSourcedEntity(
         |        MyEntity3.class,
         |        ServiceOuterClass3.getDescriptor().findServiceByName("MyService3"),

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGeneratorSuite.scala
@@ -226,6 +226,7 @@ class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
          |package com.example.service;
          |
          |import com.akkaserverless.javasdk.valueentity.ValueEntityContext;
+         |import com.akkaserverless.javasdk.valueentity.ValueEntityOptions;
          |import com.akkaserverless.javasdk.valueentity.ValueEntityProvider;
          |import com.example.service.ServiceOuterClass;
          |import com.example.service.persistence.EntityOuterClass;
@@ -238,9 +239,27 @@ class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
          |public class MyServiceProvider implements ValueEntityProvider {
          |
          |  private final Function<ValueEntityContext, MyService> entityFactory;
+         |  private final ValueEntityOptions options;
          |
-         |  public MyServiceProvider(Function<ValueEntityContext, MyService> entityFactory) {
+         |  /** Factory method of MyServiceProvider */
+         |  public static MyServiceProvider of(Function<ValueEntityContext, MyService> entityFactory) {
+         |    return new MyServiceProvider(entityFactory, ValueEntityOptions.defaults());
+         |  }
+         | 
+         |  private MyServiceProvider(
+         |      Function<ValueEntityContext, MyService> entityFactory,
+         |      ValueEntityOptions options) {
          |    this.entityFactory = entityFactory;
+         |    this.options = options;
+         |  }
+         |
+         |  @Override
+         |  public final ValueEntityOptions options() {
+         |    return options;
+         |  }
+         | 
+         |  public final MyServiceProvider withOptions(ValueEntityOptions options) {
+         |    return new MyServiceProvider(entityFactory, options);
          |  }
          |
          |  @Override

--- a/samples/java-customer-registry/src/main/java/customer/Main.java
+++ b/samples/java-customer-registry/src/main/java/customer/Main.java
@@ -53,7 +53,7 @@ public final class Main {
               "customerByName",
               CustomerDomain.getDescriptor())
           // end::register[]
-          .register(new CustomerValueEntityProvider(CustomerValueEntity::new))
+          .register(CustomerValueEntityProvider.of(CustomerValueEntity::new))
           .start()
           .toCompletableFuture()
           .get();

--- a/sdk/src/main/java/com/akkaserverless/javasdk/AkkaServerless.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/AkkaServerless.java
@@ -497,26 +497,21 @@ public final class AkkaServerless {
   }
 
   /**
-   * Register a value based entity using a ValueEntityProvider.
+   * Register a value based entity using a {{@link ValueEntityProvider}}. The concrete <code>
+   * ValueEntityProvider</code> is generated for the specific entities defined in Protobuf, for
+   * example <code>CustomerEntityProvider</code>.
+   *
+   * <p>{{@link ValueEntityOptions}} can be defined by in the <code>ValueEntityProvider</code>.
    *
    * @return This stateful service builder.
    */
   public <T> AkkaServerless register(ValueEntityProvider provider) {
-    return register(provider, ValueEntityOptions.defaults());
-  }
-
-  /**
-   * Register a value based entity using a ValueEntityProvider with user defined ValueEntityOptions.
-   *
-   * @return This stateful service builder.
-   */
-  public <T> AkkaServerless register(ValueEntityProvider provider, ValueEntityOptions options) {
     return lowLevel()
         .registerValueEntity(
-            context -> provider.newHandler(context),
+            provider::newHandler,
             provider.serviceDescriptor(),
             provider.entityType(),
-            options,
+            provider.options(),
             provider.additionalDescriptors());
   }
 

--- a/sdk/src/main/java/com/akkaserverless/javasdk/valueentity/ValueEntityProvider.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/valueentity/ValueEntityProvider.java
@@ -21,6 +21,8 @@ import com.google.protobuf.Descriptors;
 
 public interface ValueEntityProvider {
 
+  ValueEntityOptions options();
+
   Descriptors.ServiceDescriptor serviceDescriptor();
 
   String entityType();


### PR DESCRIPTION
* include options in ValueEntityProvider instead of having overloaded register
  methods
* this will make it easier for us to add more optional parameters when needed

Follow up on https://github.com/lightbend/akkaserverless-java-sdk/pull/190/files#r687726999