### PR TITLE
fix: simplify running locally

### DIFF
--- a/docs/src/modules/java/pages/quickstart-java-maven.adoc
+++ b/docs/src/modules/java/pages/quickstart-java-maven.adoc
@@ -184,30 +184,22 @@ You can run your service locally for manual testing via HTTP or gRPC requests. T
 
 To start the proxy, run the following command from the project directory:
 
-[.tabset]
-MacOS, Windows::
-+
 --
 [source,bash]
 ----
 docker compose up
 ----
---
-Linux::
-+
---
+
 NOTE: On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007), or for a `USER_FUNCTION_HOST` environment variable to be set manually.
 [source,bash]
-----
-docker compose -f docker-compose.yml -f docker-compose.linux.yml up
-----
+
 --
 
 Use the `exec-maven-plugin` to start the application locally with the following command:
 
 [source,bash]
 ----
-mvn compile exec:java
+mvn compile exec:exec
 ----
 
 == Deploy to Akka Serverless

--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -24,7 +24,6 @@
                 <include>.gitignore</include>
                 <include>README.md</include>
                 <include>docker-compose.yml</include>
-                <include>docker-compose.linux.yml</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
@@ -29,25 +29,17 @@ In order to run your application locally, you must run the Akka Serverless proxy
 It also contains the configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to.
 To start the proxy, run the following command from this directory:
 
-### macOS and Windows
-
 ```
 docker-compose up
 ```
 
-### Linux
-
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
-
-```
-docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
 
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
 ```
-mvn compile exec:java
+mvn compile exec:exec
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://developer.lightbend.com/docs/akka-serverless/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:

--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.linux.yml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
-#[[      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
-      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}]]#
+      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
+      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
+#[[      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
-      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator ]]#
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -183,12 +183,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${D}{mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${D}{mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -24,7 +24,6 @@
                 <include>.gitignore</include>
                 <include>README.md</include>
                 <include>docker-compose.yml</include>
-                <include>docker-compose.linux.yml</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
@@ -29,25 +29,17 @@ In order to run your application locally, you must run the Akka Serverless proxy
 It also contains the configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to.
 To start the proxy, run the following command from this directory:
 
-### macOS and Windows
-
 ```
 docker-compose up
 ```
 
-### Linux
-
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
-
-```
-docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
 
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
 ```
-mvn compile exec:java
+mvn compile exec:exec
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://developer.lightbend.com/docs/akka-serverless/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.linux.yml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
-#[[      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
-      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}]]#
+      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
+      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
+#[[      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
-      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator ]]#
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -168,12 +168,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${D}{mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${D}{mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-customer-registry-quickstart/README.md
+++ b/samples/java-customer-registry-quickstart/README.md
@@ -30,23 +30,17 @@ To run the example locally, you must run the Akka Serverless proxy. The included
 It also contains the configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to.
 To start the proxy, run the following command from this directory:
 
-
 ```
 docker-compose up
 ```
 
-
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
-
-```
-docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
 
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
 ```
-mvn compile exec:java
+mvn compile exec:exec
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://developer.lightbend.com/docs/akka-serverless/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:

--- a/samples/java-customer-registry-quickstart/docker-compose.linux.yml
+++ b/samples/java-customer-registry-quickstart/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-customer-registry-quickstart/docker-compose.yml
+++ b/samples/java-customer-registry-quickstart/docker-compose.yml
@@ -1,13 +1,16 @@
 version: "3"
 services:
   akka-serverless-proxy:
-    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.14
+    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.0-beta.19
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-customer-registry-quickstart/pom.xml
+++ b/samples/java-customer-registry-quickstart/pom.xml
@@ -166,12 +166,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-doc-snippets/pom.xml
+++ b/samples/java-doc-snippets/pom.xml
@@ -168,12 +168,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-eventsourced-counter/README.md
+++ b/samples/java-eventsourced-counter/README.md
@@ -29,39 +29,33 @@ In order to run your application locally, you must run the Akka Serverless proxy
 It also contains the configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to.
 To start the proxy, run the following command from this directory:
 
-
 ```
 docker-compose up
 ```
 
-
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
-
-```
-docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
 
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
 ```
-mvn compile exec:java
+mvn compile exec:exec
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://developer.lightbend.com/docs/akka-serverless/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
-```
-> curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.MyServiceEntity/GetValue -d '{"entityId": "foo"}'
-The command handler for `GetValue` is not implemented, yet
+```shell
+> curl -XPOST -H "Content-Type: application/json" localhost:9000/com.example.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'        
+{"value":0}
 ```
 
 For example, using [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 
 ```shell
-> grpcurl -plaintext -d '{"entityId": "foo"}' localhost:9000 com.example.MyServiceEntity/GetValue
-ERROR:
-  Code: Unknown
-  Message: The command handler for `GetValue` is not implemented, yet
+> grpcurl -plaintext -d '{"counterId": "foo"}' localhost:9000 com.example.CounterService/GetCurrentCounter
+{
+  
+}
 ```
 
 > Note: The failure is to be expected if you have not yet provided an implementation of `GetValue` in

--- a/samples/java-eventsourced-counter/docker-compose.linux.yml
+++ b/samples/java-eventsourced-counter/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-eventsourced-counter/docker-compose.yml
+++ b/samples/java-eventsourced-counter/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-eventsourced-counter/pom.xml
+++ b/samples/java-eventsourced-counter/pom.xml
@@ -168,13 +168,22 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <mainClass>${mainClass}</mainClass>
-        </configuration>
+       <configuration>
+         <executable>java</executable>
+         <arguments>
+           <argument>-classpath</argument>
+           <classpath/>
+           <argument>${mainClass}</argument>
+         </arguments>
+         <environmentVariables>
+           <!-- needed for the proxy to access the user function on all platforms -->
+           <HOST>0.0.0.0</HOST>
+         </environmentVariables>
+       </configuration>
       </plugin>
 
       <plugin>

--- a/samples/java-eventsourced-customer-registry/pom.xml
+++ b/samples/java-eventsourced-customer-registry/pom.xml
@@ -168,12 +168,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-eventsourced-shopping-cart/README.md
+++ b/samples/java-eventsourced-shopping-cart/README.md
@@ -22,24 +22,19 @@ mvn compile
 
 In order to run your application locally, you must run the Akka Serverless proxy. The included `docker-compose` file
 contains the configuration required to run the proxy for a locally running application. It also contains the
-configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to. To start the
-proxy, run the following command from this directory:
+configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to. To start the proxy, run the following command from this directory:
 
-```shell
+```
 docker-compose up
 ```
 
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
 
-```shell
-docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
-
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
-```shell
-mvn compile exec:java
+```
+mvn compile exec:exec
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.

--- a/samples/java-eventsourced-shopping-cart/docker-compose.linux.yml
+++ b/samples/java-eventsourced-shopping-cart/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/java-eventsourced-shopping-cart/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-eventsourced-shopping-cart/pom.xml
@@ -187,12 +187,21 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>java</goal>
+                            <goal>exec</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
-                    <mainClass>${mainClass}</mainClass>
+                    <executable>java</executable>
+                    <arguments>
+                        <argument>-classpath</argument>
+                        <classpath/>
+                        <argument>${mainClass}</argument>
+                    </arguments>
+                    <environmentVariables>
+                        <!-- needed for the proxy to access the user function on all platforms -->
+                        <HOST>0.0.0.0</HOST>
+                    </environmentVariables>
                 </configuration>
             </plugin>
 

--- a/samples/java-fibonacci-action/README.md
+++ b/samples/java-fibonacci-action/README.md
@@ -25,22 +25,17 @@ In order to run your application locally, you must run the Akka Serverless proxy
 It also contains the configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to.
 To start the proxy, run the following command from this directory:
 
-
-```shell
-docker compose up
+```
+docker-compose up
 ```
 
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
 
-```shell
-docker compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
-
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
-```shell
-mvn compile exec:java
+```
+mvn compile exec:exec
 ```
 
 For further details see [Running a service locally](https://developer.lightbend.com/docs/akka-serverless/developing/running-service-locally.html) in the documentation.

--- a/samples/java-fibonacci-action/docker-compose.linux.yml
+++ b/samples/java-fibonacci-action/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-fibonacci-action/docker-compose.yml
+++ b/samples/java-fibonacci-action/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-fibonacci-action/pom.xml
+++ b/samples/java-fibonacci-action/pom.xml
@@ -168,12 +168,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-first-service/README.md
+++ b/samples/java-first-service/README.md
@@ -29,23 +29,18 @@ In order to run your application locally, you must run the Akka Serverless proxy
 It also contains the configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to.
 To start the proxy, run the following command from this directory:
 
-
 ```
 docker-compose up
 ```
 
-
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
-
-```
-docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
 
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
 ```
-mvn compile exec:java
+mvn compile exec:exec
+```ile exec:java
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://developer.lightbend.com/docs/akka-serverless/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:

--- a/samples/java-first-service/docker-compose.linux.yml
+++ b/samples/java-first-service/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-first-service/docker-compose.yml
+++ b/samples/java-first-service/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-first-service/pom.xml
+++ b/samples/java-first-service/pom.xml
@@ -168,12 +168,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-replicatedentity-examples/docker-compose.linux.yml
+++ b/samples/java-replicatedentity-examples/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-replicatedentity-examples/docker-compose.yml
+++ b/samples/java-replicatedentity-examples/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-replicatedentity-examples/pom.xml
+++ b/samples/java-replicatedentity-examples/pom.xml
@@ -166,12 +166,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-replicatedentity-shopping-cart/README.md
+++ b/samples/java-replicatedentity-shopping-cart/README.md
@@ -21,24 +21,19 @@ mvn compile
 
 In order to run your application locally, you must run the Akka Serverless proxy. The included `docker-compose` file
 contains the configuration required to run the proxy for a locally running application. It also contains the
-configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to. To start the
-proxy, run the following command from this directory:
+configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to. To start the proxy, run the following command from this directory:
 
-```shell
+```
 docker-compose up
 ```
 
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
 
-```shell
-docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
-
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
-```shell
-mvn compile exec:java
+```
+mvn compile exec:exec
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.

--- a/samples/java-replicatedentity-shopping-cart/docker-compose.linux.yml
+++ b/samples/java-replicatedentity-shopping-cart/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-replicatedentity-shopping-cart/docker-compose.yml
+++ b/samples/java-replicatedentity-shopping-cart/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-replicatedentity-shopping-cart/pom.xml
@@ -166,12 +166,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-valueentity-counter/README.md
+++ b/samples/java-valueentity-counter/README.md
@@ -39,22 +39,17 @@ In order to run your application locally, you must run the Akka Serverless proxy
 It also contains the configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to.
 To start the proxy, run the following command from this directory:
 
-
-```shell
-docker compose up
+```
+docker-compose up
 ```
 
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
 
-```shell
-docker compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
-
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
-```shell
-mvn compile exec:java
+```
+mvn compile exec:exec
 ```
 
 For further details see [Running a service locally](https://developer.lightbend.com/docs/akka-serverless/developing/running-service-locally.html) in the documentation.

--- a/samples/java-valueentity-counter/docker-compose.linux.yml
+++ b/samples/java-valueentity-counter/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-valueentity-counter/docker-compose.yml
+++ b/samples/java-valueentity-counter/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-valueentity-counter/pom.xml
+++ b/samples/java-valueentity-counter/pom.xml
@@ -179,12 +179,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-valueentity-customer-registry/docker-compose.linux.yml
+++ b/samples/java-valueentity-customer-registry/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-valueentity-customer-registry/docker-compose.yml
+++ b/samples/java-valueentity-customer-registry/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-valueentity-customer-registry/pom.xml
+++ b/samples/java-valueentity-customer-registry/pom.xml
@@ -168,12 +168,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/samples/java-valueentity-shopping-cart/README.md
+++ b/samples/java-valueentity-shopping-cart/README.md
@@ -22,24 +22,19 @@ mvn compile
 
 In order to run your application locally, you must run the Akka Serverless proxy. The included `docker-compose` file
 contains the configuration required to run the proxy for a locally running application. It also contains the
-configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to. To start the
-proxy, run the following command from this directory:
+configuration to start a local Google Pub/Sub emulator that the Akka Serverless proxy will connect to. To start the proxy, run the following command from this directory:
 
-```shell
+```
 docker-compose up
 ```
 
 > On Linux this requires Docker 20.10 or later (https://github.com/moby/moby/pull/40007),
 > or for a `USER_FUNCTION_HOST` environment variable to be set manually.
 
-```shell
-docker-compose -f docker-compose.yml -f docker-compose.linux.yml up
-```
-
 To start the application locally, the `exec-maven-plugin` is used. Use the following command:
 
-```shell
-mvn compile exec:java
+```
+mvn compile exec:exec
 ```
 
 With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`.

--- a/samples/java-valueentity-shopping-cart/docker-compose.linux.yml
+++ b/samples/java-valueentity-shopping-cart/docker-compose.linux.yml
@@ -1,5 +1,0 @@
-version: "3"
-services:
-  akka-serverless-proxy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"

--- a/samples/java-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/java-valueentity-shopping-cart/docker-compose.yml
@@ -5,9 +5,12 @@ services:
     command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/samples/java-valueentity-shopping-cart/pom.xml
+++ b/samples/java-valueentity-shopping-cart/pom.xml
@@ -169,12 +169,21 @@
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <mainClass>${mainClass}</mainClass>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>${mainClass}</argument>
+          </arguments>
+          <environmentVariables>
+            <!-- needed for the proxy to access the user function on all platforms -->
+            <HOST>0.0.0.0</HOST>
+          </environmentVariables>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Refs #388
Refs lightbend/akkaserverless-framework#581

Changes:
 * Use `exec:exec` to run to be able to set `HOST` to `0.0.0.0` from `pom.xml` when running locally, in all samples and archetypes, to allow proxy in local docker connecting on all platform
 * Set `PUBSUB_EMULATOR_HOST` in `docker-compose.yml` to make pub sub emulator work on all platforms
 * Include additional `extra_host` needed for Linux in the shared `docker-compose.yml` and get rid of the Linux specific one