### PR TITLE
fix: make sure unmanaged generated files are detected on first compilation attempt

### DIFF
--- a/samples/scala-fibonacci-action/build.sbt
+++ b/samples/scala-fibonacci-action/build.sbt
@@ -1,5 +1,3 @@
-import com.akkaserverless.sbt.AkkaserverlessPlugin.autoImport.generateUnmanaged
-
 name := "fibonacci-action"
 
 organization := "com.akkaseverless.samples"
@@ -32,11 +30,3 @@ Test / logBuffered := false
 
 run / fork := false
 Global / cancelable := false // ctrl-c
-
-Compile / compile := {
-  // Make sure 'generateUnmanaged' is executed on each compile, to generate scaffolding code for
-  // newly-introduced concepts.
-  // After initial generation they are to be maintained manually and will not be overwritten.
-  (Compile / generateUnmanaged).value
-  (Compile / compile).value
-}

--- a/samples/scala-value-entity-customer-registry/build.sbt
+++ b/samples/scala-value-entity-customer-registry/build.sbt
@@ -1,5 +1,3 @@
-import com.akkaserverless.sbt.AkkaserverlessPlugin.autoImport.generateUnmanaged
-
 name := "customer-registry"
 
 organization := "com.akkaseverless.samples"
@@ -32,11 +30,3 @@ Test / logBuffered := false
 
 run / fork := false
 Global / cancelable := false // ctrl-c
-
-Compile / compile := {
-  // Make sure 'generateUnmanaged' is executed on each compile, to generate scaffolding code for
-  // newly-introduced concepts.
-  // After initial generation they are to be maintained manually and will not be overwritten.
-  (Compile / generateUnmanaged).value
-  (Compile / compile).value
-}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/basic/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/basic/build.sbt
@@ -1,13 +1,3 @@
-import com.akkaserverless.sbt.AkkaserverlessPlugin.autoImport.generateUnmanaged
-
 scalaVersion := "2.13.6"
 
 enablePlugins(AkkaserverlessPlugin)
-
-Compile / compile := {
-  // Make sure 'generateUnmanaged' is executed on each compile, to generate scaffolding code for
-  // newly-introduced concepts.
-  // After initial generation they are to be maintained manually and will not be overwritten.
-  (Compile / generateUnmanaged).value
-  (Compile / compile).value
-}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/basic/test
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/basic/test
@@ -1,6 +1,3 @@
-# TODO replace with just ``> compile` when issue #454 has been fixed
-> protocGenerate
-> generateUnmanaged
 > compile
 $ exists src/main/scala/foo/bar/Baz.scala
 $ exists target/scala-2.13/src_managed/main/akkaserverless/foo/bar/AbstractBaz.scala


### PR DESCRIPTION
There's no happens-before relationship between mentioned tasks in a task
definition, so we need to make sure to include generated files
explicitly.

Fixes #435