### PR TITLE
events should indicate by how much we increase or decrease

### DIFF
--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/counter_domain.proto
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/counter_domain.proto
@@ -19,10 +19,12 @@ message CounterState {
 
 message ValueIncreased {
     string counter_id = 1 [(akkaserverless.field).entity_key = true];
+    int32 value = 2;
 }
 
 message ValueDecreased {
     string counter_id = 1 [(akkaserverless.field).entity_key = true];
+    int32 value = 2;
 }
 
 message ValueReset {

--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/counter_domain.proto
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/counter_domain.proto
@@ -18,15 +18,12 @@ message CounterState {
 }
 
 message ValueIncreased {
-    string counter_id = 1 [(akkaserverless.field).entity_key = true];
-    int32 value = 2;
+    int32 value = 1;
 }
 
 message ValueDecreased {
-    string counter_id = 1 [(akkaserverless.field).entity_key = true];
-    int32 value = 2;
+    int32 value = 1;
 }
 
 message ValueReset {
-    string counter_id = 1 [(akkaserverless.field).entity_key = true];
 }


### PR DESCRIPTION
The events sourced archetype has commands for increase and decrease a counter with a value field meaning that we could increase by 2, 3, etc. 

The events on the other hand, doesn't not hold any value as if we should only increase/decrease by one. 

