### PR TITLE
feat: support protobuf scalar types for replicated entity codegen

### DIFF
--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/ModelBuilder.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/ModelBuilder.scala
@@ -89,7 +89,64 @@ object ModelBuilder {
   /**
    * Type argument for generic replicated data types with type parameters.
    */
-  case class TypeArgument(fqn: FullyQualifiedName)
+  sealed trait TypeArgument
+
+  object TypeArgument {
+    def apply(name: String, proto: PackageNaming): TypeArgument = {
+      if (name.nonEmpty && name.charAt(0).isLower) ScalarTypeArgument(ScalarType(name))
+      else MessageTypeArgument(FullyQualifiedName(name, proto))
+    }
+  }
+
+  /**
+   * Type argument for Protobuf message types.
+   */
+  case class MessageTypeArgument(fqn: FullyQualifiedName) extends TypeArgument
+
+  /**
+   * Type argument for Protobuf scalar types.
+   */
+  case class ScalarTypeArgument(scalar: ScalarType) extends TypeArgument
+
+  sealed trait ScalarType
+
+  object ScalarType {
+    case object Double extends ScalarType
+    case object Float extends ScalarType
+    case object Int32 extends ScalarType
+    case object Int64 extends ScalarType
+    case object UInt32 extends ScalarType
+    case object UInt64 extends ScalarType
+    case object SInt32 extends ScalarType
+    case object SInt64 extends ScalarType
+    case object Fixed32 extends ScalarType
+    case object Fixed64 extends ScalarType
+    case object SFixed32 extends ScalarType
+    case object SFixed64 extends ScalarType
+    case object Bool extends ScalarType
+    case object String extends ScalarType
+    case object Bytes extends ScalarType
+    case object Unknown extends ScalarType
+
+    def apply(protoType: String): ScalarType = protoType match {
+      case "double"   => Double
+      case "float"    => Float
+      case "int32"    => Int32
+      case "int64"    => Int64
+      case "uint32"   => UInt32
+      case "uint64"   => UInt64
+      case "sint32"   => SInt32
+      case "sint64"   => SInt64
+      case "fixed32"  => Fixed32
+      case "fixed64"  => Fixed64
+      case "sfixed32" => SFixed32
+      case "sfixed64" => SFixed64
+      case "bool"     => Bool
+      case "string"   => String
+      case "bytes"    => Bytes
+      case _          => Unknown
+    }
+  }
 
   /**
    * A Service backed by Akka Serverless; either an Action, View or Entity
@@ -363,24 +420,24 @@ object ModelBuilder {
         case ReplicatedDataCase.REPLICATED_COUNTER =>
           Some(ReplicatedCounter)
         case ReplicatedDataCase.REPLICATED_REGISTER =>
-          val value = TypeArgument(FullyQualifiedName(rawEntity.getReplicatedRegister.getValue, protoReference))
+          val value = TypeArgument(rawEntity.getReplicatedRegister.getValue, protoReference)
           Some(ReplicatedRegister(value))
         case ReplicatedDataCase.REPLICATED_SET =>
-          val element = TypeArgument(FullyQualifiedName(rawEntity.getReplicatedSet.getElement, protoReference))
+          val element = TypeArgument(rawEntity.getReplicatedSet.getElement, protoReference)
           Some(ReplicatedSet(element))
         case ReplicatedDataCase.REPLICATED_MAP =>
-          val key = TypeArgument(FullyQualifiedName(rawEntity.getReplicatedMap.getKey, protoReference))
+          val key = TypeArgument(rawEntity.getReplicatedMap.getKey, protoReference)
           Some(ReplicatedMap(key))
         case ReplicatedDataCase.REPLICATED_COUNTER_MAP =>
-          val key = TypeArgument(FullyQualifiedName(rawEntity.getReplicatedCounterMap.getKey, protoReference))
+          val key = TypeArgument(rawEntity.getReplicatedCounterMap.getKey, protoReference)
           Some(ReplicatedCounterMap(key))
         case ReplicatedDataCase.REPLICATED_REGISTER_MAP =>
-          val key = TypeArgument(FullyQualifiedName(rawEntity.getReplicatedRegisterMap.getKey, protoReference))
-          val value = TypeArgument(FullyQualifiedName(rawEntity.getReplicatedRegisterMap.getValue, protoReference))
+          val key = TypeArgument(rawEntity.getReplicatedRegisterMap.getKey, protoReference)
+          val value = TypeArgument(rawEntity.getReplicatedRegisterMap.getValue, protoReference)
           Some(ReplicatedRegisterMap(key, value))
         case ReplicatedDataCase.REPLICATED_MULTI_MAP =>
-          val key = TypeArgument(FullyQualifiedName(rawEntity.getReplicatedMultiMap.getKey, protoReference))
-          val value = TypeArgument(FullyQualifiedName(rawEntity.getReplicatedMultiMap.getValue, protoReference))
+          val key = TypeArgument(rawEntity.getReplicatedMultiMap.getKey, protoReference)
+          val value = TypeArgument(rawEntity.getReplicatedMultiMap.getValue, protoReference)
           Some(ReplicatedMultiMap(key, value))
         case ReplicatedDataCase.REPLICATED_VOTE =>
           Some(ReplicatedVote)

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
@@ -250,7 +250,7 @@ class ModelBuilderSuite extends munit.FunSuite {
       val entity = ModelBuilder.ReplicatedEntity(
         FullyQualifiedName("ShoppingCart", domainProto),
         "shopping-cart",
-        ModelBuilder.ReplicatedCounterMap(ModelBuilder.TypeArgument(FullyQualifiedName("Product", domainProto))))
+        ModelBuilder.ReplicatedCounterMap(ModelBuilder.TypeArgument("Product", domainProto)))
 
       assertEquals(model.entities, Map(entity.fqn.fullQualifiedName -> entity))
 

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/counter_map_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/counter_map_api.proto
@@ -61,3 +61,15 @@ service CounterMapService {
   rpc Get(GetValue) returns (CurrentValue);
   rpc GetAll(GetAllValues) returns (CurrentValues);
 }
+
+service ScalarCounterMapService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "com.example.replicated.countermap.domain.SomeScalarCounterMap"
+  };
+
+  rpc Increase(IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease(DecreaseValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+  rpc GetAll(GetAllValues) returns (CurrentValues);
+}

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/counter_map_domain_scalar.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/counter_map_domain_scalar.proto
@@ -14,27 +14,16 @@
 
 syntax = "proto3";
 
-package com.example.replicated.registermap.domain;
+package com.example.replicated.countermap.domain;
 
 import "akkaserverless/annotations.proto";
 
-option java_outer_classname = "SomeRegisterMapDomain";
+option java_outer_classname = "SomeScalarCounterMapDomain";
 
-// tag::replicated_entity[]
 option (akkaserverless.file).replicated_entity = {
-  name: "SomeRegisterMap"
-  entity_type: "some-register-map"
-  replicated_register_map: { // <1>
-    key: "SomeKey" // <2>
-    value: "SomeValue" // <3>
+  name: "SomeScalarCounterMap"
+  entity_type: "some-scalar-counter-map"
+  replicated_counter_map: {
+    key: "int64"
   }
 };
-
-message SomeKey {
-  string some_field = 1;
-}
-
-message SomeValue {
-  string some_field = 1;
-}
-// end::replicated_entity[]

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/map_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/map_api.proto
@@ -69,3 +69,17 @@ service MapService {
   rpc RemoveBaz(RemoveBazValue) returns (google.protobuf.Empty);
   rpc Get(GetValues) returns (CurrentValues);
 }
+
+service ScalarMapService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "com.example.replicated.map.domain.SomeScalarMap"
+  };
+
+  rpc IncreaseFoo(IncreaseFooValue) returns (google.protobuf.Empty);
+  rpc DecreaseFoo(DecreaseFooValue) returns (google.protobuf.Empty);
+  rpc SetBar(SetBarValue) returns (google.protobuf.Empty);
+  rpc AddBaz(AddBazValue) returns (google.protobuf.Empty);
+  rpc RemoveBaz(RemoveBazValue) returns (google.protobuf.Empty);
+  rpc Get(GetValues) returns (CurrentValues);
+}

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/map_domain_scalar.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/map_domain_scalar.proto
@@ -14,27 +14,16 @@
 
 syntax = "proto3";
 
-package com.example.replicated.registermap.domain;
+package com.example.replicated.map.domain;
 
 import "akkaserverless/annotations.proto";
 
-option java_outer_classname = "SomeRegisterMapDomain";
+option java_outer_classname = "SomeScalarMapDomain";
 
-// tag::replicated_entity[]
 option (akkaserverless.file).replicated_entity = {
-  name: "SomeRegisterMap"
-  entity_type: "some-register-map"
-  replicated_register_map: { // <1>
-    key: "SomeKey" // <2>
-    value: "SomeValue" // <3>
+  name: "SomeScalarMap"
+  entity_type: "some-scalar-map"
+  replicated_map: {
+    key: "string"
   }
 };
-
-message SomeKey {
-  string some_field = 1;
-}
-
-message SomeValue {
-  string some_field = 1;
-}
-// end::replicated_entity[]

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/multi_map_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/multi_map_api.proto
@@ -70,3 +70,15 @@ service MultiMapService {
   rpc Get(GetValues) returns (CurrentValues);
   rpc GetAll(GetAllValues) returns (AllCurrentValues);
 }
+
+service ScalarMultiMapService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "com.example.replicated.multimap.domain.SomeScalarMultiMap"
+  };
+
+  rpc Put(PutValue) returns (google.protobuf.Empty);
+  rpc Remove(RemoveValue) returns (google.protobuf.Empty);
+  rpc Get(GetValues) returns (CurrentValues);
+  rpc GetAll(GetAllValues) returns (AllCurrentValues);
+}

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/multi_map_domain_scalar.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/multi_map_domain_scalar.proto
@@ -14,27 +14,17 @@
 
 syntax = "proto3";
 
-package com.example.replicated.registermap.domain;
+package com.example.replicated.multimap.domain;
 
 import "akkaserverless/annotations.proto";
 
-option java_outer_classname = "SomeRegisterMapDomain";
+option java_outer_classname = "SomeScalarMultiMapDomain";
 
-// tag::replicated_entity[]
 option (akkaserverless.file).replicated_entity = {
-  name: "SomeRegisterMap"
-  entity_type: "some-register-map"
-  replicated_register_map: { // <1>
-    key: "SomeKey" // <2>
-    value: "SomeValue" // <3>
+  name: "SomeScalarMultiMap"
+  entity_type: "some-scalar-multi-map"
+  replicated_multi_map: {
+    key: "string"
+    value: "double"
   }
 };
-
-message SomeKey {
-  string some_field = 1;
-}
-
-message SomeValue {
-  string some_field = 1;
-}
-// end::replicated_entity[]

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/register_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/register_api.proto
@@ -43,3 +43,13 @@ service RegisterService {
   rpc Set(SetValue) returns (google.protobuf.Empty);
   rpc Get(GetValue) returns (CurrentValue);
 }
+
+service ScalarRegisterService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "com.example.replicated.register.domain.SomeScalarRegister"
+  };
+
+  rpc Set(SetValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+}

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/register_domain_scalar.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/register_domain_scalar.proto
@@ -14,27 +14,16 @@
 
 syntax = "proto3";
 
-package com.example.replicated.registermap.domain;
+package com.example.replicated.register.domain;
 
 import "akkaserverless/annotations.proto";
 
-option java_outer_classname = "SomeRegisterMapDomain";
+option java_outer_classname = "SomeScalarRegisterDomain";
 
-// tag::replicated_entity[]
 option (akkaserverless.file).replicated_entity = {
-  name: "SomeRegisterMap"
-  entity_type: "some-register-map"
-  replicated_register_map: { // <1>
-    key: "SomeKey" // <2>
-    value: "SomeValue" // <3>
+  name: "SomeScalarRegister"
+  entity_type: "some-scalar-register"
+  replicated_register: {
+    value: "bytes"
   }
 };
-
-message SomeKey {
-  string some_field = 1;
-}
-
-message SomeValue {
-  string some_field = 1;
-}
-// end::replicated_entity[]

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/register_map_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/register_map_api.proto
@@ -63,3 +63,14 @@ service RegisterMapService {
   rpc Get(GetValue) returns (CurrentValue);
   rpc GetAll(GetAllValues) returns (CurrentValues);
 }
+
+service ScalarRegisterMapService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "com.example.replicated.registermap.domain.SomeScalarRegisterMap"
+  };
+
+  rpc Set(SetValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+  rpc GetAll(GetAllValues) returns (CurrentValues);
+}

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/register_map_domain_scalar.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/register_map_domain_scalar.proto
@@ -18,23 +18,13 @@ package com.example.replicated.registermap.domain;
 
 import "akkaserverless/annotations.proto";
 
-option java_outer_classname = "SomeRegisterMapDomain";
+option java_outer_classname = "SomeScalarRegisterMapDomain";
 
-// tag::replicated_entity[]
 option (akkaserverless.file).replicated_entity = {
-  name: "SomeRegisterMap"
-  entity_type: "some-register-map"
-  replicated_register_map: { // <1>
-    key: "SomeKey" // <2>
-    value: "SomeValue" // <3>
+  name: "SomeScalarRegisterMap"
+  entity_type: "some-scalar-register-map"
+  replicated_register_map: {
+    key: "sint32"
+    value: "string"
   }
 };
-
-message SomeKey {
-  string some_field = 1;
-}
-
-message SomeValue {
-  string some_field = 1;
-}
-// end::replicated_entity[]

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/set_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/set_api.proto
@@ -53,3 +53,14 @@ service SetService {
   rpc Remove(RemoveElement) returns (google.protobuf.Empty);
   rpc Get(GetElements) returns (CurrentElements);
 }
+
+service ScalarSetService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "com.example.replicated.set.domain.SomeScalarSet"
+  };
+
+  rpc Add(AddElement) returns (google.protobuf.Empty);
+  rpc Remove(RemoveElement) returns (google.protobuf.Empty);
+  rpc Get(GetElements) returns (CurrentElements);
+}

--- a/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/set_domain_scalar.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/replicated-entities/set_domain_scalar.proto
@@ -14,27 +14,16 @@
 
 syntax = "proto3";
 
-package com.example.replicated.registermap.domain;
+package com.example.replicated.set.domain;
 
 import "akkaserverless/annotations.proto";
 
-option java_outer_classname = "SomeRegisterMapDomain";
+option java_outer_classname = "SomeScalarSetDomain";
 
-// tag::replicated_entity[]
 option (akkaserverless.file).replicated_entity = {
-  name: "SomeRegisterMap"
-  entity_type: "some-register-map"
-  replicated_register_map: { // <1>
-    key: "SomeKey" // <2>
-    value: "SomeValue" // <3>
+  name: "SomeScalarSet"
+  entity_type: "some-scalar-set"
+  replicated_set: {
+    element: "string"
   }
 };
-
-message SomeKey {
-  string some_field = 1;
-}
-
-message SomeValue {
-  string some_field = 1;
-}
-// end::replicated_entity[]

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
@@ -34,7 +34,7 @@ class SourceGeneratorSuite extends munit.FunSuite {
   }
 
   def domainType(name: String): ModelBuilder.TypeArgument =
-    ModelBuilder.TypeArgument(FullyQualifiedName(name, TestData.domainProto()))
+    ModelBuilder.TypeArgument(name, TestData.domainProto())
 
   test("generate") {
     val sourceDirectory = Files.createTempDirectory("source-generator-test")

--- a/docs/src/modules/java/pages/replicated-entity.adoc
+++ b/docs/src/modules/java/pages/replicated-entity.adoc
@@ -197,7 +197,9 @@ include::example$replicatedentity-examples/src/main/proto/replicated/register_do
 ----
 
 <1> Specify the Replicated Data type as a Replicated Register.
-<2> Specify the `protobuf` message type for the register's value.
+<2> Specify the `protobuf` type for the value of the Replicated Register.
+
+NOTE: The type for the value can be a `protobuf` https://developers.google.com/protocol-buffers/docs/proto3#simple[message type] or https://developers.google.com/protocol-buffers/docs/proto3#scalar[scalar value type]. The generated code will use the corresponding Java type. A message type is being used for the value type in this example.
 
 When implementing a Replicated Register entity, an initial or empty value needs to be defined by overriding the `emptyValue` method:
 
@@ -245,7 +247,9 @@ include::example$replicatedentity-examples/src/main/proto/replicated/set_domain.
 ----
 
 <1> Specify the Replicated Data type as a Replicated Set.
-<2> Specify the `protobuf` message type for the elements of the set.
+<2> Specify the `protobuf` type for the elements of the Replicated Set.
+
+NOTE: The type for the elements can be a `protobuf` https://developers.google.com/protocol-buffers/docs/proto3#simple[message type] or https://developers.google.com/protocol-buffers/docs/proto3#scalar[scalar value type]. The generated code will use the corresponding Java type. The `string` scalar type is being used for the element type in this example, which corresponds to the Java `String` class.
 
 IMPORTANT: Care needs to be taken to ensure that the serialized values for elements in the set are stable.
 
@@ -257,8 +261,7 @@ When implementing a Replicated Set entity, the state can be updated by calling t
 include::example$replicatedentity-examples/src/main/java/com/example/replicated/set/domain/SomeSet.java[tag=update]
 ----
 
-<1> Create a domain object for the element.
-<2> Modify the elements of the Replicated Set with `add` or `remove` and trigger a replicated update by returning an `Effect` with `effects().update`.
+<1> Modify the elements of the Replicated Set with `add` or `remove` and trigger a replicated update by returning an `Effect` with `effects().update`.
 
 The `elements` method for Replicated Set returns a regular `java.util.Set` that can be used to iterate over the current elements:
 
@@ -286,7 +289,9 @@ include::example$replicatedentity-examples/src/main/proto/replicated/counter_map
 ----
 
 <1> Specify the Replicated Data type as a Replicated Counter Map.
-<2> Specify the `protobuf` message type for the keys of the map.
+<2> Specify the `protobuf` type for the keys of the Replicated Counter Map.
+
+NOTE: The type for the key can be a `protobuf` https://developers.google.com/protocol-buffers/docs/proto3#simple[message type] or https://developers.google.com/protocol-buffers/docs/proto3#scalar[scalar value type]. The generated code will use the corresponding Java type. The `string` scalar type is being used for the key type in this example, which corresponds to the Java `String` class.
 
 When implementing a Replicated Counter Map entity, the value of an entry can be updated by calling the `increment` or `decrement` methods on the current data object, and then triggering an update with the modified data object. Entries can be removed from the map using the `remove` method.
 
@@ -296,8 +301,7 @@ When implementing a Replicated Counter Map entity, the value of an entry can be 
 include::example$replicatedentity-examples/src/main/java/com/example/replicated/countermap/domain/SomeCounterMap.java[tag=update]
 ----
 
-<1> Create a domain object for the key.
-<2> Modify the values of the Replicated Counter Map with `increment`, `decrement`, or `remove` and trigger a replicated update by returning an `Effect` with `effects().update`.
+<1> Modify the values of the Replicated Counter Map with `increment`, `decrement`, or `remove` and trigger a replicated update by returning an `Effect` with `effects().update`.
 
 Individual counters in a Replicated Counter Map can be accessed, or the set of keys can be used to iterate over all counters.
 
@@ -307,9 +311,8 @@ Individual counters in a Replicated Counter Map can be accessed, or the set of k
 include::example$replicatedentity-examples/src/main/java/com/example/replicated/countermap/domain/SomeCounterMap.java[tag=get]
 ----
 
-<1> Create a domain object for the key.
-<2> Get the current counter value for a key using `get`.
-<3> Iterate over the current entries of a Replicated Counter Map using `keySet`. Note that this may not be the most up-to-date view of the entries when there are concurrent modifications.
+<1> Get the current counter value for a key using `get`.
+<2> Iterate over the current entries of a Replicated Counter Map using `keySet`.
 
 NOTE: The `get` method returns a default value of `0L` if the map does not contain the key.
 
@@ -331,8 +334,10 @@ include::example$replicatedentity-examples/src/main/proto/replicated/register_ma
 ----
 
 <1> Specify the Replicated Data type as a Replicated Register Map.
-<2> Specify the `protobuf` message type for the keys of the map.
-<3> Specify the `protobuf` message type for the values of the map.
+<2> Specify the `protobuf` type for the keys of the Replicated Register Map.
+<3> Specify the `protobuf` type for the values of the Replicated Register Map.
+
+NOTE: The type for the key or value can be a `protobuf` https://developers.google.com/protocol-buffers/docs/proto3#simple[message type] or https://developers.google.com/protocol-buffers/docs/proto3#scalar[scalar value type]. The generated code will use the corresponding Java type. Message types are being used for both the key and value types in this example.
 
 When implementing a Replicated Register Map entity, the value of an entry can be updated by calling the `setValue` method on the current data object, and then triggering an update with the modified data object. Entries can be removed from the map using the `remove` method.
 
@@ -376,8 +381,10 @@ include::example$replicatedentity-examples/src/main/proto/replicated/multi_map_d
 ----
 
 <1> Specify the Replicated Data type as a Replicated Multi-Map.
-<2> Specify the `protobuf` message type for the keys of the multi-map.
-<3> Specify the `protobuf` message type for the values of the multi-map.
+<2> Specify the `protobuf` type for the keys of the Replicated Multi-Map.
+<3> Specify the `protobuf` type for the values of the Replicated Multi-Map.
+
+NOTE: The type for the key or value can be a `protobuf` https://developers.google.com/protocol-buffers/docs/proto3#simple[message type] or https://developers.google.com/protocol-buffers/docs/proto3#scalar[scalar value type]. The generated code will use the corresponding Java type. The `string` scalar type is being used for the key type and the `double` scalar type for the value type in this example, which correspond to the Java types for `String` and `Double`.
 
 When implementing a Replicated Multi-Map entity, the values of an entry can be updated by calling the `put`, `putAll`, or `remove` methods on the current data object, and then triggering an update with the modified data object. Entries can be removed entirely from the map using the `removeAll` method.
 
@@ -387,9 +394,7 @@ When implementing a Replicated Multi-Map entity, the values of an entry can be u
 include::example$replicatedentity-examples/src/main/java/com/example/replicated/multimap/domain/SomeMultiMap.java[tag=update]
 ----
 
-<1> Create a domain object for the key.
-<2> Create a domain object for the value.
-<3> Modify the values of the Replicated Multi-Map with `put`, `putAll`, `remove`, or `removeAll` and trigger a replicated update by returning an `Effect` with `effects().update`.
+<1> Modify the values of the Replicated Multi-Map with `put`, `putAll`, `remove`, or `removeAll` and trigger a replicated update by returning an `Effect` with `effects().update`.
 
 Individual entries in a Replicated Multi-Map can be accessed, or the set of keys can be used to iterate over all value sets.
 
@@ -399,9 +404,8 @@ Individual entries in a Replicated Multi-Map can be accessed, or the set of keys
 include::example$replicatedentity-examples/src/main/java/com/example/replicated/multimap/domain/SomeMultiMap.java[tag=get]
 ----
 
-<1> Create a domain object for the key.
-<2> Get the current set of values for a key using `get`.
-<3> Iterate over the current entries of a Replicated Multi-Map using `keySet`.
+<1> Get the current set of values for a key using `get`.
+<2> Iterate over the current entries of a Replicated Multi-Map using `keySet`.
 
 NOTE: Entries may not contain the most up-to-date values when there are concurrent modifications.
 
@@ -421,7 +425,9 @@ include::example$replicatedentity-examples/src/main/proto/replicated/map_domain.
 ----
 
 <1> Specify the Replicated Data type as a Replicated Map.
-<2> Specify the `protobuf` message type for the keys of the map.
+<2> Specify the `protobuf` type for the keys of the map.
+
+NOTE: The type for the key can be a `protobuf` https://developers.google.com/protocol-buffers/docs/proto3#simple[message type] or https://developers.google.com/protocol-buffers/docs/proto3#scalar[scalar value type]. The generated code will use the corresponding Java type. A message type is being used for the key type in this example.
 
 NOTE: The value type for a Replicated Map is not specified for code-generation, and will be set to `ReplicatedData` for a heterogeneous map (a Replicated Map that contains different types of Replicated Data values).
 

--- a/samples/replicatedentity-examples/src/it/java/com/example/replicated/registermap/domain/SomeRegisterMapIntegrationTest.java
+++ b/samples/replicatedentity-examples/src/it/java/com/example/replicated/registermap/domain/SomeRegisterMapIntegrationTest.java
@@ -37,8 +37,8 @@ public class SomeRegisterMapIntegrationTest {
         .set(
             SomeRegisterMapApi.SetValue.newBuilder()
                 .setRegisterMapId(registerMapId)
-                .setKey(SomeRegisterMapApi.Key.newBuilder().setKey(key))
-                .setValue(SomeRegisterMapApi.Value.newBuilder().setValue(value))
+                .setKey(SomeRegisterMapApi.Key.newBuilder().setField(key))
+                .setValue(SomeRegisterMapApi.Value.newBuilder().setField(value))
                 .build())
         .toCompletableFuture()
         .get(5, SECONDS);
@@ -49,7 +49,7 @@ public class SomeRegisterMapIntegrationTest {
         .remove(
             SomeRegisterMapApi.RemoveValue.newBuilder()
                 .setRegisterMapId(registerMapId)
-                .setKey(SomeRegisterMapApi.Key.newBuilder().setKey(key))
+                .setKey(SomeRegisterMapApi.Key.newBuilder().setField(key))
                 .build())
         .toCompletableFuture()
         .get(5, SECONDS);
@@ -60,12 +60,12 @@ public class SomeRegisterMapIntegrationTest {
         .get(
             SomeRegisterMapApi.GetValue.newBuilder()
                 .setRegisterMapId(registerMapId)
-                .setKey(SomeRegisterMapApi.Key.newBuilder().setKey(key))
+                .setKey(SomeRegisterMapApi.Key.newBuilder().setField(key))
                 .build())
         .toCompletableFuture()
         .get(5, SECONDS)
         .getValue()
-        .getValue();
+        .getField();
   }
 
   public Map<String, String> getAll(String registerMapId) throws Exception {
@@ -77,7 +77,7 @@ public class SomeRegisterMapIntegrationTest {
         .getValuesList()
         .stream()
         .collect(
-            Collectors.toMap(key -> key.getKey().getKey(), value -> value.getValue().getValue()));
+            Collectors.toMap(key -> key.getKey().getField(), value -> value.getValue().getField()));
   }
 
   @Test

--- a/samples/replicatedentity-examples/src/it/java/com/example/replicated/set/domain/SomeSetIntegrationTest.java
+++ b/samples/replicatedentity-examples/src/it/java/com/example/replicated/set/domain/SomeSetIntegrationTest.java
@@ -8,7 +8,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,22 +31,14 @@ public class SomeSetIntegrationTest {
 
   public void add(String setId, String value) throws Exception {
     client
-        .add(
-            SomeSetApi.AddElement.newBuilder()
-                .setSetId(setId)
-                .setElement(SomeSetApi.Element.newBuilder().setValue(value))
-                .build())
+        .add(SomeSetApi.AddElement.newBuilder().setSetId(setId).setElement(value).build())
         .toCompletableFuture()
         .get(5, SECONDS);
   }
 
   public void remove(String setId, String value) throws Exception {
     client
-        .remove(
-            SomeSetApi.RemoveElement.newBuilder()
-                .setSetId(setId)
-                .setElement(SomeSetApi.Element.newBuilder().setValue(value))
-                .build())
+        .remove(SomeSetApi.RemoveElement.newBuilder().setSetId(setId).setElement(value).build())
         .toCompletableFuture()
         .get(5, SECONDS);
   }
@@ -57,10 +48,7 @@ public class SomeSetIntegrationTest {
         .get(SomeSetApi.GetElements.newBuilder().setSetId(setId).build())
         .toCompletableFuture()
         .get(5, SECONDS)
-        .getElementsList()
-        .stream()
-        .map(SomeSetApi.Element::getValue)
-        .collect(Collectors.toList());
+        .getElementsList();
   }
 
   @Test

--- a/samples/replicatedentity-examples/src/main/java/com/example/replicated/countermap/domain/SomeCounterMap.java
+++ b/samples/replicatedentity-examples/src/main/java/com/example/replicated/countermap/domain/SomeCounterMap.java
@@ -20,34 +20,25 @@ public class SomeCounterMap extends AbstractSomeCounterMap {
   // tag::update[]
   @Override
   public Effect<Empty> increase(
-      ReplicatedCounterMap<SomeCounterMapDomain.SomeKey> counterMap,
-      SomeCounterMapApi.IncreaseValue command) {
-    SomeCounterMapDomain.SomeKey key = // <1>
-        SomeCounterMapDomain.SomeKey.newBuilder().setKey(command.getKey()).build();
+      ReplicatedCounterMap<String> counterMap, SomeCounterMapApi.IncreaseValue command) {
     return effects()
-        .update(counterMap.increment(key, command.getValue())) // <2>
+        .update(counterMap.increment(command.getKey(), command.getValue())) // <1>
         .thenReply(Empty.getDefaultInstance());
   }
 
   @Override
   public Effect<Empty> decrease(
-      ReplicatedCounterMap<SomeCounterMapDomain.SomeKey> counterMap,
-      SomeCounterMapApi.DecreaseValue command) {
-    SomeCounterMapDomain.SomeKey key = // <1>
-        SomeCounterMapDomain.SomeKey.newBuilder().setKey(command.getKey()).build();
+      ReplicatedCounterMap<String> counterMap, SomeCounterMapApi.DecreaseValue command) {
     return effects()
-        .update(counterMap.decrement(key, command.getValue())) // <2>
+        .update(counterMap.decrement(command.getKey(), command.getValue())) // <1>
         .thenReply(Empty.getDefaultInstance());
   }
 
   @Override
   public Effect<Empty> remove(
-      ReplicatedCounterMap<SomeCounterMapDomain.SomeKey> counterMap,
-      SomeCounterMapApi.RemoveValue command) {
-    SomeCounterMapDomain.SomeKey key = // <1>
-        SomeCounterMapDomain.SomeKey.newBuilder().setKey(command.getKey()).build();
+      ReplicatedCounterMap<String> counterMap, SomeCounterMapApi.RemoveValue command) {
     return effects()
-        .update(counterMap.remove(key)) // <2>
+        .update(counterMap.remove(command.getKey())) // <1>
         .thenReply(Empty.getDefaultInstance());
   }
   // end::update[]
@@ -55,11 +46,8 @@ public class SomeCounterMap extends AbstractSomeCounterMap {
   // tag::get[]
   @Override
   public Effect<SomeCounterMapApi.CurrentValue> get(
-      ReplicatedCounterMap<SomeCounterMapDomain.SomeKey> counterMap,
-      SomeCounterMapApi.GetValue command) {
-    SomeCounterMapDomain.SomeKey key = // <1>
-        SomeCounterMapDomain.SomeKey.newBuilder().setKey(command.getKey()).build();
-    long value = counterMap.get(key); // <2>
+      ReplicatedCounterMap<String> counterMap, SomeCounterMapApi.GetValue command) {
+    long value = counterMap.get(command.getKey()); // <1>
     SomeCounterMapApi.CurrentValue currentValue =
         SomeCounterMapApi.CurrentValue.newBuilder().setValue(value).build();
     return effects().reply(currentValue);
@@ -67,11 +55,10 @@ public class SomeCounterMap extends AbstractSomeCounterMap {
 
   @Override
   public Effect<SomeCounterMapApi.CurrentValues> getAll(
-      ReplicatedCounterMap<SomeCounterMapDomain.SomeKey> counterMap,
-      SomeCounterMapApi.GetAllValues command) {
+      ReplicatedCounterMap<String> counterMap, SomeCounterMapApi.GetAllValues command) {
     Map<String, Long> values =
-        counterMap.keySet().stream() // <3>
-            .map(key -> new SimpleEntry<>(key.getKey(), counterMap.get(key)))
+        counterMap.keySet().stream() // <2>
+            .map(key -> new SimpleEntry<>(key, counterMap.get(key)))
             .collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue));
     SomeCounterMapApi.CurrentValues currentValues =
         SomeCounterMapApi.CurrentValues.newBuilder().putAllValues(values).build();

--- a/samples/replicatedentity-examples/src/main/java/com/example/replicated/map/domain/SomeMap.java
+++ b/samples/replicatedentity-examples/src/main/java/com/example/replicated/map/domain/SomeMap.java
@@ -16,13 +16,13 @@ public class SomeMap extends AbstractSomeMap {
   private final String entityId;
 
   private static final SomeMapDomain.SomeKey FOO_KEY =
-      SomeMapDomain.SomeKey.newBuilder().setKey("foo").build();
+      SomeMapDomain.SomeKey.newBuilder().setSomeField("foo").build();
 
   private static final SomeMapDomain.SomeKey BAR_KEY =
-      SomeMapDomain.SomeKey.newBuilder().setKey("bar").build();
+      SomeMapDomain.SomeKey.newBuilder().setSomeField("bar").build();
 
   private static final SomeMapDomain.SomeKey BAZ_KEY =
-      SomeMapDomain.SomeKey.newBuilder().setKey("baz").build();
+      SomeMapDomain.SomeKey.newBuilder().setSomeField("baz").build();
 
   public SomeMap(ReplicatedEntityContext context) {
     this.entityId = context.entityId();

--- a/samples/replicatedentity-examples/src/main/java/com/example/replicated/register/domain/SomeRegister.java
+++ b/samples/replicatedentity-examples/src/main/java/com/example/replicated/register/domain/SomeRegister.java
@@ -25,7 +25,7 @@ public class SomeRegister extends AbstractSomeRegister {
   public Effect<Empty> set(
       ReplicatedRegister<SomeRegisterDomain.SomeValue> register, SomeRegisterApi.SetValue command) {
     SomeRegisterDomain.SomeValue newValue = // <1>
-        SomeRegisterDomain.SomeValue.newBuilder().setValue(command.getValue()).build();
+        SomeRegisterDomain.SomeValue.newBuilder().setSomeField(command.getValue()).build();
     return effects()
         .update(register.set(newValue)) // <2>
         .thenReply(Empty.getDefaultInstance());
@@ -38,7 +38,7 @@ public class SomeRegister extends AbstractSomeRegister {
       ReplicatedRegister<SomeRegisterDomain.SomeValue> register, SomeRegisterApi.GetValue command) {
     SomeRegisterDomain.SomeValue value = register.get(); // <1>
     SomeRegisterApi.CurrentValue currentValue = // <2>
-        SomeRegisterApi.CurrentValue.newBuilder().setValue(value.getValue()).build();
+        SomeRegisterApi.CurrentValue.newBuilder().setValue(value.getSomeField()).build();
     return effects().reply(currentValue);
   }
   // end::get[]

--- a/samples/replicatedentity-examples/src/main/java/com/example/replicated/registermap/domain/SomeRegisterMap.java
+++ b/samples/replicatedentity-examples/src/main/java/com/example/replicated/registermap/domain/SomeRegisterMap.java
@@ -24,10 +24,12 @@ public class SomeRegisterMap extends AbstractSomeRegisterMap {
           registerMap,
       SomeRegisterMapApi.SetValue command) {
     SomeRegisterMapDomain.SomeKey key = // <1>
-        SomeRegisterMapDomain.SomeKey.newBuilder().setKey(command.getKey().getKey()).build();
+        SomeRegisterMapDomain.SomeKey.newBuilder()
+            .setSomeField(command.getKey().getField())
+            .build();
     SomeRegisterMapDomain.SomeValue value = // <2>
         SomeRegisterMapDomain.SomeValue.newBuilder()
-            .setValue(command.getValue().getValue())
+            .setSomeField(command.getValue().getField())
             .build();
     return effects()
         .update(registerMap.setValue(key, value)) // <3>
@@ -40,7 +42,9 @@ public class SomeRegisterMap extends AbstractSomeRegisterMap {
           registerMap,
       SomeRegisterMapApi.RemoveValue command) {
     SomeRegisterMapDomain.SomeKey key = // <1>
-        SomeRegisterMapDomain.SomeKey.newBuilder().setKey(command.getKey().getKey()).build();
+        SomeRegisterMapDomain.SomeKey.newBuilder()
+            .setSomeField(command.getKey().getField())
+            .build();
     return effects()
         .update(registerMap.remove(key)) // <3>
         .thenReply(Empty.getDefaultInstance());
@@ -54,20 +58,24 @@ public class SomeRegisterMap extends AbstractSomeRegisterMap {
           registerMap,
       SomeRegisterMapApi.GetValue command) {
     SomeRegisterMapDomain.SomeKey key = // <1>
-        SomeRegisterMapDomain.SomeKey.newBuilder().setKey(command.getKey().getKey()).build();
+        SomeRegisterMapDomain.SomeKey.newBuilder()
+            .setSomeField(command.getKey().getField())
+            .build();
     Optional<SomeRegisterMapDomain.SomeValue> maybeValue = registerMap.getValue(key); // <2>
     SomeRegisterMapApi.CurrentValue currentValue =
         SomeRegisterMapApi.CurrentValue.newBuilder()
             .setValue(
                 SomeRegisterMapApi.Value.newBuilder()
-                    .setValue(maybeValue.map(SomeRegisterMapDomain.SomeValue::getValue).orElse("")))
+                    .setField(
+                        maybeValue.map(SomeRegisterMapDomain.SomeValue::getSomeField).orElse("")))
             .build();
     return effects().reply(currentValue);
   }
 
   @Override
   public Effect<SomeRegisterMapApi.CurrentValues> getAll(
-      ReplicatedRegisterMap<SomeRegisterMapDomain.SomeKey, SomeRegisterMapDomain.SomeValue> registerMap,
+      ReplicatedRegisterMap<SomeRegisterMapDomain.SomeKey, SomeRegisterMapDomain.SomeValue>
+          registerMap,
       SomeRegisterMapApi.GetAllValues command) {
     List<SomeRegisterMapApi.CurrentValue> allValues =
         registerMap.keySet().stream() // <3>
@@ -76,11 +84,11 @@ public class SomeRegisterMap extends AbstractSomeRegisterMap {
                   String value =
                       registerMap
                           .getValue(key)
-                          .map(SomeRegisterMapDomain.SomeValue::getValue)
+                          .map(SomeRegisterMapDomain.SomeValue::getSomeField)
                           .orElse("");
                   return SomeRegisterMapApi.CurrentValue.newBuilder()
-                      .setKey(SomeRegisterMapApi.Key.newBuilder().setKey(key.getKey()))
-                      .setValue(SomeRegisterMapApi.Value.newBuilder().setValue(value))
+                      .setKey(SomeRegisterMapApi.Key.newBuilder().setField(key.getSomeField()))
+                      .setValue(SomeRegisterMapApi.Value.newBuilder().setField(value))
                       .build();
                 })
             .collect(Collectors.toList());

--- a/samples/replicatedentity-examples/src/main/java/com/example/replicated/set/domain/SomeSet.java
+++ b/samples/replicatedentity-examples/src/main/java/com/example/replicated/set/domain/SomeSet.java
@@ -5,7 +5,6 @@ import com.akkaserverless.javasdk.replicatedentity.ReplicatedSet;
 import com.example.replicated.set.SomeSetApi;
 import com.google.protobuf.Empty;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,22 +18,16 @@ public class SomeSet extends AbstractSomeSet {
 
   // tag::update[]
   @Override
-  public Effect<Empty> add(
-      ReplicatedSet<SomeSetDomain.SomeElement> set, SomeSetApi.AddElement command) {
-    SomeSetDomain.SomeElement element = // <1>
-        SomeSetDomain.SomeElement.newBuilder().setValue(command.getElement().getValue()).build();
+  public Effect<Empty> add(ReplicatedSet<String> set, SomeSetApi.AddElement command) {
     return effects()
-        .update(set.add(element)) // <2>
+        .update(set.add(command.getElement())) // <1>
         .thenReply(Empty.getDefaultInstance());
   }
 
   @Override
-  public Effect<Empty> remove(
-      ReplicatedSet<SomeSetDomain.SomeElement> set, SomeSetApi.RemoveElement command) {
-    SomeSetDomain.SomeElement element = // <1>
-        SomeSetDomain.SomeElement.newBuilder().setValue(command.getElement().getValue()).build();
+  public Effect<Empty> remove(ReplicatedSet<String> set, SomeSetApi.RemoveElement command) {
     return effects()
-        .update(set.remove(element)) // <2>
+        .update(set.remove(command.getElement())) // <1>
         .thenReply(Empty.getDefaultInstance());
   }
   // end::update[]
@@ -42,11 +35,10 @@ public class SomeSet extends AbstractSomeSet {
   // tag::get[]
   @Override
   public Effect<SomeSetApi.CurrentElements> get(
-      ReplicatedSet<SomeSetDomain.SomeElement> set, SomeSetApi.GetElements command) {
-    List<SomeSetApi.Element> elements =
+      ReplicatedSet<String> set, SomeSetApi.GetElements command) {
+    List<String> elements =
         set.elements().stream() // <1>
-            .map(element -> SomeSetApi.Element.newBuilder().setValue(element.getValue()).build())
-            .sorted(Comparator.comparing(SomeSetApi.Element::getValue))
+            .sorted()
             .collect(Collectors.toList());
 
     SomeSetApi.CurrentElements currentElements =

--- a/samples/replicatedentity-examples/src/main/proto/replicated/counter_map_domain.proto
+++ b/samples/replicatedentity-examples/src/main/proto/replicated/counter_map_domain.proto
@@ -25,11 +25,7 @@ option (akkaserverless.file).replicated_entity = {
   name: "SomeCounterMap"
   entity_type: "some-counter-map"
   replicated_counter_map: { // <1>
-    key: "SomeKey" // <2>
+    key: "string" // <2>
   }
 };
-
-message SomeKey {
-  string key = 1;
-}
 // end::replicated_entity[]

--- a/samples/replicatedentity-examples/src/main/proto/replicated/map_domain.proto
+++ b/samples/replicatedentity-examples/src/main/proto/replicated/map_domain.proto
@@ -30,6 +30,6 @@ option (akkaserverless.file).replicated_entity = {
 };
 
 message SomeKey {
-  string key = 1;
+  string some_field = 1;
 }
 // end::replicated_entity[]

--- a/samples/replicatedentity-examples/src/main/proto/replicated/multi_map_api.proto
+++ b/samples/replicatedentity-examples/src/main/proto/replicated/multi_map_api.proto
@@ -21,45 +21,37 @@ package com.example.replicated.multimap;
 
 option java_outer_classname = "SomeMultiMapApi";
 
-message Key {
-  string key = 1;
-}
-
-message Value {
-  string value = 1;
-}
-
 message PutValue {
   string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
-  Key key = 2;
-  Value value = 3;
+  string key = 2;
+  double value = 3;
 }
 
 message PutAllValues {
   string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
-  Key key = 2;
-  repeated Value values = 3;
+  string key = 2;
+  repeated double values = 3;
 }
 
 message RemoveValue {
   string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
-  Key key = 2;
-  Value value = 3;
+  string key = 2;
+  double value = 3;
 }
 
 message RemoveAllValues {
   string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
-  Key key = 2;
+  string key = 2;
 }
 
 message GetValues {
   string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
-  Key key = 2;
+  string key = 2;
 }
 
 message CurrentValues {
-  Key key = 1;
-  repeated Value values = 2;
+  string key = 1;
+  repeated double values = 2;
 }
 
 message GetAllValues {

--- a/samples/replicatedentity-examples/src/main/proto/replicated/multi_map_domain.proto
+++ b/samples/replicatedentity-examples/src/main/proto/replicated/multi_map_domain.proto
@@ -25,16 +25,8 @@ option (akkaserverless.file).replicated_entity = {
   name: "SomeMultiMap"
   entity_type: "some-multi-map"
   replicated_multi_map: { // <1>
-    key: "SomeKey" // <2>
-    value: "SomeValue" // <3>
+    key: "string" // <2>
+    value: "double" // <3>
   }
 };
-
-message SomeKey {
-  string key = 1;
-}
-
-message SomeValue {
-  string value = 1;
-}
 // end::replicated_entity[]

--- a/samples/replicatedentity-examples/src/main/proto/replicated/register_domain.proto
+++ b/samples/replicatedentity-examples/src/main/proto/replicated/register_domain.proto
@@ -30,6 +30,6 @@ option (akkaserverless.file).replicated_entity = {
 };
 
 message SomeValue {
-  string value = 1;
+  string some_field = 1;
 }
 // end::replicated_entity[]

--- a/samples/replicatedentity-examples/src/main/proto/replicated/register_map_api.proto
+++ b/samples/replicatedentity-examples/src/main/proto/replicated/register_map_api.proto
@@ -22,11 +22,11 @@ package com.example.replicated.registermap;
 option java_outer_classname = "SomeRegisterMapApi";
 
 message Key {
-  string key = 1;
+  string field = 1;
 }
 
 message Value {
-  string value = 1;
+  string field = 1;
 }
 
 message SetValue {

--- a/samples/replicatedentity-examples/src/main/proto/replicated/set_api.proto
+++ b/samples/replicatedentity-examples/src/main/proto/replicated/set_api.proto
@@ -21,18 +21,15 @@ package com.example.replicated.set;
 
 option java_outer_classname = "SomeSetApi";
 
-message Element {
-  string value = 1;
-}
 
 message AddElement {
   string set_id = 1 [(akkaserverless.field).entity_key = true];
-  Element element = 2;
+  string element = 2;
 }
 
 message RemoveElement {
   string set_id = 1 [(akkaserverless.field).entity_key = true];
-  Element element = 2;
+  string element = 2;
 }
 
 message GetElements {
@@ -40,7 +37,7 @@ message GetElements {
 }
 
 message CurrentElements {
-  repeated Element elements = 1;
+  repeated string elements = 1;
 }
 
 service SetService {

--- a/samples/replicatedentity-examples/src/main/proto/replicated/set_domain.proto
+++ b/samples/replicatedentity-examples/src/main/proto/replicated/set_domain.proto
@@ -25,11 +25,7 @@ option (akkaserverless.file).replicated_entity = {
   name: "SomeSet"
   entity_type: "some-set"
   replicated_set: { // <1>
-    element: "SomeElement" // <2>
+    element: "string" // <2>
   }
 };
-
-message SomeElement {
-  string value = 1;
-}
 // end::replicated_entity[]


### PR DESCRIPTION
Resolves #301. Support scalar types in the codegen annotation for replicated entities. Update some doc examples to use scalar value types instead of message types.