### PR TITLE
fix: Use specific archetypeVersion instead of LATEST

### DIFF
--- a/docs/src/modules/java/pages/developer-tools.adoc
+++ b/docs/src/modules/java/pages/developer-tools.adoc
@@ -18,7 +18,7 @@ mvn \
   archetype:generate \
   -DarchetypeGroupId=com.lightbend \
   -DarchetypeArtifactId=maven-archetype-akkasls \
-  -DarchetypeVersion=LATEST
+  -DarchetypeVersion={akkaserverless-java-sdk-version}
 ----
 
 Windows::
@@ -29,7 +29,7 @@ mvn ^
   archetype:generate ^
   -DarchetypeGroupId=com.lightbend ^
   -DarchetypeArtifactId=maven-archetype-akkasls ^
-  -DarchetypeVersion=LATEST
+  -DarchetypeVersion={akkaserverless-java-sdk-version}
 ----
 
 

--- a/docs/src/modules/java/pages/kickstart.adoc
+++ b/docs/src/modules/java/pages/kickstart.adoc
@@ -50,7 +50,7 @@ Linux or macOS::
 mvn archetype:generate \
   -DarchetypeGroupId=com.akkaserverless \
   -DarchetypeArtifactId=akkaserverless-maven-archetype \
-  -DarchetypeVersion=LATEST
+  -DarchetypeVersion={akkaserverless-java-sdk-version}
 ----
 --
 Windows 10+::
@@ -61,7 +61,7 @@ Windows 10+::
 mvn archetype:generate ^
   -DarchetypeGroupId=com.akkaserverless ^
   -DarchetypeArtifactId=akkaserverless-maven-archetype ^
-  -DarchetypeVersion=LATEST
+  -DarchetypeVersion={akkaserverless-java-sdk-version}
 ----
 --
 


### PR DESCRIPTION
* seems like LATEST is not resolving to 0.7.0
* don't know why, but it's better to use the released version

Fixes https://github.com/lightbend/akkaserverless-java-sdk/issues/360