### PR TITLE
chore(docs): update makefile with latest Java SDK version

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,7 +35,7 @@ attributes:
 		>> "${managed_partials}/attributes.adoc"
 	echo ":recommended-java-version: 11" \
 		>> "${managed_partials}/attributes.adoc"
-	echo ":java_minimum_sdk_version: 0.7.0-beta.19" \
+	echo ":java_minimum_sdk_version: 0.7.0" \
 		>> "${managed_partials}/attributes.adoc"
 
 apidocs:


### PR DESCRIPTION
The minimum supported version should come from the SDK itself, not from the main docs repo. Updating this parameter so we can remove the parameter from the main docs repo.