### PR TITLE
chore(scalasdk): codegenScala sbt project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
       - restore_deps_cache
       - run:
           name: Run tests
-          command: sbt test codegenCore/publishLocal akkaserverless-codegen-scala/publishLocal sdkCore/publishLocal sdkJava/publishLocal sdkScala/publishLocal scripted
+          command: sbt test codegenCore/publishLocal codegenScala/publishLocal sdkCore/publishLocal sdkJava/publishLocal sdkScala/publishLocal scripted
       - save_deps_cache
 
   integration-tests:

--- a/build.sbt
+++ b/build.sbt
@@ -246,16 +246,19 @@ lazy val attachProtobufDescriptorSets = Seq(
   Compile / managedResources += protobufDescriptorSetOut.value,
   Compile / unmanagedResourceDirectories ++= (Compile / PB.protoSources).value)
 
-lazy val codegenScala = Project(id = "akkaserverless-codegen-scala", base = file("codegen/scala-gen"))
-  .enablePlugins(BuildInfoPlugin)
-  .enablePlugins(PublishSonatype)
-  .settings(Dependencies.codegenScala)
-  .settings(
-    scalaVersion := Dependencies.ScalaVersionForSbtPlugin,
-    buildInfoKeys := Seq[BuildInfoKey](name, organization, version, scalaVersion, sbtVersion),
-    buildInfoPackage := "com.akkaserverless.codegen.scalasdk",
-    testFrameworks += new TestFramework("munit.Framework"))
-  .dependsOn(codegenCore % "compile->compile;test->test")
+lazy val codegenScala =
+  project
+    .in(file("codegen/scala-gen"))
+    .enablePlugins(BuildInfoPlugin)
+    .enablePlugins(PublishSonatype)
+    .settings(Dependencies.codegenScala)
+    .settings(
+      name := "akkaserverless-codegen-scala",
+      scalaVersion := Dependencies.ScalaVersionForSbtPlugin,
+      buildInfoKeys := Seq[BuildInfoKey](name, organization, version, scalaVersion, sbtVersion),
+      buildInfoPackage := "com.akkaserverless.codegen.scalasdk",
+      testFrameworks += new TestFramework("munit.Framework"))
+    .dependsOn(codegenCore % "compile->compile;test->test")
 
 lazy val sbtPlugin = Project(id = "sbt-akkaserverless", base = file("sbt-plugin"))
   .enablePlugins(SbtPlugin)


### PR DESCRIPTION
* similar to codegenJava
* annoying that they have different naming conventions

tab completion:
```
sbt:akkaserverless-java-sdk> codegen
codegenCore/                  codegenJava/                  codegenJavaCompilationTest/   codegenScala/
```