### PR TITLE
fix(sbt-plugin): make sure akkaserverless classes are generated

### DIFF
--- a/sbt-plugin/src/main/scala/com/akkaserverless/sbt/AkkaserverlessPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/akkaserverless/sbt/AkkaserverlessPlugin.scala
@@ -43,7 +43,7 @@ object AkkaserverlessPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[sbt.Setting[_]] = Seq(
     libraryDependencies ++= Seq(
-      "com.akkaserverless" % "akkaserverless-sdk-protocol" % "0.7.0-beta.19" % "protobuf",
+      "com.akkaserverless" % "akkaserverless-sdk-protocol" % "0.7.0-beta.19" % "protobuf-src",
       "com.google.protobuf" % "protobuf-java" % "3.17.3" % "protobuf"),
     Compile / PB.targets +=
       gen(Seq(AkkaserverlessGenerator.enableDebug)) -> (Compile / sourceManaged).value / "akkaserverless",


### PR DESCRIPTION
This way we don't get the class files from a dependencies, but we get
the proto files and generate the class files ourselves: this way we have
more control over how they are generated.