### PR TITLE
fix(codegen-scala): correctly refer to descriptor object

### DIFF
--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
@@ -111,6 +111,7 @@ class ModelBuilderSuite extends munit.FunSuite {
           "com.example.shoppingcart.ShoppingCartService" ->
           ModelBuilder.EntityService(
             FullyQualifiedName("ShoppingCartService", shoppingCartProto),
+            FullyQualifiedName("ShoppingCartServiceProto", shoppingCartProto),
             List(
               command(
                 "AddItem",
@@ -188,6 +189,7 @@ class ModelBuilderSuite extends munit.FunSuite {
           "com.example.shoppingcart.ShoppingCartService" ->
           ModelBuilder.EntityService(
             FullyQualifiedName("ShoppingCartService", shoppingCartProto),
+            FullyQualifiedName("ShoppingCartServiceProto", shoppingCartProto),
             List(
               command(
                 "AddItem",
@@ -269,6 +271,7 @@ class ModelBuilderSuite extends munit.FunSuite {
           "com.example.shoppingcart.ShoppingCartService" ->
           ModelBuilder.EntityService(
             FullyQualifiedName("ShoppingCartService", shoppingCartProto),
+            FullyQualifiedName("ShoppingCartServiceProto", shoppingCartProto),
             List(
               command(
                 "AddItem",
@@ -370,6 +373,7 @@ class ModelBuilderSuite extends munit.FunSuite {
           "shopping.cart.view.ShoppingCartViewService" ->
           ModelBuilder.ViewService(
             FullyQualifiedName("ShoppingCartViewService", "ShoppingCartViewService", shoppingCartProto),
+            FullyQualifiedName("ShoppingCartViewServiceProto", shoppingCartProto),
             transformedUpdates ++ queries,
             "ShoppingCartViewService",
             transformedUpdates,

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
@@ -111,7 +111,7 @@ class ModelBuilderSuite extends munit.FunSuite {
           "com.example.shoppingcart.ShoppingCartService" ->
           ModelBuilder.EntityService(
             FullyQualifiedName("ShoppingCartService", shoppingCartProto),
-            FullyQualifiedName("ShoppingCartServiceProto", shoppingCartProto),
+            FullyQualifiedName("ShoppingCartApi", shoppingCartProto),
             List(
               command(
                 "AddItem",
@@ -189,7 +189,7 @@ class ModelBuilderSuite extends munit.FunSuite {
           "com.example.shoppingcart.ShoppingCartService" ->
           ModelBuilder.EntityService(
             FullyQualifiedName("ShoppingCartService", shoppingCartProto),
-            FullyQualifiedName("ShoppingCartServiceProto", shoppingCartProto),
+            FullyQualifiedName("ShoppingCartApi", shoppingCartProto),
             List(
               command(
                 "AddItem",
@@ -271,7 +271,7 @@ class ModelBuilderSuite extends munit.FunSuite {
           "com.example.shoppingcart.ShoppingCartService" ->
           ModelBuilder.EntityService(
             FullyQualifiedName("ShoppingCartService", shoppingCartProto),
-            FullyQualifiedName("ShoppingCartServiceProto", shoppingCartProto),
+            FullyQualifiedName("ShoppingCartApi", shoppingCartProto),
             List(
               command(
                 "AddItem",
@@ -373,7 +373,7 @@ class ModelBuilderSuite extends munit.FunSuite {
           "shopping.cart.view.ShoppingCartViewService" ->
           ModelBuilder.ViewService(
             FullyQualifiedName("ShoppingCartViewService", "ShoppingCartViewService", shoppingCartProto),
-            FullyQualifiedName("ShoppingCartViewServiceProto", shoppingCartProto),
+            FullyQualifiedName("ShoppingCartViewModel", shoppingCartProto),
             transformedUpdates ++ queries,
             "ShoppingCartViewService",
             transformedUpdates,

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
@@ -88,6 +88,7 @@ class TestData(packageNamingTemplate: PackageNaming) {
   def simpleEntityService(proto: PackageNaming = serviceProto(), suffix: String = ""): ModelBuilder.EntityService =
     ModelBuilder.EntityService(
       FullyQualifiedName(s"MyService$suffix", proto),
+      FullyQualifiedName(s"MyService${suffix}Proto", proto),
       List(
         command("Set", FullyQualifiedName("SetValue", proto), FullyQualifiedName("Empty", externalProto)),
         command("Get", FullyQualifiedName("GetValue", proto), FullyQualifiedName("MyState", proto))),
@@ -97,6 +98,7 @@ class TestData(packageNamingTemplate: PackageNaming) {
 
     ModelBuilder.ActionService(
       FullyQualifiedName(proto.name, proto.name, proto),
+      FullyQualifiedName(proto.name + "Proto", proto),
       List(
         command("SimpleMethod", FullyQualifiedName("MyRequest", proto), FullyQualifiedName("Empty", externalProto)),
         command(
@@ -120,6 +122,7 @@ class TestData(packageNamingTemplate: PackageNaming) {
   def simpleJsonPubSubActionService(proto: PackageNaming = serviceProto()): ModelBuilder.ActionService = {
     ModelBuilder.ActionService(
       FullyQualifiedName(proto.name, proto.name, proto),
+      FullyQualifiedName(proto.name + "Proto", proto),
       List(
         command(
           "InFromTopic",
@@ -145,6 +148,7 @@ class TestData(packageNamingTemplate: PackageNaming) {
         FullyQualifiedName("ViewState", proto)))
     ModelBuilder.ViewService(
       FullyQualifiedName(s"MyService${suffix}", s"MyService${suffix}View", proto),
+      FullyQualifiedName(s"MyService${suffix}Proto", proto),
       List(
         command(
           "Created",

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
@@ -88,7 +88,7 @@ class TestData(packageNamingTemplate: PackageNaming) {
   def simpleEntityService(proto: PackageNaming = serviceProto(), suffix: String = ""): ModelBuilder.EntityService =
     ModelBuilder.EntityService(
       FullyQualifiedName(s"MyService$suffix", proto),
-      FullyQualifiedName(s"MyService${suffix}Proto", proto),
+      FullyQualifiedName(proto.javaOuterClassnameOption.getOrElse(s"MyService${suffix}Proto"), proto),
       List(
         command("Set", FullyQualifiedName("SetValue", proto), FullyQualifiedName("Empty", externalProto)),
         command("Get", FullyQualifiedName("GetValue", proto), FullyQualifiedName("MyState", proto))),
@@ -98,7 +98,7 @@ class TestData(packageNamingTemplate: PackageNaming) {
 
     ModelBuilder.ActionService(
       FullyQualifiedName(proto.name, proto.name, proto),
-      FullyQualifiedName(proto.name + "Proto", proto),
+      FullyQualifiedName(proto.javaOuterClassnameOption.getOrElse(proto.name + "Proto"), proto),
       List(
         command("SimpleMethod", FullyQualifiedName("MyRequest", proto), FullyQualifiedName("Empty", externalProto)),
         command(
@@ -122,7 +122,7 @@ class TestData(packageNamingTemplate: PackageNaming) {
   def simpleJsonPubSubActionService(proto: PackageNaming = serviceProto()): ModelBuilder.ActionService = {
     ModelBuilder.ActionService(
       FullyQualifiedName(proto.name, proto.name, proto),
-      FullyQualifiedName(proto.name + "Proto", proto),
+      FullyQualifiedName(proto.javaOuterClassnameOption.getOrElse(proto.name + "Proto"), proto),
       List(
         command(
           "InFromTopic",
@@ -148,7 +148,7 @@ class TestData(packageNamingTemplate: PackageNaming) {
         FullyQualifiedName("ViewState", proto)))
     ModelBuilder.ViewService(
       FullyQualifiedName(s"MyService${suffix}", s"MyService${suffix}View", proto),
-      FullyQualifiedName(s"MyService${suffix}Proto", proto),
+      FullyQualifiedName(proto.javaOuterClassnameOption.getOrElse(s"MyService${suffix}Proto"), proto),
       List(
         command(
           "Created",

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestFullyQualifiedNameExtractor.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestFullyQualifiedNameExtractor.scala
@@ -22,6 +22,9 @@ object TestFullyQualifiedNameExtractor extends ModelBuilder.FullyQualifiedNameEx
   override def apply(descriptor: Descriptors.GenericDescriptor): FullyQualifiedName =
     FullyQualifiedName(descriptor.getName, descriptor.getName, packageName(descriptor))
 
+  override def fileDescriptorObject(descriptor: Descriptors.FileDescriptor): FullyQualifiedName =
+    ???
+
   override def packageName(descriptor: Descriptors.GenericDescriptor): PackageNaming = {
     val fileDescriptor = descriptor.getFile
     if (fileDescriptor.getName == s"google.protobuf.${descriptor.getName}.placeholder.proto") {

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestFullyQualifiedNameExtractor.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestFullyQualifiedNameExtractor.scala
@@ -22,8 +22,10 @@ object TestFullyQualifiedNameExtractor extends ModelBuilder.FullyQualifiedNameEx
   override def apply(descriptor: Descriptors.GenericDescriptor): FullyQualifiedName =
     FullyQualifiedName(descriptor.getName, descriptor.getName, packageName(descriptor))
 
-  override def fileDescriptorObject(descriptor: Descriptors.FileDescriptor): FullyQualifiedName =
-    ???
+  override def fileDescriptorObject(descriptor: Descriptors.FileDescriptor): FullyQualifiedName = {
+    val parent = apply(descriptor).parent
+    FullyQualifiedName(parent.javaOuterClassname, parent)
+  }
 
   override def packageName(descriptor: Descriptors.GenericDescriptor): PackageNaming = {
     val fileDescriptor = descriptor.getFile

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionServiceSourceGenerator.scala
@@ -319,7 +319,6 @@ object ActionServiceSourceGenerator {
     val classNameAction = service.className
     val protoName = service.fqn.protoName
 
-    val grpcServiceClass = service.fqn.parent.javaOuterClassname
     val descriptors =
       (collectRelevantTypes(service.commandTypes, service.fqn)
         .map(d =>
@@ -374,7 +373,7 @@ object ActionServiceSourceGenerator {
       |
       |  @Override
       |  public final Descriptors.ServiceDescriptor serviceDescriptor() {
-      |    return $grpcServiceClass.getDescriptor().findServiceByName("$protoName");
+      |    return ${service.descriptorObject.name}.getDescriptor().findServiceByName("$protoName");
       |  }
       |
       |  @Override

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
@@ -282,7 +282,7 @@ object EntityServiceSourceGenerator {
         |
         |  @Override
         |  public final Descriptors.ServiceDescriptor serviceDescriptor() {
-        |    return ${service.fqn.parent.javaOuterClassname}.getDescriptor().findServiceByName("${service.fqn.name}");
+        |    return ${service.descriptorObject.name}.getDescriptor().findServiceByName("${service.fqn.name}");
         |  }
         |
         |  @Override

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/FullyQualifiedNameExtractor.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/FullyQualifiedNameExtractor.scala
@@ -39,7 +39,8 @@ object FullyQualifiedNameExtractor extends ModelBuilder.FullyQualifiedNameExtrac
     } else PackageNaming.from(fileDescriptor)
   }
 
-  override def fileDescriptorObject(descriptor: Descriptors.FileDescriptor): FullyQualifiedName =
-    // TODO move logic from generator classes to here
-    ???
+  override def fileDescriptorObject(descriptor: Descriptors.FileDescriptor): FullyQualifiedName = {
+    val parent = apply(descriptor).parent
+    FullyQualifiedName(parent.javaOuterClassname, parent)
+  }
 }

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/FullyQualifiedNameExtractor.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/FullyQualifiedNameExtractor.scala
@@ -38,4 +38,8 @@ object FullyQualifiedNameExtractor extends ModelBuilder.FullyQualifiedNameExtrac
         javaMultipleFiles = true)
     } else PackageNaming.from(fileDescriptor)
   }
+
+  override def fileDescriptorObject(descriptor: Descriptors.FileDescriptor): FullyQualifiedName =
+    // TODO move logic from generator classes to here
+    ???
 }

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGenerator.scala
@@ -209,7 +209,7 @@ object ReplicatedEntitySourceGenerator {
         |
         |  @Override
         |  public final Descriptors.ServiceDescriptor serviceDescriptor() {
-        |    return ${service.fqn.parent.javaOuterClassname}.getDescriptor().findServiceByName("${service.fqn.name}");
+        |    return ${service.descriptorObject.name}.getDescriptor().findServiceByName("${service.fqn.name}");
         |  }
         |
         |  @Override

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
@@ -196,7 +196,7 @@ object ValueEntitySourceGenerator {
         |
         |  @Override
         |  public final Descriptors.ServiceDescriptor serviceDescriptor() {
-        |    return ${service.fqn.parent.javaOuterClassname}.getDescriptor().findServiceByName("${service.fqn.name}");
+        |    return ${service.descriptorObject.name}.getDescriptor().findServiceByName("${service.fqn.name}");
         |  }
         |
         |  @Override

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGenerator.scala
@@ -178,7 +178,7 @@ object ViewServiceSourceGenerator {
         |
         |  @Override
         |  public final Descriptors.ServiceDescriptor serviceDescriptor() {
-        |    return ${view.fqn.parent.javaOuterClassname}.getDescriptor().findServiceByName("${view.fqn.protoName}");
+        |    return ${view.descriptorObject.name}.getDescriptor().findServiceByName("${view.fqn.protoName}");
         |  }
         |
         |  @Override

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntityTestKitGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntityTestKitGeneratorSuite.scala
@@ -266,6 +266,7 @@ class EventSourcedEntityTestKitGeneratorSuite extends munit.FunSuite {
         javaMultipleFiles = true)
     ModelBuilder.EntityService(
       FullyQualifiedName("ShoppingCartService", shoppingCartProto),
+      FullyQualifiedName("ShoppingCartServiceProto", shoppingCartProto),
       List(
         testData.command(
           "AddItem",

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGeneratorSuite.scala
@@ -243,6 +243,7 @@ class ValueEntityTestKitGeneratorSuite extends munit.FunSuite {
         javaMultipleFiles = true)
     ModelBuilder.EntityService(
       FullyQualifiedName("ShoppingCartService", shoppingCartProto),
+      FullyQualifiedName("ShoppingCartServiceProto", shoppingCartProto),
       List(
         testData.command(
           "AddItem",

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/FullyQualifiedNameExtractor.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/FullyQualifiedNameExtractor.scala
@@ -22,10 +22,9 @@ import protocgen.CodeGenRequest
 import scalapb.compiler.{ DescriptorImplicits, GeneratorParams }
 
 class FullyQualifiedNameExtractor(val di: DescriptorImplicits) extends ModelBuilder.FullyQualifiedNameExtractor {
+  import di._
 
   override def apply(descriptor: Descriptors.GenericDescriptor): FullyQualifiedName = {
-    import di._
-
     val name = descriptor match {
       case d: Descriptors.Descriptor =>
         d.scalaType.name
@@ -38,9 +37,7 @@ class FullyQualifiedNameExtractor(val di: DescriptorImplicits) extends ModelBuil
     FullyQualifiedName(name, packageName(descriptor))
   }
 
-  override def packageName(descriptor: Descriptors.GenericDescriptor): PackageNaming = {
-    import di._
-
+  override def packageName(descriptor: Descriptors.GenericDescriptor): PackageNaming =
     PackageNaming(
       descriptor.getFile.getName,
       descriptor.getName,
@@ -49,7 +46,21 @@ class FullyQualifiedNameExtractor(val di: DescriptorImplicits) extends ModelBuil
       None,
       None,
       javaMultipleFiles = false)
-  }
+
+  def packageName(protoFileName: String, scalaName: ScalaName): PackageNaming =
+    PackageNaming(
+      protoFileName,
+      scalaName.name,
+      scalaName.fullName.split("\\.").init.mkString("."),
+      None,
+      None,
+      None,
+      javaMultipleFiles = false)
+
+  override def fileDescriptorObject(descriptor: Descriptors.FileDescriptor): FullyQualifiedName =
+    FullyQualifiedName(
+      descriptor.fileDescriptorObject.name,
+      packageName(descriptor.getName, descriptor.fileDescriptorObject))
 }
 object FullyQualifiedNameExtractor {
   def apply(request: CodeGenRequest): FullyQualifiedNameExtractor =

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
@@ -106,7 +106,7 @@ object ViewServiceSourceGenerator {
   private[codegen] def viewProvider(view: ModelBuilder.ViewService): String = {
     implicit val imports =
       generateImports(
-        Seq(view.state.fqn),
+        Seq(view.state.fqn, view.descriptorObject),
         view.fqn.parent.scalaPackage,
         otherImports = Seq(
           "com.akkaserverless.javasdk.impl.view.UpdateHandlerNotFound",
@@ -142,13 +142,13 @@ object ViewServiceSourceGenerator {
         |    new ${view.providerName}(viewFactory, viewId)
         |
         |  override final def serviceDescriptor: Descriptors.ServiceDescriptor =
-        |    ${view.fqn.parent.name}Proto.javaDescriptor.findServiceByName("${view.fqn.protoName}")
+        |    ${typeName(view.descriptorObject)}.javaDescriptor.findServiceByName("${view.fqn.protoName}")
         |
         |  override final def newHandler(context: ViewCreationContext): ${view.handlerName} =
         |    new ${view.handlerName}(viewFactory(context))
         |
         |  override final def additionalDescriptors: immutable.Seq[Descriptors.FileDescriptor] =
-        |    ${view.fqn.parent.name}Proto.javaDescriptor ::
+        |    ${typeName(view.descriptorObject)}.javaDescriptor ::
         |    Nil
         |}
         |""".stripMargin

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/FullyQualifiedNameExtractorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/FullyQualifiedNameExtractorSuite.scala
@@ -41,15 +41,15 @@ class FullyQualifiedNameExtractorSuite extends munit.FunSuite {
   val domain = descriptors.find(_.getName == "shoppingcart_domain.proto").get
   val stateCart = domain.getMessageTypes.asScala.find(_.getName == "Cart").get
 
-  implicit val fqnExtractor = new FullyQualifiedNameExtractor(
-    DescriptorImplicits.fromCodeGenRequest(
-      GeneratorParams(),
-      CodeGenRequest(
-        parameter = "",
-        filesToGenerate = Seq.empty,
-        allProtos = descriptors,
-        compilerVersion = None,
-        CodeGeneratorRequest.newBuilder().build())))
+  val di = DescriptorImplicits.fromCodeGenRequest(
+    GeneratorParams(),
+    CodeGenRequest(
+      parameter = "",
+      filesToGenerate = Seq.empty,
+      allProtos = descriptors,
+      compilerVersion = None,
+      CodeGeneratorRequest.newBuilder().build()))
+  implicit val fqnExtractor = new FullyQualifiedNameExtractor(di)
 
   test("extract api message types") {
     val fqn = fqnExtractor(apiCart)
@@ -68,5 +68,13 @@ class FullyQualifiedNameExtractorSuite extends munit.FunSuite {
     val shoppingCartValueEntity = model.entities.values.head.asInstanceOf[ModelBuilder.ValueEntity]
 
     assertNoDiff(shoppingCartValueEntity.state.fqn.parent.scalaPackage, fqnExtractor(stateCart).parent.scalaPackage)
+  }
+
+  test("find the filename of the Scala representation of the proto") {
+    import di._
+    val fileDescriptorObject = fqnExtractor.fileDescriptorObject(api)
+    assertNoDiff(
+      "com.example.shoppingcart.shoppingcart_api.ShoppingcartApiProto",
+      fileDescriptorObject.fullQualifiedName)
   }
 }

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
@@ -24,6 +24,7 @@ import scalapb.compiler.{ DescriptorImplicits, GeneratorParams }
 class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
   import com.akkaserverless.codegen.scalasdk.impl.ValueEntitySourceGenerator._
 
+  // TODO use package naming template parameter to generate Scala-style testData
   private val testData = TestData()
 
   val domainParent = PackageNaming("domain.proto", "", "com.example.service.domain", None, None, None, false)


### PR DESCRIPTION
There is still a problem with the customer-registry sample
where Akka gRPC-generated code refers to AnnotationsProto
in a way that does not currently work, but that's a separate
issue