### PR TITLE
chore(docs): update page link for seo

### DIFF
--- a/docs/src/modules/java/pages/replicated-entity-crdt.adoc
+++ b/docs/src/modules/java/pages/replicated-entity-crdt.adoc
@@ -1,4 +1,5 @@
 = Implementing Replicated Entities in Java
+:page-aliases: replicated-entity.adoc
 
 include::ROOT:partial$include.adoc[]
 


### PR DESCRIPTION
Update the page link (file name) for SEO, which fixes #399. A redirect to the old name has been added