### PR TITLE
fix: favor scala function syntax

### DIFF
--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/MainSourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/MainSourceGenerator.scala
@@ -225,20 +225,20 @@ object MainSourceGenerator {
         .sortBy(_.fqn.name)
         .collect {
           case entity: ModelBuilder.EventSourcedEntity =>
-            s"create${entity.fqn.name}: Function[EventSourcedEntityContext, ${entity.fqn.name}]"
+            s"create${entity.fqn.name}: EventSourcedEntityContext => ${entity.fqn.name}"
           case entity: ModelBuilder.ValueEntity =>
-            s"create${entity.fqn.name}: Function[ValueEntityContext, ${entity.fqn.name}]"
+            s"create${entity.fqn.name}: ValueEntityContext => ${entity.fqn.name}"
           case entity: ModelBuilder.ReplicatedEntity =>
-            s"create${entity.fqn.name}: Function[ReplicatedEntityContext, ${entity.fqn.name}]"
+            s"create${entity.fqn.name}: ReplicatedEntityContext => ${entity.fqn.name}"
         }
 
     val serviceCreators = model.services.values.toList
       .sortBy(_.fqn.name)
       .collect {
         case service: ModelBuilder.ActionService =>
-          s"create${service.className}: Function[ActionCreationContext, ${service.className}]"
+          s"create${service.className}: ActionCreationContext => ${service.className}"
         case view: ModelBuilder.ViewService =>
-          s"create${view.className}: Function[ViewCreationContext, ${view.className}]"
+          s"create${view.className}: ViewCreationContext => ${view.className}"
       }
 
     val creatorParameters = entityCreators ::: serviceCreators

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ViewServiceSourceGenerator.scala
@@ -127,12 +127,12 @@ object ViewServiceSourceGenerator {
         |$imports
         |
         |object ${view.providerName} {
-        |  def apply(viewFactory: Function[ViewCreationContext, ${view.className}]): ${view.providerName} =
+        |  def apply(viewFactory: ViewCreationContext => ${view.className}): ${view.providerName} =
         |    new ${view.providerName}(viewFactory, viewId = "${view.viewId}", options = ViewOptions.defaults)
         |}
         |
         |class ${view.providerName} private(
-        |    viewFactory: Function[ViewCreationContext, ${view.className}],
+        |    viewFactory: ViewCreationContext => ${view.className},
         |    override val viewId: String,
         |    override val options: ViewOptions)
         |  extends ViewProvider[${typeName(view.state.fqn)}, ${view.className}] {

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/MainSourceGeneratorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/MainSourceGeneratorSuite.scala
@@ -129,12 +129,12 @@ class MainSourceGeneratorSuite extends munit.FunSuite {
          |object AkkaServerlessFactory {
          |
          |  def withComponents(
-         |      createMyEntity1: Function[EventSourcedEntityContext, MyEntity1],
-         |      createMyEntity3: Function[EventSourcedEntityContext, MyEntity3],
-         |      createMyReplicatedEntity6: Function[ReplicatedEntityContext, MyReplicatedEntity6],
-         |      createMyValueEntity2: Function[ValueEntityContext, MyValueEntity2],
-         |      createMyService4ViewImpl: Function[ViewCreationContext, MyService4ViewImpl],
-         |      createMyService5Action: Function[ActionCreationContext, MyService5Action]): AkkaServerless = {
+         |      createMyEntity1: EventSourcedEntityContext => MyEntity1,
+         |      createMyEntity3: EventSourcedEntityContext => MyEntity3,
+         |      createMyReplicatedEntity6: ReplicatedEntityContext => MyReplicatedEntity6,
+         |      createMyValueEntity2: ValueEntityContext => MyValueEntity2,
+         |      createMyService4ViewImpl: ViewCreationContext => MyService4ViewImpl,
+         |      createMyService5Action: ActionCreationContext => MyService5Action): AkkaServerless = {
          |    val akkaServerless = AkkaServerless()
          |    akkaServerless
          |      .register(MyEntity1Provider(createMyEntity1))
@@ -171,7 +171,7 @@ class MainSourceGeneratorSuite extends munit.FunSuite {
          |object AkkaServerlessFactory {
          |
          |  def withComponents(
-         |      createMyServiceViewImpl: Function[ViewCreationContext, MyServiceViewImpl]): AkkaServerless = {
+         |      createMyServiceViewImpl: ViewCreationContext => MyServiceViewImpl): AkkaServerless = {
          |    val akkaServerless = AkkaServerless()
          |    akkaServerless
          |      .register(MyServiceViewProvider(createMyServiceViewImpl))

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ViewServiceSourceGeneratorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ViewServiceSourceGeneratorSuite.scala
@@ -181,12 +181,12 @@ class ViewServiceSourceGeneratorSuite extends munit.FunSuite {
          |import scala.collection.immutable
          |
          |object MyServiceViewProvider {
-         |  def apply(viewFactory: Function[ViewCreationContext, MyServiceViewImpl]): MyServiceViewProvider =
+         |  def apply(viewFactory: ViewCreationContext => MyServiceViewImpl): MyServiceViewProvider =
          |    new MyServiceViewProvider(viewFactory, viewId = "MyService", options = ViewOptions.defaults)
          |}
          |
          |class MyServiceViewProvider private(
-         |    viewFactory: Function[ViewCreationContext, MyServiceViewImpl],
+         |    viewFactory: ViewCreationContext => MyServiceViewImpl,
          |    override val viewId: String,
          |    override val options: ViewOptions)
          |  extends ViewProvider[ViewState, MyServiceViewImpl] {


### PR DESCRIPTION
Pure aesthetics. Favor Scala function syntax so when devs navigate to withComponents method they see Scala functions as they are used to.