### PR TITLE
feat(codegen-scala): use package imports

### DIFF
--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
@@ -152,12 +152,15 @@ object TestData {
       ModelBuilder.State(FullyQualifiedName("MyState", domainProto(suffix))),
       List(ModelBuilder.Event(FullyQualifiedName("SetEvent", domainProto(suffix)))))
 
-  def valueEntity(suffix: String = ""): ModelBuilder.ValueEntity =
+  def valueEntity(): ModelBuilder.ValueEntity = valueEntity("")
+  def valueEntity(suffix: String): ModelBuilder.ValueEntity =
+    valueEntity(domainProto(suffix), suffix)
+  def valueEntity(parent: PackageNaming, suffix: String = ""): ModelBuilder.ValueEntity =
     ModelBuilder.ValueEntity(
-      domainProto(suffix).pkg + s"MyValueEntity$suffix",
-      FullyQualifiedName(s"MyValueEntity$suffix", domainProto(suffix)),
+      parent.pkg + s"MyValueEntity$suffix",
+      FullyQualifiedName(s"MyValueEntity$suffix", parent),
       s"MyValueEntity$suffix",
-      ModelBuilder.State(FullyQualifiedName("MyState", domainProto(suffix))))
+      ModelBuilder.State(FullyQualifiedName("MyState", parent)))
 
   def replicatedEntity(data: ModelBuilder.ReplicatedData, suffix: String = ""): ModelBuilder.ReplicatedEntity =
     ModelBuilder.ReplicatedEntity(

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/FullyQualifiedNameExtractor.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/FullyQualifiedNameExtractor.scala
@@ -48,7 +48,7 @@ class FullyQualifiedNameExtractor(val di: DescriptorImplicits) extends ModelBuil
       None,
       None,
       None,
-      false)
+      javaMultipleFiles = false)
   }
 }
 object FullyQualifiedNameExtractor {

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ValueEntitySourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ValueEntitySourceGenerator.scala
@@ -24,7 +24,7 @@ object ValueEntitySourceGenerator {
   import com.lightbend.akkasls.codegen.SourceGeneratorUtils._
 
   def generateImplementationSkeleton(entity: ModelBuilder.ValueEntity, service: ModelBuilder.EntityService): File = {
-    val imports =
+    implicit val imports =
       generateImports(
         Seq(entity.state.fqn) ++
         service.commands.map(_.inputType) ++
@@ -36,13 +36,8 @@ object ValueEntitySourceGenerator {
 
     val methods = service.commands.map { cmd =>
       // TODO 'override', use 'effect' for output, use actual state type for state
-      s"""|def ${lowerFirst(cmd.name)}(currentState: ${typeName(
-        entity.state.fqn,
-        entity.fqn.parent,
-        imports)}, command: ${typeName(cmd.inputType, entity.fqn.parent, imports)}): ${typeName(
-        cmd.outputType,
-        entity.fqn.parent,
-        imports)} = ???
+      s"""|def ${lowerFirst(cmd.name)}(currentState: ${typeName(entity.state.fqn)}, command: ${typeName(
+        cmd.inputType)}): ${typeName(cmd.outputType)} = ???
           |""".stripMargin
     }
 

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
@@ -17,28 +17,30 @@
 package com.akkaserverless.codegen.scalasdk
 
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
-import com.lightbend.akkasls.codegen.TestData
+import com.lightbend.akkasls.codegen.{ PackageNaming, TestData }
 import protocgen.CodeGenRequest
 import scalapb.compiler.{ DescriptorImplicits, GeneratorParams }
 
 class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
   import com.akkaserverless.codegen.scalasdk.impl.ValueEntitySourceGenerator._
 
+  val domainParent = PackageNaming("domain.proto", "", "com.example.service.domain", None, None, None, false)
+  val apiParent = PackageNaming("api.proto", "", "com.example.service", None, None, None, false)
+
   test("it can generate a value entity implementation skeleton") {
-    val file = generateImplementationSkeleton(TestData.valueEntity(), TestData.simpleEntityService())
+    val file =
+      generateImplementationSkeleton(TestData.valueEntity(domainParent), TestData.simpleEntityService(apiParent))
     assertNoDiff(
       file.content,
       s"""package com.example.service.domain
          |
-         |import com.example.service.GetValue
-         |import com.example.service.MyState
-         |import com.example.service.SetValue
+         |import com.example.service
          |import com.external.Empty
          |
          |class MyValueEntity /* extends AbstractMyValueEntity */ {
-         |  def set(currentState: com.example.service.domain.MyState, command: SetValue): Empty = ???
+         |  def set(currentState: MyState, command: service.SetValue): Empty = ???
          |
-         |  def get(currentState: com.example.service.domain.MyState, command: GetValue): MyState = ???
+         |  def get(currentState: MyState, command: service.GetValue): service.MyState = ???
          |}
          |""".stripMargin)
   }


### PR DESCRIPTION
To make code nicer to read without introducing naming conflicts for the
common case where domain and API contain the same names.

Adding this structure could hopefully also help with detecting and avoiding
conflicts later (#327).