### PR TITLE
fix: regenerate from Maven archetype

### DIFF
--- a/docs/src/modules/java/examples/archetype/first-service/README.md
+++ b/docs/src/modules/java/examples/archetype/first-service/README.md
@@ -48,30 +48,31 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:java
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.lbcs.dev/javascript/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://developer.lightbend.com/docs/akka-serverless/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'
 The command handler for `GetCurrentCounter` is not implemented, yet
 ```
 
-For example, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
+For example, using [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 
 ```shell
-> grpcurl -plaintext -d '{"counterId": "foo"}' localhost:9000 com.example.CounterService/GetCurrentCounter
+> grpcurl -plaintext -d '{"counterId": "foo"}' localhost:9000 com.example.CounterService/GetCurrentCounter 
 ERROR:
   Code: Unknown
   Message: The command handler for `GetCurrentCounter` is not implemented, yet
 ```
 
-> Note: The failure is to be expected if you have not yet provided an implementation of `GetCurrentCounter` in your entity.
+> Note: The failure is to be expected if you have not yet provided an implementation of `GetCurrentCounter` in
+> your entity.
 
 
 ## Deploying
 
 To deploy your service, install the `akkasls` CLI as documented in
 [Setting up a local development environment](https://developer.lightbend.com/docs/akka-serverless/getting-started/set-up-development-env.html)
-and configure a Docker Registry for your container image.
+and configure a Docker Registry to upload your docker image to.
 
 You will need to update the `dockerImage` property in the `pom.xml` and refer to
 [Configuring registries](https://developer.lightbend.com/docs/akka-serverless/deploying/registries.html)

--- a/docs/src/modules/java/examples/archetype/first-service/pom.xml
+++ b/docs/src/modules/java/examples/archetype/first-service/pom.xml
@@ -21,6 +21,8 @@
 
     <akkaserverless-sdk.version>0.7.0-beta.19</akkaserverless-sdk.version>
     <akka-grpc.version>1.1.1</akka-grpc.version>
+    <akka-streams.version>2.6.14</akka-streams.version>
+    <scala.binary.version>2.13</scala.binary.version>
   </properties>
 
   <build>
@@ -96,7 +98,7 @@
               </protocPlugins>
             </configuration>
           </execution>
-      </executions>
+        </executions>
       </plugin>
 
       <plugin>
@@ -126,7 +128,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.26.1</version>
+        <version>0.36.0</version>
         <configuration>
           <images>
             <image>
@@ -202,9 +204,9 @@
       </plugin>
 
       <plugin>
-        <groupId>com.lightbend</groupId>
-        <artifactId>akkasls-maven-plugin</artifactId>
-        <version>0.30.0</version>
+        <groupId>com.akkaserverless</groupId>
+        <artifactId>akkaserverless-maven-plugin</artifactId>
+        <version>${akkaserverless-sdk.version}</version>
         <executions>
           <execution>
             <goals>
@@ -297,27 +299,17 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>lightbend-akkaserverless</id>
-      <name>repo-lightbend-com-akkaserverless</name>
-      <url>https://repo.lightbend.com/lightbend/akkaserverless/</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>lightbend-akkaserverless</id>
-      <name>repo-lightbend-com-akkaserverless</name>
-      <url>https://repo.lightbend.com/lightbend/akkaserverless/</url>
-    </pluginRepository>
-  </pluginRepositories>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.typesafe.akka</groupId>
+        <artifactId>akka-bom_${scala.binary.version}</artifactId>
+        <version>${akka-streams.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -341,6 +333,10 @@
       <groupId>ch.qos.logback.contrib</groupId>
       <artifactId>logback-jackson</artifactId>
       <version>0.1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-stream_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
       <groupId>com.akkaserverless</groupId>

--- a/docs/src/modules/java/examples/archetype/first-service/src/it/java/com/example/domain/CounterIntegrationTest.java
+++ b/docs/src/modules/java/examples/archetype/first-service/src/it/java/com/example/domain/CounterIntegrationTest.java
@@ -1,3 +1,8 @@
+/* This code was initialised by Akka Serverless tooling.
+ * As long as this file exists it will not be re-generated.
+ * You are free to make changes to this file.
+ */
+
 package com.example.domain;
 
 import com.example.Main;
@@ -9,7 +14,7 @@ import org.junit.Test;
 import static java.util.concurrent.TimeUnit.*;
 
 // Example of an integration test calling our service via the Akka Serverless proxy
-// Run all test classes ending with "IntegrationTest" using `mvn verify -Pfailsafe`
+// Run all test classes ending with "IntegrationTest" using `mvn verify -Pit`
 public class CounterIntegrationTest {
     
     /**

--- a/docs/src/modules/java/examples/archetype/first-service/src/main/java/com/example/Main.java
+++ b/docs/src/modules/java/examples/archetype/first-service/src/main/java/com/example/Main.java
@@ -1,3 +1,8 @@
+/* This code was initialised by Akka Serverless tooling.
+ * As long as this file exists it will not be re-generated.
+ * You are free to make changes to this file.
+ */
+
 package com.example;
 
 import com.akkaserverless.javasdk.AkkaServerless;
@@ -11,10 +16,13 @@ public final class Main {
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
     
     public static final AkkaServerless SERVICE =
-            withGeneratedComponentsAdded(new AkkaServerless());
+        // This withGeneratedComponentsAdded wrapper automatically registers any generated Actions, Views or Entities,
+        // and is kept up-to-date with any changes in your protobuf definitions.
+        // If you prefer, you may remove this wrapper and manually register these components.
+        withGeneratedComponentsAdded(new AkkaServerless());
     
     public static void main(String[] args) throws Exception {
         LOG.info("starting the Akka Serverless service");
-        SERVICE.start().toCompletableFuture().get();
+        SERVICE.start();
     }
 }

--- a/docs/src/modules/java/examples/archetype/first-service/src/main/java/com/example/domain/Counter.java
+++ b/docs/src/modules/java/examples/archetype/first-service/src/main/java/com/example/domain/Counter.java
@@ -1,13 +1,19 @@
+/* This code was initialised by Akka Serverless tooling.
+ * As long as this file exists it will not be re-generated.
+ * You are free to make changes to this file.
+ */
+
 package com.example.domain;
 
 import com.akkaserverless.javasdk.EntityId;
+import com.akkaserverless.javasdk.Reply;
 import com.akkaserverless.javasdk.valueentity.*;
 import com.example.CounterApi;
 import com.google.protobuf.Empty;
 
 /** A value entity. */
 @ValueEntity(entityType = "counter")
-public class Counter extends CounterInterface {
+public class Counter extends AbstractCounter {
     @SuppressWarnings("unused")
     private final String entityId;
     
@@ -16,22 +22,22 @@ public class Counter extends CounterInterface {
     }
     
     @Override
-    protected Empty increase(CounterApi.IncreaseValue command, CommandContext<CounterDomain.CounterState> ctx) {
-        throw ctx.fail("The command handler for `Increase` is not implemented, yet");
+    public Reply<Empty> increase(CounterApi.IncreaseValue command, CommandContext<CounterDomain.CounterState> context) {
+        return Reply.failure("The command handler for `Increase` is not implemented, yet");
     }
     
     @Override
-    protected Empty decrease(CounterApi.DecreaseValue command, CommandContext<CounterDomain.CounterState> ctx) {
-        throw ctx.fail("The command handler for `Decrease` is not implemented, yet");
+    public Reply<Empty> decrease(CounterApi.DecreaseValue command, CommandContext<CounterDomain.CounterState> context) {
+        return Reply.failure("The command handler for `Decrease` is not implemented, yet");
     }
     
     @Override
-    protected Empty reset(CounterApi.ResetValue command, CommandContext<CounterDomain.CounterState> ctx) {
-        throw ctx.fail("The command handler for `Reset` is not implemented, yet");
+    public Reply<Empty> reset(CounterApi.ResetValue command, CommandContext<CounterDomain.CounterState> context) {
+        return Reply.failure("The command handler for `Reset` is not implemented, yet");
     }
     
     @Override
-    protected CounterApi.CurrentCounter getCurrentCounter(CounterApi.GetCounter command, CommandContext<CounterDomain.CounterState> ctx) {
-        throw ctx.fail("The command handler for `GetCurrentCounter` is not implemented, yet");
+    public Reply<CounterApi.CurrentCounter> getCurrentCounter(CounterApi.GetCounter command, CommandContext<CounterDomain.CounterState> context) {
+        return Reply.failure("The command handler for `GetCurrentCounter` is not implemented, yet");
     }
 }

--- a/docs/src/modules/java/examples/archetype/first-service/src/test/java/com/example/domain/CounterTest.java
+++ b/docs/src/modules/java/examples/archetype/first-service/src/test/java/com/example/domain/CounterTest.java
@@ -1,3 +1,8 @@
+/* This code was initialised by Akka Serverless tooling.
+ * As long as this file exists it will not be re-generated.
+ * You are free to make changes to this file.
+ */
+
 package com.example.domain;
 
 import com.akkaserverless.javasdk.valueentity.CommandContext;
@@ -13,57 +18,55 @@ public class CounterTest {
     private Counter entity;
     private CommandContext<CounterDomain.CounterState> context = Mockito.mock(CommandContext.class);
     
-    private class MockedContextFailure extends RuntimeException {};
-    
     @Test
     public void increaseTest() {
         entity = new Counter(entityId);
         
-        Mockito.when(context.fail("The command handler for `Increase` is not implemented, yet"))
-            .thenReturn(new MockedContextFailure());
+        // TODO: write your mock here
+        // Mockito.when(context.[...]).thenReturn([...]);
         
-        // TODO: set fields in command, and update assertions to match implementation
-        assertThrows(MockedContextFailure.class, () -> {
-            entity.increaseWithReply(CounterApi.IncreaseValue.newBuilder().build(), context);
-        });
+        // TODO: set fields in command, and update assertions to verify implementation
+        // assertEquals([expected],
+        //    entity.increase(CounterApi.IncreaseValue.newBuilder().build(), context);
+        // );
     }
     
     @Test
     public void decreaseTest() {
         entity = new Counter(entityId);
         
-        Mockito.when(context.fail("The command handler for `Decrease` is not implemented, yet"))
-            .thenReturn(new MockedContextFailure());
+        // TODO: write your mock here
+        // Mockito.when(context.[...]).thenReturn([...]);
         
-        // TODO: set fields in command, and update assertions to match implementation
-        assertThrows(MockedContextFailure.class, () -> {
-            entity.decreaseWithReply(CounterApi.DecreaseValue.newBuilder().build(), context);
-        });
+        // TODO: set fields in command, and update assertions to verify implementation
+        // assertEquals([expected],
+        //    entity.decrease(CounterApi.DecreaseValue.newBuilder().build(), context);
+        // );
     }
     
     @Test
     public void resetTest() {
         entity = new Counter(entityId);
         
-        Mockito.when(context.fail("The command handler for `Reset` is not implemented, yet"))
-            .thenReturn(new MockedContextFailure());
+        // TODO: write your mock here
+        // Mockito.when(context.[...]).thenReturn([...]);
         
-        // TODO: set fields in command, and update assertions to match implementation
-        assertThrows(MockedContextFailure.class, () -> {
-            entity.resetWithReply(CounterApi.ResetValue.newBuilder().build(), context);
-        });
+        // TODO: set fields in command, and update assertions to verify implementation
+        // assertEquals([expected],
+        //    entity.reset(CounterApi.ResetValue.newBuilder().build(), context);
+        // );
     }
     
     @Test
     public void getCurrentCounterTest() {
         entity = new Counter(entityId);
         
-        Mockito.when(context.fail("The command handler for `GetCurrentCounter` is not implemented, yet"))
-            .thenReturn(new MockedContextFailure());
+        // TODO: write your mock here
+        // Mockito.when(context.[...]).thenReturn([...]);
         
-        // TODO: set fields in command, and update assertions to match implementation
-        assertThrows(MockedContextFailure.class, () -> {
-            entity.getCurrentCounterWithReply(CounterApi.GetCounter.newBuilder().build(), context);
-        });
+        // TODO: set fields in command, and update assertions to verify implementation
+        // assertEquals([expected],
+        //    entity.getCurrentCounter(CounterApi.GetCounter.newBuilder().build(), context);
+        // );
     }
 }


### PR DESCRIPTION
This updates the Maven archetype generated sources to the current state of the Java SDK.
(They are currently out of sync as we improved codegen to consistently use the `Reply` type.)
