### PR TITLE
doc: fix commands on the developer tools page

### DIFF
--- a/docs/src/modules/java/pages/developer-tools.adoc
+++ b/docs/src/modules/java/pages/developer-tools.adoc
@@ -1,18 +1,19 @@
 = Developer Tools
 
 include::ROOT:partial$include.adoc[]
+include::partial$attributes.adoc[]
 
 The Java tooling is published to https://mvnrepository.com/artifact/com.akkaserverless[Maven Central]. 
 
 == Kickstart
 
-A https://maven.apache.org/guides/introduction/introduction-to-archetypes.html[Maven archetype]; _maven-archetype-akkasls_ provides the Kickstart tooling. You supply details such as the desired artifact and group IDs, and the archetype provides a new Maven project directory with the Akka Serverless SDK and associated development support tooling set up.
+A https://maven.apache.org/guides/introduction/introduction-to-archetypes.html[Maven archetype]; _akkaserverless-maven-archetype_ provides the tooling to xref:kickstart.adoc[kickstart a Maven project]. You supply details such as the desired artifact and group IDs, and the archetype provides a new Maven project directory with the Akka Serverless SDK and associated development support tooling set up.
 
 The archetype can be used via the `mvn` CLI.
 [.tabset]
 Linux or MacOS::
 +
-[source,command line]
+[source,command line,subs="attributes"]
 ----
 mvn \
   archetype:generate \
@@ -23,7 +24,7 @@ mvn \
 
 Windows::
 +
-[source,command line]
+[source,command line,subs="attributes"]
 ----
 mvn ^
   archetype:generate ^
@@ -34,7 +35,7 @@ mvn ^
 
 
 == Ongoing development support
-The development support tooling is provided via a single Maven plugin; _akkasls-maven-plugin_. This plugin provides two Maven goals to support Protobuf driven interface-first development.
+The development support tooling is provided via a single Maven plugin; _akkaserverless-maven-plugin_. This plugin provides two Maven goals to support Protobuf driven interface-first development.
 
 === Goals
 This plugin implements the following https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html[Maven Build Lifecycle] goals:


### PR DESCRIPTION
Follow-up to #367. The mvn commands on the developer tools page didn't have the version substituted, so they were displaying `{akkaserverless-java-sdk-version}` instead of the actual version. Also fix the archetype and plugin names. Add a link to the full kickstart page.

Not sure on the purpose of this developer tools page, which overlaps a lot with the kickstart page. 