### PR TITLE
Add specialised accessors for replicated map

### DIFF
--- a/docs/src/modules/java/pages/replicated-entity.adoc
+++ b/docs/src/modules/java/pages/replicated-entity.adoc
@@ -423,9 +423,11 @@ include::example$replicatedentity-examples/src/main/proto/replicated/map_domain.
 <1> Specify the Replicated Data type as a Replicated Map.
 <2> Specify the `protobuf` message type for the keys of the map.
 
-NOTE: The value type for a Replicated Map is not specified for code-generation, and will be set to `ReplicatedData` for a heterogeneous map.
+NOTE: The value type for a Replicated Map is not specified for code-generation, and will be set to `ReplicatedData` for a heterogeneous map (a Replicated Map that contains different types of Replicated Data values).
 
 When implementing a Replicated Map entity, the replicated data for an entry can be updated by retrieving the data value using the `get` or `getOrElse` methods, updating values using the `update` method, and then triggering an update effect with the modified Replicated Map. Entries can be removed from the map using the `remove` method.
+
+There are also accessors for each of the Replicated Data types to make a heterogeneous map easier to use, such as `getReplicatedCounter` or `getReplicatedRegister`. If a key is not present in the map, these will return an empty value for the associated Replicated Data type.
 
 [source,java,indent=0]
 .src/main/java/com/example/replicated/map/domain/SomeMap.java
@@ -433,7 +435,7 @@ When implementing a Replicated Map entity, the replicated data for an entry can 
 include::example$replicatedentity-examples/src/main/java/com/example/replicated/map/domain/SomeMap.java[tag=update]
 ----
 
-<1> Get the Replicated Data object for a key using `getOrCreate`, which also takes a function to create an empty value using a `ReplicatedDataFactory`.
+<1> Get the Replicated Data value for a key using an accessor method for the Replicated Data type.
 <2> Modify the Replicated Data value using its modifying methods and `update` on the Replicated Map.
 <3> Trigger a replicated update by returning an `Effect` with `effects().update`.
 
@@ -445,7 +447,7 @@ Individual Replicated Data objects in the Replicated Map can also be accessed fo
 include::example$replicatedentity-examples/src/main/java/com/example/replicated/map/domain/SomeMap.java[tag=get]
 ----
 
-<1> Get the Replicated Data object for a key using `getOrCreate`, which also takes a function to create an empty value using a `ReplicatedDataFactory`.
+<1> Get the Replicated Data value for a key using an accessor method for the Replicated Data type.
 
 NOTE: Entries may not contain the most up-to-date values when there are concurrent modifications.
 

--- a/samples/replicatedentity-examples/src/main/java/com/example/replicated/map/domain/SomeMap.java
+++ b/samples/replicatedentity-examples/src/main/java/com/example/replicated/map/domain/SomeMap.java
@@ -2,7 +2,6 @@ package com.example.replicated.map.domain;
 
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedCounter;
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedData;
-import com.akkaserverless.javasdk.replicatedentity.ReplicatedDataFactory;
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedEntityContext;
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedMap;
 import com.akkaserverless.javasdk.replicatedentity.ReplicatedRegister;
@@ -34,8 +33,7 @@ public class SomeMap extends AbstractSomeMap {
   public Effect<Empty> increaseFoo(
       ReplicatedMap<SomeMapDomain.SomeKey, ReplicatedData> map,
       SomeMapApi.IncreaseFooValue command) {
-    ReplicatedCounter foo = // <1>
-        (ReplicatedCounter) map.getOrElse(FOO_KEY, ReplicatedDataFactory::newCounter);
+    ReplicatedCounter foo = map.getReplicatedCounter(FOO_KEY); // <1>
     return effects()
         .update(map.update(FOO_KEY, foo.increment(command.getValue()))) // <2> <3>
         .thenReply(Empty.getDefaultInstance());
@@ -45,8 +43,7 @@ public class SomeMap extends AbstractSomeMap {
   public Effect<Empty> decreaseFoo(
       ReplicatedMap<SomeMapDomain.SomeKey, ReplicatedData> map,
       SomeMapApi.DecreaseFooValue command) {
-    ReplicatedCounter foo = // <1>
-        (ReplicatedCounter) map.getOrElse(FOO_KEY, ReplicatedDataFactory::newCounter);
+    ReplicatedCounter foo = map.getReplicatedCounter(FOO_KEY); // <1>
     return effects()
         .update(map.update(FOO_KEY, foo.decrement(command.getValue()))) // <2> <3>
         .thenReply(Empty.getDefaultInstance());
@@ -55,9 +52,7 @@ public class SomeMap extends AbstractSomeMap {
   @Override
   public Effect<Empty> setBar(
       ReplicatedMap<SomeMapDomain.SomeKey, ReplicatedData> map, SomeMapApi.SetBarValue command) {
-    @SuppressWarnings("unchecked")
-    ReplicatedRegister<String> bar = // <1>
-        (ReplicatedRegister<String>) map.getOrElse(BAR_KEY, factory -> factory.newRegister(""));
+    ReplicatedRegister<String> bar = map.getReplicatedRegister(BAR_KEY); // <1>
     return effects()
         .update(map.update(BAR_KEY, bar.set(command.getValue()))) // <2> <3>
         .thenReply(Empty.getDefaultInstance());
@@ -66,9 +61,7 @@ public class SomeMap extends AbstractSomeMap {
   @Override
   public Effect<Empty> addBaz(
       ReplicatedMap<SomeMapDomain.SomeKey, ReplicatedData> map, SomeMapApi.AddBazValue command) {
-    @SuppressWarnings("unchecked")
-    ReplicatedSet<String> baz = // <1>
-        (ReplicatedSet<String>) map.getOrElse(BAZ_KEY, ReplicatedDataFactory::newReplicatedSet);
+    ReplicatedSet<String> baz = map.getReplicatedSet(BAZ_KEY); // <1>
     return effects()
         .update(map.update(BAZ_KEY, baz.add(command.getValue()))) // <2> <3>
         .thenReply(Empty.getDefaultInstance());
@@ -77,9 +70,7 @@ public class SomeMap extends AbstractSomeMap {
   @Override
   public Effect<Empty> removeBaz(
       ReplicatedMap<SomeMapDomain.SomeKey, ReplicatedData> map, SomeMapApi.RemoveBazValue command) {
-    @SuppressWarnings("unchecked")
-    ReplicatedSet<String> baz = // <1>
-        (ReplicatedSet<String>) map.getOrElse(BAZ_KEY, ReplicatedDataFactory::newReplicatedSet);
+    ReplicatedSet<String> baz = map.getReplicatedSet(BAZ_KEY); // <1>
     return effects()
         .update(map.update(BAZ_KEY, baz.remove(command.getValue()))) // <2> <3>
         .thenReply(Empty.getDefaultInstance());
@@ -90,14 +81,9 @@ public class SomeMap extends AbstractSomeMap {
   @Override
   public Effect<SomeMapApi.CurrentValues> get(
       ReplicatedMap<SomeMapDomain.SomeKey, ReplicatedData> map, SomeMapApi.GetValues command) {
-    ReplicatedCounter foo = // <1>
-        (ReplicatedCounter) map.getOrElse(FOO_KEY, ReplicatedDataFactory::newCounter);
-    @SuppressWarnings("unchecked")
-    ReplicatedRegister<String> bar = // <1>
-        (ReplicatedRegister<String>) map.getOrElse(BAR_KEY, factory -> factory.newRegister(""));
-    @SuppressWarnings("unchecked")
-    ReplicatedSet<String> baz = // <1>
-        (ReplicatedSet<String>) map.getOrElse(BAZ_KEY, ReplicatedDataFactory::newReplicatedSet);
+    ReplicatedCounter foo = map.getReplicatedCounter(FOO_KEY); // <1>
+    ReplicatedRegister<String> bar = map.getReplicatedRegister(BAR_KEY, () -> ""); // <1>
+    ReplicatedSet<String> baz = map.getReplicatedSet(BAZ_KEY); // <1>
     SomeMapApi.CurrentValues currentValues =
         SomeMapApi.CurrentValues.newBuilder()
             .setFoo(foo.getValue())

--- a/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedMap.java
+++ b/sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedMap.java
@@ -19,6 +19,7 @@ package com.akkaserverless.javasdk.replicatedentity;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A Replicated Map that allows both the addition and removal of {@link ReplicatedData} objects.
@@ -132,4 +133,118 @@ public interface ReplicatedMap<K, V extends ReplicatedData> extends ReplicatedDa
    * @return the keys contained in this map
    */
   Set<K> keySet();
+
+  /**
+   * Get a {@link ReplicatedCounter} from a heterogeneous Replicated Map (a map with different types
+   * of Replicated Data values).
+   *
+   * @param key the key for a Replicated Counter in this map
+   * @return the {@link ReplicatedCounter} associated with the given key, or an empty counter
+   */
+  @SuppressWarnings("unchecked")
+  default ReplicatedCounter getReplicatedCounter(K key) {
+    return (ReplicatedCounter) getOrElse(key, factory -> (V) factory.newCounter());
+  }
+
+  /**
+   * Get a {@link ReplicatedRegister} from a heterogeneous Replicated Map (a map with different
+   * types of Replicated Data values).
+   *
+   * @param key the key for a Replicated Register in this map
+   * @return the {@link ReplicatedRegister} associated with the given key, or an empty register
+   * @param <ValueT> the value type for the Replicated Register
+   */
+  default <ValueT> ReplicatedRegister<ValueT> getReplicatedRegister(K key) {
+    return getReplicatedRegister(key, () -> null);
+  }
+
+  /**
+   * Get a {@link ReplicatedRegister} from a heterogeneous Replicated Map (a map with different
+   * types of Replicated Data values).
+   *
+   * @param key the key for a Replicated Register in this map
+   * @param defaultValue the supplier for a default value when the register is not present
+   * @return the {@link ReplicatedRegister} associated with the given key, or a default register
+   * @param <ValueT> the value type for the Replicated Register
+   */
+  @SuppressWarnings("unchecked")
+  default <ValueT> ReplicatedRegister<ValueT> getReplicatedRegister(
+      K key, Supplier<ValueT> defaultValue) {
+    return (ReplicatedRegister<ValueT>)
+        getOrElse(key, factory -> (V) factory.newRegister(defaultValue.get()));
+  }
+
+  /**
+   * Get a {@link ReplicatedSet} from a heterogeneous Replicated Map (a map with different types of
+   * Replicated Data values).
+   *
+   * @param key the key for a Replicated Set in this map
+   * @return the {@link ReplicatedSet} associated with the given key, or an empty set
+   * @param <ElementT> the element type for the Replicated Set
+   */
+  @SuppressWarnings("unchecked")
+  default <ElementT> ReplicatedSet<ElementT> getReplicatedSet(K key) {
+    return (ReplicatedSet<ElementT>)
+        getOrElse(key, factory -> (V) factory.<ElementT>newReplicatedSet());
+  }
+
+  /**
+   * Get a {@link ReplicatedCounterMap} from a heterogeneous Replicated Map (a map with different
+   * types of Replicated Data values).
+   *
+   * @param key the key for a Replicated Counter Map in this map
+   * @return the {@link ReplicatedCounterMap} associated with the given key, or an empty map
+   * @param <KeyT> the key type for the Replicated Counter Map
+   */
+  @SuppressWarnings("unchecked")
+  default <KeyT> ReplicatedCounterMap<KeyT> getReplicatedCounterMap(K key) {
+    return (ReplicatedCounterMap<KeyT>)
+        getOrElse(key, factory -> (V) factory.<KeyT>newReplicatedCounterMap());
+  }
+
+  /**
+   * Get a {@link ReplicatedRegisterMap} from a heterogeneous Replicated Map (a map with different
+   * types of Replicated Data values).
+   *
+   * @param key the key for a Replicated Register Map in this map
+   * @return the {@link ReplicatedRegisterMap} associated with the given key, or an empty map
+   * @param <KeyT> the key type for the Replicated Register Map
+   * @param <ValueT> the value type for the Replicated Register Map
+   */
+  @SuppressWarnings("unchecked")
+  default <KeyT, ValueT> ReplicatedRegisterMap<KeyT, ValueT> getReplicatedRegisterMap(K key) {
+    return (ReplicatedRegisterMap<KeyT, ValueT>)
+        getOrElse(key, factory -> (V) factory.<KeyT, ValueT>newReplicatedRegisterMap());
+  }
+
+  /**
+   * Get a {@link ReplicatedMultiMap} from a heterogeneous Replicated Map (a map with different
+   * types of Replicated Data values).
+   *
+   * @param key the key for a Replicated Multi-Map in this map
+   * @return the {@link ReplicatedMultiMap} associated with the given key, or an empty multi-map
+   * @param <KeyT> the key type for the Replicated Multi-Map
+   * @param <ValueT> the value type for the Replicated Multi-Map
+   */
+  @SuppressWarnings("unchecked")
+  default <KeyT, ValueT> ReplicatedMultiMap<KeyT, ValueT> getReplicatedMultiMap(K key) {
+    return (ReplicatedMultiMap<KeyT, ValueT>)
+        getOrElse(key, factory -> (V) factory.<KeyT, ValueT>newReplicatedMultiMap());
+  }
+
+  /**
+   * Get a {@link ReplicatedMap} from a heterogeneous Replicated Map (a map with different types of
+   * Replicated Data values).
+   *
+   * @param key the key for a Replicated Map in this map
+   * @return the {@link ReplicatedMap} associated with the given key, or an empty map
+   * @param <KeyT> the key type for the Replicated Map
+   * @param <ValueT> the value type for the Replicated Map
+   */
+  @SuppressWarnings("unchecked")
+  default <KeyT, ValueT extends ReplicatedData> ReplicatedMap<KeyT, ValueT> getReplicatedMap(
+      K key) {
+    return (ReplicatedMap<KeyT, ValueT>)
+        getOrElse(key, factory -> (V) factory.<KeyT, ValueT>newReplicatedMap());
+  }
 }


### PR DESCRIPTION
Since Replicated Maps will usually contain different types of Replicated Data values, add accessor methods for each of the Replicated Data types which take care of the (unchecked) casting and creating default values with the factory.