### PR TITLE
fix: syntax renamed to Format

### DIFF
--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Format.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Format.scala
@@ -16,7 +16,7 @@
 
 package com.lightbend.akkasls.codegen
 
-object Syntax {
+object Format {
 
   val break = "\n"
 
@@ -24,7 +24,7 @@ object Syntax {
     indent(lines.mkString(break), num)
 
   /*
-   * Be mindful that `Syntax.indent` does not indent the first line,
+   * Be mindful that `Format.indent` does not indent the first line,
    * so the invocation itself needs to be indented as required.
    *
    * Empty lines are not indented either.

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionServiceSourceGenerator.scala
@@ -154,7 +154,7 @@ object ActionServiceSourceGenerator {
         |
         |  public $className(ActionCreationContext creationContext) {}
         |
-        |  ${Syntax.indent(methods, 2)}
+        |  ${Format.indent(methods, 2)}
         |}
         |""".stripMargin
   }
@@ -203,7 +203,7 @@ object ActionServiceSourceGenerator {
         |/** An action. */
         |public abstract class ${service.interfaceName} extends Action {
         |
-        |  ${Syntax.indent(methods, 2)}
+        |  ${Format.indent(methods, 2)}
         |}""".stripMargin
   }
 
@@ -277,7 +277,7 @@ object ActionServiceSourceGenerator {
         |  @Override
         |  public Action.Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
         |    switch (commandName) {
-        |      ${Syntax.indent(unaryCases, 6)}
+        |      ${Format.indent(unaryCases, 6)}
         |      default:
         |        throw new ActionHandler.HandlerNotFound(commandName);
         |    }
@@ -286,7 +286,7 @@ object ActionServiceSourceGenerator {
         |  @Override
         |  public Source<Action.Effect<?>, NotUsed> handleStreamedOut(String commandName, MessageEnvelope<Object> message) {
         |    switch (commandName) {
-        |      ${Syntax.indent(streamOutCases, 6)}
+        |      ${Format.indent(streamOutCases, 6)}
         |      default:
         |        throw new ActionHandler.HandlerNotFound(commandName);
         |    }
@@ -295,7 +295,7 @@ object ActionServiceSourceGenerator {
         |  @Override
         |  public Action.Effect<?> handleStreamedIn(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
         |    switch (commandName) {
-        |      ${Syntax.indent(streamInCases, 6)}
+        |      ${Format.indent(streamInCases, 6)}
         |      default:
         |        throw new ActionHandler.HandlerNotFound(commandName);
         |    }
@@ -304,7 +304,7 @@ object ActionServiceSourceGenerator {
         |  @Override
         |  public Source<Action.Effect<?>, NotUsed> handleStreamed(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
         |    switch (commandName) {
-        |      ${Syntax.indent(streamInOutCases, 6)}
+        |      ${Format.indent(streamInOutCases, 6)}
         |      default:
         |        throw new ActionHandler.HandlerNotFound(commandName);
         |    }
@@ -385,7 +385,7 @@ object ActionServiceSourceGenerator {
       |  @Override
       |  public final Descriptors.FileDescriptor[] additionalDescriptors() {
       |    return new Descriptors.FileDescriptor[] {
-      |      ${Syntax.indent(descriptors.mkString(",\n"), 6)}
+      |      ${Format.indent(descriptors.mkString(",\n"), 6)}
       |    };
       |  }
       |

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
@@ -198,7 +198,7 @@ object EntityServiceSourceGenerator {
         |
         |  @Override
         |  public $stateType handleEvent($stateType state, Object event) {
-        |    ${Syntax.indent(eventCases, 4)}
+        |    ${Format.indent(eventCases, 4)}
         |  }
         |
         |  @Override
@@ -206,7 +206,7 @@ object EntityServiceSourceGenerator {
         |      String commandName, $stateType state, Object command, CommandContext context) {
         |    switch (commandName) {
         |
-        |      ${Syntax.indent(commandCases, 6)}
+        |      ${Format.indent(commandCases, 6)}
         |
         |      default:
         |        throw new EventSourcedEntityHandler.CommandHandlerNotFound(commandName);
@@ -298,7 +298,7 @@ object EntityServiceSourceGenerator {
         |  @Override
         |  public final Descriptors.FileDescriptor[] additionalDescriptors() {
         |    return new Descriptors.FileDescriptor[] {
-        |      ${Syntax.indent(descriptors.mkString(",\n"), 6)}
+        |      ${Format.indent(descriptors.mkString(",\n"), 6)}
         |    };
         |  }
         |}
@@ -368,9 +368,9 @@ object EntityServiceSourceGenerator {
        |    throw new UnsupportedOperationException("Not implemented yet, replace with your empty entity state");
        |  }
        |
-       |  ${Syntax.indent(commandHandlers, num = 2)}
+       |  ${Format.indent(commandHandlers, num = 2)}
        |
-       |  ${Syntax.indent(eventHandlers, num = 2)}
+       |  ${Format.indent(eventHandlers, num = 2)}
        |
        |}
        |""".stripMargin
@@ -453,9 +453,9 @@ object EntityServiceSourceGenerator {
         |/** An event sourced entity. */
         |public abstract class Abstract${className} extends EventSourcedEntity<${qualifiedType(entity.state.fqn)}> {
         |
-        |  ${Syntax.indent(commandHandlers, num = 2)}
+        |  ${Format.indent(commandHandlers, num = 2)}
         |
-        |  ${Syntax.indent(eventHandlers, num = 2)}
+        |  ${Format.indent(eventHandlers, num = 2)}
         |
         |}""".stripMargin
   }
@@ -531,7 +531,7 @@ object EntityServiceSourceGenerator {
       |    client = ${serviceName}Client.create(testkit.getGrpcClientSettings(), testkit.getActorSystem());
       |  }
       |
-      |  ${Syntax.indent(testCases, num = 2)}
+      |  ${Format.indent(testCases, num = 2)}
       |}
       |""".stripMargin
   }

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntityTestKitGenerator.scala
@@ -136,7 +136,7 @@ object EventSourcedEntityTestKitGenerator {
           |  }
           |
           |  private $stateClassName handleEvent($stateClassName state, Object event) {
-          |    ${Syntax.indent(generateHandleEvents(entity.events), 4)}
+          |    ${Format.indent(generateHandleEvents(entity.events), 4)}
           |  }
           |
           |  private <Reply> EventSourcedResult<Reply> interpretEffects(EventSourcedEntity.Effect<Reply> effect) {
@@ -148,7 +148,7 @@ object EventSourcedEntityTestKitGenerator {
           |    return new EventSourcedResultImpl(effect, state);
           |  }
           |
-          |  ${Syntax.indent(generateServices(service), 2)}
+          |  ${Format.indent(generateServices(service), 2)}
           |}
           |""".stripMargin
   }
@@ -254,7 +254,7 @@ object EventSourcedEntityTestKitGenerator {
       |    // assertEquals(expectedResponse, actualResponse);
       |  }
       |
-      |  ${Syntax.indent(dummyTestCases, 2)}
+      |  ${Format.indent(dummyTestCases, 2)}
       |
       |}
       |""".stripMargin

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGenerator.scala
@@ -17,7 +17,7 @@
 package com.lightbend.akkasls.codegen.java
 
 import com.lightbend.akkasls.codegen.ModelBuilder
-import com.lightbend.akkasls.codegen.Syntax
+import com.lightbend.akkasls.codegen.Format
 
 object ReplicatedEntitySourceGenerator {
   import SourceGenerator._
@@ -75,7 +75,7 @@ object ReplicatedEntitySourceGenerator {
         |    this.entityId = context.entityId();
         |  }
         |$emptyValue
-        |  ${Syntax.indent(methods, num = 2)}
+        |  ${Format.indent(methods, num = 2)}
         |}
         |""".stripMargin
   }
@@ -127,7 +127,7 @@ object ReplicatedEntitySourceGenerator {
         |      String commandName, $parameterizedDataType data, Object command, CommandContext context) {
         |    switch (commandName) {
         |
-        |      ${Syntax.indent(commandCases, 6)}
+        |      ${Format.indent(commandCases, 6)}
         |
         |      default:
         |        throw new ReplicatedEntityHandler.CommandHandlerNotFound(commandName);
@@ -225,7 +225,7 @@ object ReplicatedEntitySourceGenerator {
         |  @Override
         |  public final Descriptors.FileDescriptor[] additionalDescriptors() {
         |    return new Descriptors.FileDescriptor[] {
-        |      ${Syntax.indent(descriptors.mkString(",\n"), 6)}
+        |      ${Format.indent(descriptors.mkString(",\n"), 6)}
         |    };
         |  }
         |}
@@ -272,7 +272,7 @@ object ReplicatedEntitySourceGenerator {
         |/** A replicated entity. */
         |public abstract class Abstract$className extends $baseClass$typeArguments {
         |
-        |  ${Syntax.indent(methods, 2)}
+        |  ${Format.indent(methods, 2)}
         |
         |}
         |""".stripMargin

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/SourceGenerator.scala
@@ -307,7 +307,7 @@ object SourceGenerator {
         |      ${creatorParameters.mkString(",\n      ")}) {
         |    AkkaServerless akkaServerless = new AkkaServerless();
         |    return akkaServerless
-        |      ${Syntax.indent(registrations, 6)};
+        |      ${Format.indent(registrations, 6)};
         |  }
         |}
         |""".stripMargin

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
@@ -17,7 +17,7 @@
 package com.lightbend.akkasls.codegen.java
 
 import com.lightbend.akkasls.codegen.ModelBuilder
-import com.lightbend.akkasls.codegen.Syntax
+import com.lightbend.akkasls.codegen.Format
 
 object ValueEntitySourceGenerator {
   import SourceGenerator._
@@ -68,7 +68,7 @@ object ValueEntitySourceGenerator {
         |    throw new UnsupportedOperationException("Not implemented yet, replace with your empty entity state");
         |  }
         |
-        |  ${Syntax.indent(methods, num = 2)}
+        |  ${Format.indent(methods, num = 2)}
         |}
         |""".stripMargin
   }
@@ -119,7 +119,7 @@ object ValueEntitySourceGenerator {
         |      String commandName, $stateType state, Object command, CommandContext context) {
         |    switch (commandName) {
         |
-        |      ${Syntax.indent(commandCases, 6)}
+        |      ${Format.indent(commandCases, 6)}
         |
         |      default:
         |        throw new ValueEntityHandler.CommandHandlerNotFound(commandName);
@@ -212,7 +212,7 @@ object ValueEntitySourceGenerator {
         |  @Override
         |  public final Descriptors.FileDescriptor[] additionalDescriptors() {
         |    return new Descriptors.FileDescriptor[] {
-        |      ${Syntax.indent(descriptors.mkString(",\n"), 6)}
+        |      ${Format.indent(descriptors.mkString(",\n"), 6)}
         |    };
         |  }
         |}
@@ -256,7 +256,7 @@ object ValueEntitySourceGenerator {
         |/** A value entity. */
         |public abstract class Abstract$className extends ValueEntity<$stateType> {
         |
-        |  ${Syntax.indent(methods, 2)}
+        |  ${Format.indent(methods, 2)}
         |
         |}
         |""".stripMargin

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGenerator.scala
@@ -18,7 +18,7 @@ package com.lightbend.akkasls.codegen.java
 
 import com.google.common.base.Charsets
 import com.lightbend.akkasls.codegen.ModelBuilder
-import com.lightbend.akkasls.codegen.Syntax
+import com.lightbend.akkasls.codegen.Format
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -138,7 +138,7 @@ object ValueEntityTestKitGenerator {
        |    return result;
        |  }
        |
-       |  ${Syntax.indent(generateServices(service), 2)}
+       |  ${Format.indent(generateServices(service), 2)}
        |}
        |""".stripMargin
   }
@@ -218,7 +218,7 @@ object ValueEntityTestKitGenerator {
        |    // assertEquals(expectedState, testKit.getState());
        |  }
        |
-       |  ${Syntax.indent(dummyTestCases, 2)}
+       |  ${Format.indent(dummyTestCases, 2)}
        |
        |}
        |""".stripMargin

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGenerator.scala
@@ -113,7 +113,7 @@ object ViewServiceSourceGenerator {
         |      Object event) {
         |
         |    switch (eventName) {
-        |      ${Syntax.indent(cases, 6)}
+        |      ${Format.indent(cases, 6)}
         |
         |      default:
         |        throw new UpdateHandlerNotFound(eventName);
@@ -227,7 +227,7 @@ object ViewServiceSourceGenerator {
        |
        |  public ${view.className}(ViewContext context) {}
        |$emptyState
-       |  ${Syntax.indent(handlers, 2)}
+       |  ${Format.indent(handlers, 2)}
        |}
        |""".stripMargin
   }
@@ -260,7 +260,7 @@ object ViewServiceSourceGenerator {
       |
       |public abstract class ${view.abstractViewName} extends View<${qualifiedType(view.state.fqn)}> {
       |$emptyState
-      |  ${Syntax.indent(handlers, 2)}
+      |  ${Format.indent(handlers, 2)}
       |}
       |""".stripMargin
   }

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/FormatSpec.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/FormatSpec.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import com.lightbend.akkasls.codegen.Syntax
+import com.lightbend.akkasls.codegen.Format
 
-class SyntaxSpec extends munit.FunSuite {
+class FormatSpec extends munit.FunSuite {
 
   test("indenting should leave alone the first line") {
 
@@ -28,7 +28,7 @@ class SyntaxSpec extends munit.FunSuite {
       s"""
         |a
         |
-        |  ${Syntax.indent(method, 2)}
+        |  ${Format.indent(method, 2)}
         |b
         """.stripMargin
 


### PR DESCRIPTION
Syntax was a bad name that I picked back in the time. This PR change it to Format. 

Not urgent. I can rebase later when we finish the round of changes we are doing.