### PR TITLE
Generated integration test independent of impl existence

### DIFF
--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
@@ -139,6 +139,9 @@ class SourceGeneratorSuite extends munit.FunSuite {
                 generatedTestSourceDirectory.resolve(
                   "com/example/service/domain/MyEntity1TestKit.java"
                 ),
+                integrationTestSourceDirectory.resolve(
+                  "com/example/service/domain/MyEntity1IntegrationTest.java"
+                ),
                 sourceDirectory.resolve("com/example/service/domain/MyValueEntity2.java"),
                 generatedSourceDirectory.resolve(
                   "com/example/service/domain/AbstractMyValueEntity2.java"


### PR DESCRIPTION
Integration test was only generated the very first time, when the entity impl file doesn't exist. Only look for existence of the integration test file instead.

Useful for example when regenerating the integration test (rename old file and generate new).