### PR TITLE
fix: remove unused goPackage

### DIFF
--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Packaging.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/Packaging.scala
@@ -16,9 +16,8 @@
 
 package com.lightbend.akkasls.codegen
 
-import com.akkaserverless.ServiceOptions.ServiceType
-
 import scala.jdk.CollectionConverters._
+
 import com.google.protobuf.Descriptors
 
 /**
@@ -56,7 +55,6 @@ case class PackageNaming(
     protoFileName: String,
     name: String,
     pkg: String,
-    goPackageOption: Option[String],
     javaPackageOption: Option[String],
     javaOuterClassnameOption: Option[String],
     javaMultipleFiles: Boolean) {
@@ -84,7 +82,6 @@ object PackageNaming {
       (fieldDescriptor.getFullName, field)
     }
 
-    val goPackage = generalOptions.get("google.protobuf.FileOptions.go_package").map(_.toString())
     val javaPackage =
       generalOptions.get("google.protobuf.FileOptions.java_package").map(_.toString())
 
@@ -109,7 +106,6 @@ object PackageNaming {
       descriptor.getName,
       name,
       descriptor.getPackage,
-      goPackage,
       javaPackage,
       Some(javaOuterClassname),
       javaMultipleFiles)

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
@@ -70,7 +70,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "ShoppingcartApi",
           "com.example.shoppingcart",
           None,
-          None,
           Some("ShoppingCartApi"),
           javaMultipleFiles = false)
 
@@ -80,7 +79,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "ShoppingcartDomain",
           "com.example.shoppingcart.domain",
           None,
-          None,
           Some("ShoppingCartDomain"),
           javaMultipleFiles = false)
 
@@ -89,7 +87,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "Empty",
           "Empty",
           "google.protobuf",
-          Some("google.golang.org/protobuf/types/known/emptypb"),
           Some("com.google.protobuf"),
           Some("EmptyProto"),
           javaMultipleFiles = true)
@@ -152,7 +149,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "ShoppingcartApi",
           "com.example.shoppingcart",
           None,
-          None,
           Some("ShoppingCartApi"),
           javaMultipleFiles = false)
 
@@ -162,7 +158,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "ShoppingcartDomain",
           "com.example.shoppingcart.domain",
           None,
-          None,
           Some("ShoppingCartDomain"),
           javaMultipleFiles = false)
 
@@ -171,7 +166,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "Empty",
           "Empty",
           "google.protobuf",
-          Some("google.golang.org/protobuf/types/known/emptypb"),
           Some("com.google.protobuf"),
           Some("EmptyProto"),
           javaMultipleFiles = true)
@@ -234,7 +228,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "ShoppingcartApi",
           "com.example.shoppingcart",
           None,
-          None,
           Some("ShoppingCartApi"),
           javaMultipleFiles = false)
 
@@ -244,7 +237,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "ShoppingcartDomain",
           "com.example.shoppingcart.domain",
           None,
-          None,
           Some("ShoppingCartDomain"),
           javaMultipleFiles = false)
 
@@ -253,7 +245,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "Empty",
           "Empty",
           "google.protobuf",
-          Some("google.golang.org/protobuf/types/known/emptypb"),
           Some("com.google.protobuf"),
           Some("EmptyProto"),
           javaMultipleFiles = true)
@@ -318,7 +309,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "ShoppingCartViewModel",
           "shopping.cart.view",
           None,
-          None,
           Some("ShoppingCartViewModel"),
           javaMultipleFiles = false)
 
@@ -328,7 +318,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "ShoppingCartDomain",
           "shopping.cart.domain",
           None,
-          None,
           Some("ShoppingCartDomain"),
           javaMultipleFiles = false)
 
@@ -337,7 +326,6 @@ class ModelBuilderSuite extends munit.FunSuite {
           "Empty",
           "Empty",
           "google.protobuf",
-          Some("google.golang.org/protobuf/types/known/emptypb"),
           Some("com.google.protobuf"),
           Some("EmptyProto"),
           javaMultipleFiles = true)
@@ -386,16 +374,9 @@ class ModelBuilderSuite extends munit.FunSuite {
     val name = "Name"
     val pkg = "com.example"
 
-    assertEquals(PackageNaming(protoFileName, name, pkg, None, None, None, javaMultipleFiles = false).javaPackage, pkg)
+    assertEquals(PackageNaming(protoFileName, name, pkg, None, None, javaMultipleFiles = false).javaPackage, pkg)
     assertEquals(
-      PackageNaming(
-        protoFileName,
-        name,
-        pkg,
-        None,
-        Some("override.package"),
-        None,
-        javaMultipleFiles = false).javaPackage,
+      PackageNaming(protoFileName, name, pkg, Some("override.package"), None, javaMultipleFiles = false).javaPackage,
       "override.package")
   }
 

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
@@ -23,7 +23,6 @@ object TestData {
       "Undefined",
       "undefined",
       None,
-      None,
       Some("UndefinedOuterClass"),
       javaMultipleFiles = false)
 
@@ -63,17 +62,10 @@ class TestData(packageNamingTemplate: PackageNaming) {
       javaOuterClassnameOption = packageNamingTemplate.javaOuterClassnameOption.map(_ => s"EntityOuterClass$suffix"))
 
   val externalProto: PackageNaming =
-    PackageNaming("external_domain.proto", "ExternalDomain", "com.external", None, None, None, javaMultipleFiles = true)
+    PackageNaming("external_domain.proto", "ExternalDomain", "com.external", None, None, javaMultipleFiles = true)
 
   val googleProto: PackageNaming =
-    PackageNaming(
-      "google_proto.proto",
-      "GoogleProto",
-      "com.google.protobuf",
-      None,
-      None,
-      None,
-      javaMultipleFiles = true)
+    PackageNaming("google_proto.proto", "GoogleProto", "com.google.protobuf", None, None, javaMultipleFiles = true)
 
   def command(
       name: String,

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestFullyQualifiedNameExtractor.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestFullyQualifiedNameExtractor.scala
@@ -36,7 +36,6 @@ object TestFullyQualifiedNameExtractor extends ModelBuilder.FullyQualifiedNameEx
         descriptor.getName,
         descriptor.getName,
         fileDescriptor.getPackage,
-        Some(s"google.golang.org/protobuf/types/known/${descriptor.getName.toLowerCase}pb"),
         Some(s"com.${fileDescriptor.getPackage}"),
         Some(s"${descriptor.getName}Proto"),
         javaMultipleFiles = true)

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/FullyQualifiedNameExtractor.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/FullyQualifiedNameExtractor.scala
@@ -32,7 +32,6 @@ object FullyQualifiedNameExtractor extends ModelBuilder.FullyQualifiedNameExtrac
         descriptor.getName,
         descriptor.getName,
         fileDescriptor.getPackage,
-        Some(s"google.golang.org/protobuf/types/known/${descriptor.getName.toLowerCase}pb"),
         Some(s"com.${fileDescriptor.getPackage}"),
         Some(s"${descriptor.getName}Proto"),
         javaMultipleFiles = true)

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntityTestKitGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntityTestKitGeneratorSuite.scala
@@ -229,7 +229,6 @@ class EventSourcedEntityTestKitGeneratorSuite extends munit.FunSuite {
         "ShoppingcartDomain", // Cart here is lowerCase as per protobuf generation
         "com.example.shoppingcart.domain",
         None,
-        None,
         Some("ShoppingCartDomain"),
         javaMultipleFiles = false)
 
@@ -252,7 +251,6 @@ class EventSourcedEntityTestKitGeneratorSuite extends munit.FunSuite {
         "ShoppingcartApi", // Cart here is lowerCase as per protobuf generation
         "com.example.shoppingcart",
         None,
-        None,
         Some("ShoppingCartApi"),
         javaMultipleFiles = false)
     val googleEmptyProto =
@@ -260,8 +258,10 @@ class EventSourcedEntityTestKitGeneratorSuite extends munit.FunSuite {
         "Empty",
         "Empty",
         "google.protobuf",
-        Some("google.golang.org/protobuf/types/known/emptypb"),
-        Some("com.google.protobuf"),
+        Some(
+          "com.google.protobuf" +
+          "" +
+          ""),
         Some("EmptyProto"),
         javaMultipleFiles = true)
     ModelBuilder.EntityService(

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGeneratorSuite.scala
@@ -208,7 +208,6 @@ class ValueEntityTestKitGeneratorSuite extends munit.FunSuite {
         "ShoppingcartDomain", // Cart here is lowerCase as per protobuf generation
         "com.example.shoppingcart.domain",
         None,
-        None,
         Some("ShoppingCartDomain"),
         javaMultipleFiles = false)
 
@@ -229,7 +228,6 @@ class ValueEntityTestKitGeneratorSuite extends munit.FunSuite {
         "ShoppingcartApi", // Cart here is lowerCase as per protobuf generation
         "com.example.shoppingcart",
         None,
-        None,
         Some("ShoppingCartApi"),
         javaMultipleFiles = false)
     val googleEmptyProto =
@@ -237,7 +235,6 @@ class ValueEntityTestKitGeneratorSuite extends munit.FunSuite {
         "Empty",
         "Empty",
         "google.protobuf",
-        Some("google.golang.org/protobuf/types/known/emptypb"),
         Some("com.google.protobuf"),
         Some("EmptyProto"),
         javaMultipleFiles = true)

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/FullyQualifiedNameExtractor.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/FullyQualifiedNameExtractor.scala
@@ -44,7 +44,6 @@ class FullyQualifiedNameExtractor(val di: DescriptorImplicits) extends ModelBuil
       descriptor.getFile.scalaPackage.fullName,
       None,
       None,
-      None,
       javaMultipleFiles = false)
 
   def packageName(protoFileName: String, scalaName: ScalaName): PackageNaming =
@@ -52,7 +51,6 @@ class FullyQualifiedNameExtractor(val di: DescriptorImplicits) extends ModelBuil
       protoFileName,
       scalaName.name,
       scalaName.fullName.split("\\.").init.mkString("."),
-      None,
       None,
       None,
       javaMultipleFiles = false)

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
@@ -27,8 +27,8 @@ class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
   // TODO use package naming template parameter to generate Scala-style testData
   private val testData = TestData()
 
-  val domainParent = PackageNaming("domain.proto", "", "com.example.service.domain", None, None, None, false)
-  val apiParent = PackageNaming("api.proto", "", "com.example.service", None, None, None, false)
+  val domainParent = PackageNaming("domain.proto", "", "com.example.service.domain", None, None, false)
+  val apiParent = PackageNaming("api.proto", "", "com.example.service", None, None, false)
 
   test("it can generate a value entity implementation skeleton") {
     val file =


### PR DESCRIPTION
Just clean-up. 

I noticed that we this goPackage, but we clearly don't use it. That probably come from the time that we had plans to have one codegen for all languages.