### PR TITLE
doc: fix links to main docs and validate links in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,9 @@ jobs:
       - restore_deps_cache
       - run:
           name: Validate docs
-          command: make -C docs
+          command: |
+            make -C docs
+            make -C docs validate-links
       - save_deps_cache
 
   tests:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -87,7 +87,7 @@ validate-links:
 		--rm \
 		--entrypoint /bin/sh \
 		-t ${antora_docker_image}:${antora_docker_image_tag} \
-		-c "cd /antora/${base_path} && find src -name '*.adoc' -print0 | xargs -0 -n1 asciidoc-link-check --progress"
+		-c "cd /antora/${base_path} && find src -name '*.adoc' -print0 | xargs -0 -n1 asciidoc-link-check --progress --config config/validate-links.json"
 
 deploy: clean managed
 	bin/deploy.sh --module ${module} --upstream ${upstream} --branch ${branch} ${sources}

--- a/docs/config/validate-links.json
+++ b/docs/config/validate-links.json
@@ -1,0 +1,5 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^https://mvnrepository\\.com" }
+  ]
+}

--- a/docs/src/modules/developing/pages/development-process-java.adoc
+++ b/docs/src/modules/developing/pages/development-process-java.adoc
@@ -66,10 +66,8 @@ It is good practice to write unit tests as you implement your services. The kick
 
 Use Docker to package your service and any of its dependencies. See the following pages for more information:
 
-* https://developer.lightbend.com/docs/akka-serverless/setting-up/#_docker[Installing Docker]
-* https://developer.lightbend.com/docs/akka-serverless/deploying/docker.html[Packaging with Docker]
+* https://developer.lightbend.com/docs/akka-serverless/setting-up/#_containers[Setting up containers]
 * https://developer.lightbend.com/docs/akka-serverless/projects/container-registries.html[Configuring registries]
-* https://developer.lightbend.com/docs/akka-serverless/tutorial/node-cart-package-deploy.html[Example of how to package a service]
 
 [#_run_locally]
 == Run locally
@@ -82,6 +80,5 @@ xref:java:run-locally.adoc[running them locally] before deploying to Akka Server
 
 After testing locally, deploy your service to Akka Serverless using the CLI or the Console. The following pages provide information about deployment:
 
-* https://developer.lightbend.com/docs/akka-serverless/getting-started/projects.html[Working with Akka Serverless deployment projects]
-* https://developer.lightbend.com/docs/akka-serverless/deploying/deploying.html[Deploying a packaged service]
-* https://developer.lightbend.com/docs/akka-serverless/tutorial/index.html[Examples of how to deploy]
+* https://developer.lightbend.com/docs/akka-serverless/projects/index.html[Working with Akka Serverless deployment projects]
+* https://developer.lightbend.com/docs/akka-serverless/quickstart/index.html[Quickstart examples]

--- a/docs/src/modules/java/pages/index.adoc
+++ b/docs/src/modules/java/pages/index.adoc
@@ -5,12 +5,12 @@ include::partial$attributes.adoc[]
 
 The Akka Serverless Java SDK offers an idiomatic, annotation-based Java language SDK for writing components. This page describes prerequisites for Java development and basic requirements for a development project.
 
-NOTE: Lightbend provides Tier 1 support for the Java SDK. See https://developer.lightbend.com/docs/akka-serverless/developing/sdk-support.html[an explanation of support tiers] for more information.
+NOTE: Lightbend provides Tier 1 support for the Java SDK. See https://developer.lightbend.com/docs/akka-serverless/faq/index.html#_what_languages_are_supported[an explanation of support tiers] for more information.
 
 
 Your development project needs to include the Akka Serverless Java SDK and logic to start the gRPC server. You define your components in gRPC descriptors and use `protoc` to compile them. Finally, you implement business logic for service components.
 
-To save the work of starting from scratch, the Java xref:java:kickstart.adoc[code generation tool] creates a project, complete with descriptors and implementations. Or, you can start from one of our https://developer.lightbend.com/docs/akka-serverless/tutorial/index.html[example applications].
+To save the work of starting from scratch, the Java xref:java:kickstart.adoc[code generation tool] creates a project, complete with descriptors and implementations. Or, you can start from one of our https://developer.lightbend.com/docs/akka-serverless/quickstart/index.html[quickstart example applications].
 
 == Prerequisites
 

--- a/docs/src/modules/java/pages/quickstart-java-maven.adoc
+++ b/docs/src/modules/java/pages/quickstart-java-maven.adoc
@@ -22,8 +22,8 @@ Before running the code generation tools, make sure you have the following:
 
 To deploy the generated service, you will need:
 
-* An https://developer.lightbend.com/docs/akka-serverless/getting-started/lightbend-account.html[Akka Serverless account]
-* An https://developer.lightbend.com/docs/akka-serverless/getting-started/projects.html#_create_a_project[Akka Serverless project]
+* An https://developer.lightbend.com/docs/akka-serverless/setting-up/index.html#_akka_serverless_account[Akka Serverless account]
+* An https://developer.lightbend.com/docs/akka-serverless/projects/create-project.html[Akka Serverless project]
 * The https://developer.lightbend.com/docs/akka-serverless/setting-up/#_akka_serverless_cli[akkasls] CLI
 * A configured registry in which to publish the service container image. Refer to https://developer.lightbend.com/docs/akka-serverless/projects/container-registries.html[Configuring registries] for more information on how to make your Docker registry available to Akka Serverless.
 

--- a/docs/src/modules/java/partials/topic-eventing.adoc
+++ b/docs/src/modules/java/partials/topic-eventing.adoc
@@ -2,7 +2,7 @@ include::ROOT:partial$include.adoc[]
 
 Akka Serverless integrates with https://cloud.google.com/pubsub/docs/overview[Google Cloud Pub/Sub] to enable asynchronous messaging. Consumers of published messages are guaranteed to receive them at least once. This means that receivers must be able to handle duplicate messages. If you are new to the world of Pub/Sub, many online resources provide tips on handling duplicate messages.
 
-This page describes how to subscribe to published events, but you also need to configure Google Cloud Pub/Sub access for your Akka Serverless project as explained in https://developer.lightbend.com/docs/akka-serverless/how-to/message-broker.html[How to configure a broker].
+This page describes how to subscribe to published events, but you also need to configure Google Cloud Pub/Sub access for your Akka Serverless project as explained in https://developer.lightbend.com/docs/akka-serverless/projects/message-brokers.html[how to configure message brokers].
 
 NOTE: It is your responsibility to create the topics in Google Cloud Pub/Sub before configuring publishers or subscribers.
 


### PR DESCRIPTION
The restructure in the main docs broke some links. There's already a `validate-links` target, add this to CI.

For Cloudstate, we found the external link checking to be flaky, so only ran it manually. But the Cloudstate docs also had a different setup which allowed separate modules to use xrefs rather than external links, so these would be validated already, but here we're using external links to the main docs. We can see how it goes with running it regularly, and how often it needs to be rerun.