### PR TITLE
Make all codegen warnings fatal

### DIFF
--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Log.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Log.scala
@@ -17,8 +17,9 @@
 package com.lightbend.akkasls.codegen
 
 trait Log {
+  // On sbt we don't have a neat way to hook into logging,
+  // so there debug/info messages are either silent or println'ed, and
+  // all other problems should be fatal.
   def debug(message: String): Unit
   def info(message: String): Unit
-  def warning(message: String): Unit
-  def error(message: String): Unit
 }

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
@@ -33,8 +33,6 @@ class ModelBuilderSuite extends munit.FunSuite {
   implicit val codegenLog = new Log {
     override def debug(message: String): Unit = log.debug(message)
     override def info(message: String): Unit = log.info(message)
-    override def warning(message: String): Unit = log.warn(message)
-    override def error(message: String): Unit = log.error(message)
   }
 
   def command(

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
@@ -70,11 +70,9 @@ object SourceGenerator {
       case service: ModelBuilder.EntityService =>
         model.entities.get(service.componentFullName) match {
           case None =>
-            // TODO perhaps we even want to make this an error, to really go all-in on codegen?
-            log.warning(
+            throw new IllegalStateException(
               "Service [" + service.fqn.fullQualifiedName + "] refers to entity [" + service.componentFullName +
               "], but no entity configuration is found for that component name")
-            Seq.empty
           case Some(entity) =>
             EntityServiceSourceGenerator.generate(
               entity,

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/SourceGeneratorSuite.scala
@@ -29,8 +29,6 @@ class SourceGeneratorSuite extends munit.FunSuite {
   implicit val codegenLog = new Log {
     override def debug(message: String): Unit = log.debug(message)
     override def info(message: String): Unit = log.info(message)
-    override def warning(message: String): Unit = log.warn(message)
-    override def error(message: String): Unit = log.error(message)
   }
 
   def domainType(name: String): ModelBuilder.TypeArgument =

--- a/maven-java/akkaserverless-maven-plugin/src/main/java/com/akkaserverless/GenerateMojo.java
+++ b/maven-java/akkaserverless-maven-plugin/src/main/java/com/akkaserverless/GenerateMojo.java
@@ -80,10 +80,6 @@ public class GenerateMojo extends AbstractMojo {
       public void debug(String message) { getLog().debug(message); }
       @Override
       public void info(String message) { getLog().info(message); }
-      @Override
-      public void warning(String message) { getLog().warn(message); }
-      @Override
-      public void error(String message) { getLog().error(message); }
     };
 
     /**

--- a/project/ReflectiveCodeGen.scala
+++ b/project/ReflectiveCodeGen.scala
@@ -51,8 +51,6 @@ object ReflectiveCodeGen extends AutoPlugin {
       |  implicit val codegenLog = new com.lightbend.akkasls.codegen.Log {
       |      override def debug(message: String): Unit = logger.debug(message)
       |      override def info(message: String): Unit = logger.info(message)
-      |      override def warning(message: String): Unit = logger.warn(message)
-      |      override def error(message: String): Unit = logger.error(message)
       |    }
       |  
       |  SourceGenerator


### PR DESCRIPTION
Since in sbt we don't have a good way to signal them anyway