### PR TITLE
Fix 371

### DIFF
--- a/docs/src/modules/java/pages/event-sourced-entities.adoc
+++ b/docs/src/modules/java/pages/event-sourced-entities.adoc
@@ -1,4 +1,5 @@
 = Implementing Event Sourced Entities in Java
+:page-aliases: eventsourced.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$eventsourced.adoc[]

--- a/docs/src/modules/java/pages/event-sourced-entities.adoc
+++ b/docs/src/modules/java/pages/event-sourced-entities.adoc
@@ -1,5 +1,5 @@
 = Implementing Event Sourced Entities in Java
-:page-aliases: eventsourced.adoc
+:page-aliases: java:eventsourced.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$eventsourced.adoc[]

--- a/docs/src/modules/java/pages/publish-and-subscribe.adoc
+++ b/docs/src/modules/java/pages/publish-and-subscribe.adoc
@@ -1,5 +1,5 @@
 = Publishing and subscribing to topics on a broker
-:page-aliases: topic-eventing.adoc
+:page-aliases: java:topic-eventing.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$topic-eventing.adoc[]

--- a/docs/src/modules/java/pages/publish-and-subscribe.adoc
+++ b/docs/src/modules/java/pages/publish-and-subscribe.adoc
@@ -1,4 +1,5 @@
 = Publishing and subscribing to topics on a broker
+:page-aliases: topic-eventing.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$topic-eventing.adoc[]

--- a/docs/src/modules/java/pages/quickstart-java-maven.adoc
+++ b/docs/src/modules/java/pages/quickstart-java-maven.adoc
@@ -1,5 +1,5 @@
 = Kickstart a Maven project
-
+:page-aliases: java:kickstart.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$attributes.adoc[]

--- a/docs/src/modules/java/pages/subscribe-to-journal.adoc
+++ b/docs/src/modules/java/pages/subscribe-to-journal.adoc
@@ -1,5 +1,5 @@
 = Subscribing to a journal
-:page-aliases: entity-eventing.adoc
+:page-aliases: java:entity-eventing.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$entity-eventing.adoc[]

--- a/docs/src/modules/java/pages/subscribe-to-journal.adoc
+++ b/docs/src/modules/java/pages/subscribe-to-journal.adoc
@@ -1,4 +1,5 @@
 = Subscribing to a journal
+:page-aliases: entity-eventing.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$entity-eventing.adoc[]

--- a/docs/src/modules/java/pages/writing-grpc-descriptors-protobuf.adoc
+++ b/docs/src/modules/java/pages/writing-grpc-descriptors-protobuf.adoc
@@ -1,4 +1,5 @@
 = Writing gRPC descriptors
+:page-aliases: proto.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$attributes.adoc[]

--- a/docs/src/modules/java/pages/writing-grpc-descriptors-protobuf.adoc
+++ b/docs/src/modules/java/pages/writing-grpc-descriptors-protobuf.adoc
@@ -1,5 +1,5 @@
 = Writing gRPC descriptors
-:page-aliases: proto.adoc
+:page-aliases: java:proto.adoc
 
 include::ROOT:partial$include.adoc[]
 include::partial$attributes.adoc[]


### PR DESCRIPTION
Fixes #371 by adding `page-aliases` to the pages mentioned. The pages have been renamed, but the `page-aliases` directive makes sure that a redirect will be generated