### PR TITLE
Correct the mention of Cloudstate in the Akka Serverless SDK

### DIFF
--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/ModelBuilder.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/ModelBuilder.scala
@@ -220,7 +220,7 @@ object ModelBuilder {
   case class State(fqn: FullyQualifiedName)
 
   /**
-   * Given a protobuf descriptor, discover the Cloudstate entities and their properties.
+   * Given a protobuf descriptor, discover the Akka Serverless entities and their properties.
    *
    * Impure.
    *


### PR DESCRIPTION
Replace the mention of the old project with the new name.