### PR TITLE
Add required update effect for replicated entities

### DIFF
--- a/samples/replicatedentity-counter/src/main/java/com/example/counter/domain/AbstractCounter.java
+++ b/samples/replicatedentity-counter/src/main/java/com/example/counter/domain/AbstractCounter.java
@@ -2,12 +2,12 @@
 
 package com.example.counter.domain;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedEntity;
+import com.akkaserverless.javasdk.replicatedentity.ReplicatedCounterEntity;
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedCounter;
 import com.example.counter.CounterApi;
 import com.google.protobuf.Empty;
 
-public abstract class AbstractCounter extends ReplicatedEntity<ReplicatedCounter> {
+public abstract class AbstractCounter extends ReplicatedCounterEntity {
 
   public abstract Effect<Empty> increase(ReplicatedCounter currentData, CounterApi.IncreaseValue command);
 

--- a/samples/replicatedentity-counter/src/main/java/com/example/counter/domain/Counter.java
+++ b/samples/replicatedentity-counter/src/main/java/com/example/counter/domain/Counter.java
@@ -13,11 +13,6 @@ public class Counter extends AbstractCounter {
   }
 
   @Override
-  public ReplicatedCounter emptyData(ReplicatedDataFactory factory) {
-    return factory.newCounter();
-  }
-
-  @Override
   public Effect<Empty> increase(ReplicatedCounter counter, CounterApi.IncreaseValue command) {
     if (command.getValue() < 0) {
       return effects().error("Increase requires a positive value. It was [" + command.getValue() + "].");
@@ -25,7 +20,7 @@ public class Counter extends AbstractCounter {
 
     counter.increment(command.getValue());
 
-    return effects().reply(Empty.getDefaultInstance());
+    return effects().update(counter).thenReply(Empty.getDefaultInstance());
   }
 
   @Override
@@ -36,7 +31,7 @@ public class Counter extends AbstractCounter {
 
     counter.decrement(command.getValue());
 
-    return effects().reply(Empty.getDefaultInstance());
+    return effects().update(counter).thenReply(Empty.getDefaultInstance());
   }
 
   @Override

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedCounterEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedCounterEntity.java
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-package com.akkaserverless.javasdk.impl.replicatedentity
+package com.akkaserverless.javasdk.replicatedentity;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedData
-import com.akkaserverless.protocol.replicated_entity.ReplicatedEntityDelta
-
-private[replicatedentity] trait InternalReplicatedData extends ReplicatedData {
-  def name: String
-  def copy(): InternalReplicatedData
-  def hasDelta: Boolean
-  def delta: ReplicatedEntityDelta.Delta
-  def resetDelta(): Unit
-  def applyDelta: PartialFunction[ReplicatedEntityDelta.Delta, Unit]
+public class ReplicatedCounterEntity extends ReplicatedEntity<ReplicatedCounter> {
+  @Override
+  public ReplicatedCounter emptyData(ReplicatedDataFactory factory) {
+    return factory.newCounter();
+  }
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedCounterMapEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedCounterMapEntity.java
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-package com.akkaserverless.javasdk.impl.replicatedentity
+package com.akkaserverless.javasdk.replicatedentity;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedData
-import com.akkaserverless.protocol.replicated_entity.ReplicatedEntityDelta
-
-private[replicatedentity] trait InternalReplicatedData extends ReplicatedData {
-  def name: String
-  def copy(): InternalReplicatedData
-  def hasDelta: Boolean
-  def delta: ReplicatedEntityDelta.Delta
-  def resetDelta(): Unit
-  def applyDelta: PartialFunction[ReplicatedEntityDelta.Delta, Unit]
+public class ReplicatedCounterMapEntity<K> extends ReplicatedEntity<ReplicatedCounterMap<K>> {
+  @Override
+  public ReplicatedCounterMap<K> emptyData(ReplicatedDataFactory factory) {
+    return factory.newReplicatedCounterMap();
+  }
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedDataFactory.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedDataFactory.java
@@ -50,5 +50,5 @@ public interface ReplicatedDataFactory {
   <K, V extends ReplicatedData> ReplicatedMap<K, V> newReplicatedMap();
 
   /** Create a new Vote. */
-  Vote newVote();
+  ReplicatedVote newVote();
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedEntity.java
@@ -57,8 +57,8 @@ public abstract class ReplicatedEntity<D extends ReplicatedData> {
     commandContext = context;
   }
 
-  protected Effect.Builder effects() {
-    return new ReplicatedEntityEffectImpl<>();
+  protected <R> Effect.Builder<D> effects() {
+    return new ReplicatedEntityEffectImpl<D, R>();
   }
 
   /**
@@ -71,8 +71,13 @@ public abstract class ReplicatedEntity<D extends ReplicatedData> {
     /**
      * Construct the effect that is returned by the command handler. The effect describes next
      * processing actions, such as sending a reply or deleting an entity.
+     *
+     * @param <D> The replicated data type for this entity.
      */
-    interface Builder {
+    interface Builder<D> {
+
+      /** Update the underlying replicated data for the replicated entity. */
+      OnSuccessBuilder update(D newData);
 
       /**
        * Delete the replicated entity.

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedMapEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedMapEntity.java
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-package com.akkaserverless.javasdk.impl.replicatedentity
+package com.akkaserverless.javasdk.replicatedentity;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedData
-import com.akkaserverless.protocol.replicated_entity.ReplicatedEntityDelta
-
-private[replicatedentity] trait InternalReplicatedData extends ReplicatedData {
-  def name: String
-  def copy(): InternalReplicatedData
-  def hasDelta: Boolean
-  def delta: ReplicatedEntityDelta.Delta
-  def resetDelta(): Unit
-  def applyDelta: PartialFunction[ReplicatedEntityDelta.Delta, Unit]
+public class ReplicatedMapEntity<K, V extends ReplicatedData>
+    extends ReplicatedEntity<ReplicatedMap<K, V>> {
+  @Override
+  public ReplicatedMap<K, V> emptyData(ReplicatedDataFactory factory) {
+    return factory.newReplicatedMap();
+  }
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedMultiMapEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedMultiMapEntity.java
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-package com.akkaserverless.javasdk.impl.replicatedentity
+package com.akkaserverless.javasdk.replicatedentity;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedData
-import com.akkaserverless.protocol.replicated_entity.ReplicatedEntityDelta
-
-private[replicatedentity] trait InternalReplicatedData extends ReplicatedData {
-  def name: String
-  def copy(): InternalReplicatedData
-  def hasDelta: Boolean
-  def delta: ReplicatedEntityDelta.Delta
-  def resetDelta(): Unit
-  def applyDelta: PartialFunction[ReplicatedEntityDelta.Delta, Unit]
+public class ReplicatedMultiMapEntity<K, V> extends ReplicatedEntity<ReplicatedMultiMap<K, V>> {
+  @Override
+  public ReplicatedMultiMap<K, V> emptyData(ReplicatedDataFactory factory) {
+    return factory.newReplicatedMultiMap();
+  }
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedRegisterEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedRegisterEntity.java
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package com.akkaserverless.javasdk.impl.replicatedentity
+package com.akkaserverless.javasdk.replicatedentity;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedData
-import com.akkaserverless.protocol.replicated_entity.ReplicatedEntityDelta
+public abstract class ReplicatedRegisterEntity<T> extends ReplicatedEntity<ReplicatedRegister<T>> {
+  /**
+   * Implement to set the default empty value for the register.
+   *
+   * @return the default empty value
+   */
+  public abstract T emptyValue();
 
-private[replicatedentity] trait InternalReplicatedData extends ReplicatedData {
-  def name: String
-  def copy(): InternalReplicatedData
-  def hasDelta: Boolean
-  def delta: ReplicatedEntityDelta.Delta
-  def resetDelta(): Unit
-  def applyDelta: PartialFunction[ReplicatedEntityDelta.Delta, Unit]
+  @Override
+  public ReplicatedRegister<T> emptyData(ReplicatedDataFactory factory) {
+    return factory.newRegister(emptyValue());
+  }
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedRegisterMapEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedRegisterMapEntity.java
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-package com.akkaserverless.javasdk.impl.replicatedentity
+package com.akkaserverless.javasdk.replicatedentity;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedData
-import com.akkaserverless.protocol.replicated_entity.ReplicatedEntityDelta
-
-private[replicatedentity] trait InternalReplicatedData extends ReplicatedData {
-  def name: String
-  def copy(): InternalReplicatedData
-  def hasDelta: Boolean
-  def delta: ReplicatedEntityDelta.Delta
-  def resetDelta(): Unit
-  def applyDelta: PartialFunction[ReplicatedEntityDelta.Delta, Unit]
+public class ReplicatedRegisterMapEntity<K, V>
+    extends ReplicatedEntity<ReplicatedRegisterMap<K, V>> {
+  @Override
+  public ReplicatedRegisterMap<K, V> emptyData(ReplicatedDataFactory factory) {
+    return factory.newReplicatedRegisterMap();
+  }
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedSetEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedSetEntity.java
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-package com.akkaserverless.javasdk.impl.replicatedentity
+package com.akkaserverless.javasdk.replicatedentity;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedData
-import com.akkaserverless.protocol.replicated_entity.ReplicatedEntityDelta
-
-private[replicatedentity] trait InternalReplicatedData extends ReplicatedData {
-  def name: String
-  def copy(): InternalReplicatedData
-  def hasDelta: Boolean
-  def delta: ReplicatedEntityDelta.Delta
-  def resetDelta(): Unit
-  def applyDelta: PartialFunction[ReplicatedEntityDelta.Delta, Unit]
+public class ReplicatedSetEntity<T> extends ReplicatedEntity<ReplicatedSet<T>> {
+  @Override
+  public ReplicatedSet<T> emptyData(ReplicatedDataFactory factory) {
+    return factory.newReplicatedSet();
+  }
 }

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedVote.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedVote.java
@@ -21,7 +21,7 @@ package com.akkaserverless.javasdk.replicatedentity;
  *
  * <p>This replicated data type is used to allow all the nodes in a cluster to vote on a condition.
  */
-public interface Vote extends ReplicatedData {
+public interface ReplicatedVote extends ReplicatedData {
   /**
    * Get the current value for this nodes vote.
    *

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedVoteEntity.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedVoteEntity.java
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-package com.akkaserverless.javasdk.impl.replicatedentity
+package com.akkaserverless.javasdk.replicatedentity;
 
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedData
-import com.akkaserverless.protocol.replicated_entity.ReplicatedEntityDelta
-
-private[replicatedentity] trait InternalReplicatedData extends ReplicatedData {
-  def name: String
-  def copy(): InternalReplicatedData
-  def hasDelta: Boolean
-  def delta: ReplicatedEntityDelta.Delta
-  def resetDelta(): Unit
-  def applyDelta: PartialFunction[ReplicatedEntityDelta.Delta, Unit]
+public class ReplicatedVoteEntity extends ReplicatedEntity<ReplicatedVote> {
+  @Override
+  public ReplicatedVote emptyData(ReplicatedDataFactory factory) {
+    return factory.newVote();
+  }
 }

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/Contexts.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/Contexts.scala
@@ -17,14 +17,9 @@
 package com.akkaserverless.javasdk.impl
 
 import com.akkaserverless.javasdk.Context
-import scala.util.control.NoStackTrace
 
 private[impl] trait ActivatableContext extends Context {
   private final var active = true
   final def deactivate(): Unit = active = false
   final def checkActive(): Unit = if (!active) throw new IllegalStateException("Context no longer active!")
-}
-
-object FailInvoked extends RuntimeException with NoStackTrace {
-  override def toString: String = "CommandContext.fail(…) invoked"
 }

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/eventsourcedentity/EventSourcedEntitiesImpl.scala
@@ -187,7 +187,6 @@ final class EventSourcedEntitiesImpl(system: ActorSystem,
                                            service.snapshotEvery,
                                            seqNr => new EventContextImpl(thisEntityId, seqNr))
           } catch {
-            case FailInvoked => new EventSourcedEntityEffectImpl[JavaPbAny]() // Ignore, error already captured
             case e: EntityException => throw e
             case NonFatal(error) =>
               throw EntityException(command, s"Unexpected failure: $error", Some(error))

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedCounterImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedCounterImpl.scala
@@ -19,9 +19,12 @@ package com.akkaserverless.javasdk.impl.replicatedentity
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedCounter
 import com.akkaserverless.protocol.replicated_entity.{ReplicatedCounterDelta, ReplicatedEntityDelta}
 
-private[replicatedentity] final class ReplicatedCounterImpl extends InternalReplicatedData with ReplicatedCounter {
+private[replicatedentity] final class ReplicatedCounterImpl(_value: Long = 0)
+    extends ReplicatedCounter
+    with InternalReplicatedData {
+
   override final val name = "ReplicatedCounter"
-  private var value: Long = 0
+  private var value: Long = _value
   private var deltaValue: Long = 0
 
   override def getValue: Long = value
@@ -33,6 +36,8 @@ private[replicatedentity] final class ReplicatedCounterImpl extends InternalRepl
   }
 
   override def decrement(by: Long): Long = increment(-by)
+
+  override def copy(): ReplicatedCounterImpl = new ReplicatedCounterImpl(value)
 
   override def hasDelta: Boolean = deltaValue != 0
 

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedDataFactoryImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedDataFactoryImpl.scala
@@ -55,5 +55,5 @@ final class ReplicatedDataFactoryImpl(anySupport: AnySupport) extends Replicated
   override def newReplicatedMap[K, V <: ReplicatedData](): ReplicatedMap[K, V] =
     newData(new ReplicatedMapImpl[K, InternalReplicatedData](anySupport)).asInstanceOf[ReplicatedMap[K, V]]
 
-  override def newVote(): Vote = newData(new VoteImpl)
+  override def newVote(): ReplicatedVote = newData(new ReplicatedVoteImpl)
 }

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedEntityDeltaTransformer.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedEntityDeltaTransformer.scala
@@ -38,7 +38,7 @@ private[replicatedentity] object ReplicatedEntityDeltaTransformer {
       case ReplicatedEntityDelta.Delta.ReplicatedMultiMap(_) =>
         new ReplicatedMultiMapImpl[Any, Any](anySupport)
       case ReplicatedEntityDelta.Delta.Vote(_) =>
-        new VoteImpl
+        new ReplicatedVoteImpl
       case _ =>
         throw new RuntimeException(s"Received unexpected replicated entity delta: ${delta.delta}")
     }

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedRegisterImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedRegisterImpl.scala
@@ -27,11 +27,14 @@ import java.util.Objects
 
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedRegister
 
-private[replicatedentity] final class ReplicatedRegisterImpl[T](anySupport: AnySupport)
-    extends InternalReplicatedData
-    with ReplicatedRegister[T] {
+private[replicatedentity] final class ReplicatedRegisterImpl[T](
+    anySupport: AnySupport,
+    _value: T = null.asInstanceOf[T]
+) extends ReplicatedRegister[T]
+    with InternalReplicatedData {
+
   override final val name = "ReplicatedRegister"
-  private var value: T = _
+  private var value: T = _value
   private var deltaValue: Option[ScalaPbAny] = None
   private var clock: ReplicatedRegister.Clock = ReplicatedRegister.Clock.DEFAULT
   private var customClockValue: Long = 0
@@ -49,6 +52,8 @@ private[replicatedentity] final class ReplicatedRegisterImpl[T](anySupport: AnyS
   }
 
   override def get(): T = value
+
+  override def copy(): ReplicatedRegisterImpl[T] = new ReplicatedRegisterImpl(anySupport, value)
 
   override def hasDelta: Boolean = deltaValue.isDefined
 

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedRegisterMapImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedRegisterMapImpl.scala
@@ -29,13 +29,15 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
 
-private[replicatedentity] final class ReplicatedRegisterMapImpl[K, V](anySupport: AnySupport)
-    extends ReplicatedRegisterMap[K, V]
+private[replicatedentity] final class ReplicatedRegisterMapImpl[K, V](
+    anySupport: AnySupport,
+    _registers: mutable.Map[K, ReplicatedRegisterImpl[V]] = mutable.Map.empty[K, ReplicatedRegisterImpl[V]]
+) extends ReplicatedRegisterMap[K, V]
     with InternalReplicatedData {
 
   override val name = "ReplicatedRegisterMap"
 
-  private val registers = mutable.Map.empty[K, ReplicatedRegisterImpl[V]]
+  private val registers = _registers
   private val removed = mutable.Set.empty[K]
   private var cleared = false
 
@@ -65,6 +67,11 @@ private[replicatedentity] final class ReplicatedRegisterMapImpl[K, V](anySupport
     registers.clear()
     removed.clear()
   }
+
+  override def copy(): ReplicatedRegisterMapImpl[K, V] =
+    new ReplicatedRegisterMapImpl(anySupport, registers.map {
+      case (key, register) => key -> register.copy()
+    })
 
   override def hasDelta: Boolean = cleared || removed.nonEmpty || registers.values.exists(_.hasDelta)
 

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedSetImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedSetImpl.scala
@@ -25,12 +25,15 @@ import scala.jdk.CollectionConverters._
 
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedSet
 
-private[replicatedentity] class ReplicatedSetImpl[T](anySupport: AnySupport)
-    extends util.AbstractSet[T]
-    with InternalReplicatedData
-    with ReplicatedSet[T] {
+private[replicatedentity] class ReplicatedSetImpl[T](
+    anySupport: AnySupport,
+    _value: util.HashSet[T] = new util.HashSet[T]()
+) extends util.AbstractSet[T]
+    with ReplicatedSet[T]
+    with InternalReplicatedData {
+
   override final val name = "ReplicatedSet"
-  private val value = new util.HashSet[T]()
+  private val value = _value
   private val added = new util.HashSet[ScalaPbAny]()
   private val removed = new util.HashSet[ScalaPbAny]()
   private var cleared = false
@@ -103,6 +106,8 @@ private[replicatedentity] class ReplicatedSetImpl[T](anySupport: AnySupport)
     removed.clear()
     added.clear()
   }
+
+  override def copy(): ReplicatedSetImpl[T] = new ReplicatedSetImpl(anySupport, new util.HashSet(value))
 
   override def hasDelta: Boolean = cleared || !added.isEmpty || !removed.isEmpty
 

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedVoteImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/replicatedentity/ReplicatedVoteImpl.scala
@@ -16,14 +16,20 @@
 
 package com.akkaserverless.javasdk.impl.replicatedentity
 
-import com.akkaserverless.javasdk.replicatedentity.Vote
+import com.akkaserverless.javasdk.replicatedentity.ReplicatedVote
 import com.akkaserverless.protocol.replicated_entity.{ReplicatedEntityDelta, VoteDelta}
 
-private[replicatedentity] final class VoteImpl extends InternalReplicatedData with Vote {
+private[replicatedentity] final class ReplicatedVoteImpl(
+    _selfVote: Boolean = false,
+    _voters: Int = 1,
+    _votesFor: Int = 0
+) extends ReplicatedVote
+    with InternalReplicatedData {
+
   override final val name = "Vote"
-  private var selfVote = false
-  private var voters = 1
-  private var votesFor = 0
+  private var selfVote = _selfVote
+  private var voters = _voters
+  private var votesFor = _votesFor
   private var selfVoteChanged = false
 
   override def getSelfVote: Boolean = selfVote
@@ -46,6 +52,8 @@ private[replicatedentity] final class VoteImpl extends InternalReplicatedData wi
         votesFor -= 1
       }
     }
+
+  override def copy(): ReplicatedVoteImpl = new ReplicatedVoteImpl(selfVote, voters, votesFor)
 
   override def hasDelta: Boolean = selfVoteChanged
 

--- a/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntitiesImpl.scala
+++ b/sdk/src/main/scala/com/akkaserverless/javasdk/impl/valueentity/ValueEntitiesImpl.scala
@@ -157,7 +157,6 @@ final class ValueEntitiesImpl(system: ActorSystem,
           val CommandResult(effect: ValueEntityEffectImpl[_]) = try {
             handler._internalHandleCommand(command.name, cmd, context)
           } catch {
-            case FailInvoked => new ValueEntityEffectImpl[JavaPbAny]() // Ignore, error already captured
             case e: EntityException => throw e
             case NonFatal(error) =>
               throw EntityException(command, s"Unexpected failure: $error", Some(error))

--- a/sdk/src/test/java/com/akkaserverless/javasdk/replicatedentity/AbstractCartEntity.java
+++ b/sdk/src/test/java/com/akkaserverless/javasdk/replicatedentity/AbstractCartEntity.java
@@ -21,7 +21,7 @@ import com.example.replicatedentity.shoppingcart.domain.ShoppingCartDomain;
 import com.google.protobuf.Empty;
 
 public abstract class AbstractCartEntity
-    extends ReplicatedEntity<ReplicatedRegisterMap<String, ShoppingCartDomain.LineItem>> {
+    extends ReplicatedRegisterMapEntity<String, ShoppingCartDomain.LineItem> {
 
   public abstract Effect<Empty> addItem(
       ReplicatedRegisterMap<String, ShoppingCartDomain.LineItem> currentData,

--- a/sdk/src/test/java/com/akkaserverless/javasdk/replicatedentity/CartEntity.java
+++ b/sdk/src/test/java/com/akkaserverless/javasdk/replicatedentity/CartEntity.java
@@ -34,21 +34,15 @@ public class CartEntity extends AbstractCartEntity {
   }
 
   @Override
-  public ReplicatedRegisterMap<String, ShoppingCartDomain.LineItem> emptyData(
-      ReplicatedDataFactory factory) {
-    return factory.newReplicatedRegisterMap();
-  }
-
-  @Override
   public Effect<Empty> addItem(
-      ReplicatedRegisterMap<String, ShoppingCartDomain.LineItem> currentData,
+      ReplicatedRegisterMap<String, ShoppingCartDomain.LineItem> cart,
       ShoppingCartApi.AddLineItem addLineItem) {
     if (addLineItem.getQuantity() <= 0) {
       return effects().error("Cannot add negative quantity to item " + addLineItem.getProductId());
     }
 
-    currentData.setValue(addLineItem.getProductId(), updateItem(addLineItem, currentData));
-    return effects().reply(Empty.getDefaultInstance());
+    cart.setValue(addLineItem.getProductId(), updateItem(addLineItem, cart));
+    return effects().update(cart).thenReply(Empty.getDefaultInstance());
   }
 
   @Override


### PR DESCRIPTION
This is an in-between step for #83. Adds a required `update` effect for replicated entities, but keeps the current mutable APIs for replicated data. It does this by making a (deep) copy of the replicated data before passing to the handler method, so that the entity is only updated when `effects().update(data)` is used, otherwise it will still have the old data without changes.

It's probably a little awkward mixing approaches, but it's simpler than converting the data structures to immutable straight away, and sets things up so that could be done next — or add the data-type-specific effects under the specialised entity classes, with the underlying replicated data as mutable but the user-facing interface as read-only. And other than the TCK, there's no test coverage for the replicated data structures themselves.