### PR TITLE
fix: codegen for outer class and multiple files variations

### DIFF
--- a/codegen/java-gen-compilation-tests/src/main/proto/actions/simple_action.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/actions/simple_action.proto
@@ -14,31 +14,20 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.action1;
 
-option java_outer_classname = "EchoActionModel";
+// no java_multiple_files option, classes will be wrapped in outer class
+// no java_outer_classname option, will default to "SimpleActionOuterClass"
 
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
-}
+message Request {}
+message Response {}
 
-message Hello {
-  string message = 1;
-}
+service SimpleAction {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ACTION
+  };
 
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
-
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+  rpc Method(Request) returns (Response);
 }

--- a/codegen/java-gen-compilation-tests/src/main/proto/actions/simple_action_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/actions/simple_action_api.proto
@@ -14,31 +14,20 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.action2;
 
-option java_outer_classname = "EchoActionModel";
+// no java_multiple_files option, classes will be wrapped in outer class
+// no java_outer_classname option, will default to "SimpleActionApi"
 
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
-}
+message Request {}
+message Response {}
 
-message Hello {
-  string message = 1;
-}
+service AnotherSimpleAction {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ACTION
+  };
 
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
-
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+  rpc Method(Request) returns (Response);
 }

--- a/codegen/java-gen-compilation-tests/src/main/proto/actions/some_action.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/actions/some_action.proto
@@ -14,31 +14,20 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.action3;
 
-option java_outer_classname = "EchoActionModel";
+option java_multiple_files = true;
+// no java_outer_classname option, will default to "SomeActionOuterClass"
 
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
-}
+message Request {}
+message Response {}
 
-message Hello {
-  string message = 1;
-}
+service SomeAction {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ACTION
+  };
 
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
-
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+  rpc Method(Request) returns (Response);
 }

--- a/codegen/java-gen-compilation-tests/src/main/proto/actions/some_other_action_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/actions/some_other_action_api.proto
@@ -14,31 +14,20 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.action4;
 
-option java_outer_classname = "EchoActionModel";
+option java_multiple_files = true;
+// no java_outer_classname option, will default to "SomeOtherActionApi"
 
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
-}
+message Request {}
+message Response {}
 
-message Hello {
-  string message = 1;
-}
+service SomeOtherAction {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ACTION
+  };
 
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
-
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+  rpc Method(Request) returns (Response);
 }

--- a/codegen/java-gen-compilation-tests/src/main/proto/actions/yet_another_action.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/actions/yet_another_action.proto
@@ -14,31 +14,20 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.action5;
 
-option java_outer_classname = "EchoActionModel";
+option java_multiple_files = true;
+option java_outer_classname = "YetAnotherActionApi";
 
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
-}
+message Request {}
+message Response {}
 
-message Hello {
-  string message = 1;
-}
+service YetAnotherAction {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ACTION
+  };
 
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
-
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+  rpc Method(Request) returns (Response);
 }

--- a/codegen/java-gen-compilation-tests/src/main/proto/event-sourced-entities/some_event_sourced_entity_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/event-sourced-entities/some_event_sourced_entity_api.proto
@@ -14,31 +14,21 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.eventsourcedentity;
 
-option java_outer_classname = "EchoActionModel";
-
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
-}
+option java_multiple_files = true;
+// no java_outer_classname option, will default to "SomeEventSourcedEntityApi"
 
-message Hello {
-  string message = 1;
-}
+message Request {}
+message Response {}
 
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
+service SomeEventSourcedEntityService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "com.example.eventsourcedentity.domain.SomeEventSourcedEntity"
+  };
 
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+  rpc Method(Request) returns (Response);
 }

--- a/codegen/java-gen-compilation-tests/src/main/proto/event-sourced-entities/some_event_sourced_entity_domain.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/event-sourced-entities/some_event_sourced_entity_domain.proto
@@ -14,31 +14,24 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.eventsourcedentity.domain;
 
-option java_outer_classname = "EchoActionModel";
-
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
+option java_multiple_files = true;
+// no java_outer_classname option, will default to "SomeEventSourcedEntityDomain"
+
+option (akkaserverless.file).event_sourced_entity = {
+    name: "SomeEventSourcedEntity"
+    entity_type: "some-event-sourced-entity"
+    state: "SomeEventSourcedEntityState"
+    events: ["SomeEvent"]
+};
+
+message SomeEventSourcedEntityState {
+  string some_field = 1;
 }
 
-message Hello {
-  string message = 1;
-}
-
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
-
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+message SomeEvent {
+  string some_field = 1;
 }

--- a/codegen/java-gen-compilation-tests/src/main/proto/value-entities/some_value_entity_api.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/value-entities/some_value_entity_api.proto
@@ -14,31 +14,21 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.valueentity;
 
-option java_outer_classname = "EchoActionModel";
-
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
-}
+option java_multiple_files = true;
+// no java_outer_classname option, will default to "SomeValueEntityApi"
 
-message Hello {
-  string message = 1;
-}
+message Request {}
+message Response {}
 
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
+service SomeValueEntityService {
+  option (akkaserverless.service) = {
+    type: SERVICE_TYPE_ENTITY
+    component: "com.example.valueentity.domain.SomeValueEntity"
+  };
 
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+  rpc Method(Request) returns (Response);
 }

--- a/codegen/java-gen-compilation-tests/src/main/proto/value-entities/some_value_entity_domain.proto
+++ b/codegen/java-gen-compilation-tests/src/main/proto/value-entities/some_value_entity_domain.proto
@@ -14,31 +14,19 @@
 
 syntax = "proto3";
 
-package com.example;
+package com.example.valueentity.domain;
 
-option java_outer_classname = "EchoActionModel";
-
-import "google/protobuf/empty.proto";
 import "akkaserverless/annotations.proto";
-import "value-entities/user_api.proto";
 
-message Person {
-    string name = 1;
-}
+option java_multiple_files = true;
+// no java_outer_classname option, will default to "SomeValueEntityDomain"
 
-message Hello {
-  string message = 1;
-}
+option (akkaserverless.file).value_entity = {
+    name: "SomeValueEntity"
+    entity_type: "some-value-entity"
+    state: "SomeValueEntityState"
+};
 
-service EchoAction {
-    option (akkaserverless.service) = {
-      type : SERVICE_TYPE_ACTION
-    };
-    rpc SayHello(Person) returns (Hello) {
-    }
-
-    // example importing a type coming from another file
-    rpc Create(CreateUser) returns (google.protobuf.Empty){
-
-    }
+message SomeValueEntityState {
+  string some_field = 1;
 }

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGenerator.scala
@@ -160,8 +160,7 @@ object ReplicatedEntitySourceGenerator {
         "com.akkaserverless.javasdk.replicatedentity.ReplicatedEntityOptions",
         "com.akkaserverless.javasdk.replicatedentity.ReplicatedEntityProvider",
         "com.google.protobuf.Descriptors",
-        "java.util.function.Function") ++ relevantTypes.map(fqn =>
-        fqn.parent.javaPackage + "." + fqn.parent.javaOuterClassname)
+        "java.util.function.Function") ++ relevantTypes.map(_.descriptorImport)
         ++ extraImports(entity.data) ++ extraTypeImports(entity.data.typeArguments))
 
     val parameterizedDataType = entity.data.name + parameterizeDataType(entity.data)

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
@@ -66,8 +66,6 @@ object SourceGenerator {
       generatedTestSourceDirectory: Path,
       mainClass: String)(implicit log: Log): Iterable[Path] = {
 
-    validate(model)
-
     val (mainClassPackageName, mainClassName) = disassembleClassName(mainClass)
 
     model.services.values.flatMap {
@@ -136,26 +134,6 @@ object SourceGenerator {
         List(akkaServerlessFactorySourcePath)
       }
     }
-  }
-
-  private def validate(model: ModelBuilder.Model): Unit = {
-    // at least for now we don't support java_multiple_files=true and java_outer_classname is required
-    def validate(pkgNaming: PackageNaming): List[String] = {
-      var errors = List.empty[String]
-      if (pkgNaming.javaOuterClassnameOption.isEmpty)
-        errors = s"${pkgNaming.protoFileName} must define java_outer_classname" :: errors
-      if (pkgNaming.javaMultipleFiles)
-        errors = s"${pkgNaming.protoFileName} must not enable java_multiple_files" :: errors
-      errors
-    }
-
-    val invalid =
-      model.services.values.flatMap(service => validate(service.fqn.parent)) ++
-      model.entities.values.flatMap(service => validate(service.fqn.parent))
-
-    if (invalid.nonEmpty)
-      throw new IllegalArgumentException(s"Validation errors of Protobuf model: ${invalid.mkString(", ")}")
-
   }
 
   def generate(

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGenerator.scala
@@ -81,10 +81,8 @@ object ValueEntityTestKitGenerator {
         "com.akkaserverless.javasdk.testkit.impl.TestKitValueEntityContext",
         "java.util.function.Function"))
 
-    val domainClassName = entity.fqn.parent.javaOuterClassname
     val entityClassName = entity.fqn.name
-    val entityStateName = entity.state.fqn.name
-    val stateClassName = s"${domainClassName}.${entityStateName}"
+    val stateClassName = entity.state.fqn.fullName
 
     val testkitClassName = s"${entityClassName}TestKit"
 
@@ -150,20 +148,19 @@ object ValueEntityTestKitGenerator {
   }
 
   def generateServices(service: ModelBuilder.EntityService): String = {
-    val apiClassName = service.fqn.parent.javaOuterClassname
 
     def selectOutput(command: ModelBuilder.Command): String =
       if (command.outputType.name == "Empty") {
         "Empty"
       } else {
-        apiClassName + "." + command.outputType.name
+        command.outputType.fullName
       }
 
     service.commands
       .map { command =>
         val output = selectOutput(command)
         s"""|public ValueEntityResult<$output> ${lowerFirst(
-          command.fqn.name)}(${apiClassName}.${command.inputType.name} ${lowerFirst(command.inputType.name)}) {
+          command.fqn.name)}(${command.inputType.fullName} ${lowerFirst(command.inputType.name)}) {
        |  ValueEntity.Effect<$output> effect = entity.${lowerFirst(command.fqn.name)}(state, ${lowerFirst(
           command.inputType.name)});
        |  return interpretEffects(effect);


### PR DESCRIPTION
Fixes #239 and follow-up to #396.

Code generation now takes into account what the generated outer class will be, with or without the `java_outer_classname` option, and whether generated classes will be wrapped or not based on `java_multiple_files`. Add some compilation tests — add all variations for actions, and a multiple files + default outer class for event sourced and value entities.