### PR TITLE
fix: camelCase toJavaSdk

### DIFF
--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/view/ViewAdapter.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/view/ViewAdapter.scala
@@ -64,7 +64,7 @@ private[scalasdk] class Scala2JavaViewHandlerAdapter[S](
 
   override def handleUpdate(commandName: String, state: S, event: Any): javasdk.view.View.UpdateEffect[S] = {
     scalasdkHandler.handleUpdate(commandName, state, event) match {
-      case effect: ViewUpdateEffectImpl.PrimaryUpdateEffect[S] => effect.toJavasdk
+      case effect: ViewUpdateEffectImpl.PrimaryUpdateEffect[S] => effect.toJavaSdk
     }
   }
 }

--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/view/ViewUpdateEffectImpl.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/view/ViewUpdateEffectImpl.scala
@@ -21,22 +21,22 @@ import com.akkaserverless.scalasdk.view.View
 
 private[scalasdk] object ViewUpdateEffectImpl {
   sealed trait PrimaryUpdateEffect[S] extends View.UpdateEffect[S] {
-    def toJavasdk: javasdk.impl.view.ViewUpdateEffectImpl.PrimaryUpdateEffect[S]
+    def toJavaSdk: javasdk.impl.view.ViewUpdateEffectImpl.PrimaryUpdateEffect[S]
   }
 
   case class Update[S](state: S) extends PrimaryUpdateEffect[S] {
-    override def toJavasdk =
+    override def toJavaSdk =
       javasdk.impl.view.ViewUpdateEffectImpl.Update(state)
   }
 
   case object Ignore extends PrimaryUpdateEffect[Nothing] {
-    override def toJavasdk =
+    override def toJavaSdk =
       javasdk.impl.view.ViewUpdateEffectImpl.Ignore
         .asInstanceOf[javasdk.impl.view.ViewUpdateEffectImpl.PrimaryUpdateEffect[Nothing]]
   }
 
   case class Error[T](description: String) extends PrimaryUpdateEffect[T] {
-    override def toJavasdk =
+    override def toJavaSdk =
       javasdk.impl.view.ViewUpdateEffectImpl.Error(description)
   }
 }


### PR DESCRIPTION
Found this minor thing. 

I'm calling it `toJavaSdk` on the Actions PR. Fixing for Views in separate PR though.