### PR TITLE
feat(scala-sample): add docker configuration

### DIFF
--- a/samples/scala-value-entity-customer-registry/build.sbt
+++ b/samples/scala-value-entity-customer-registry/build.sbt
@@ -8,7 +8,15 @@ licenses := Seq(
 
 scalaVersion := "2.13.6"
 
-enablePlugins(AkkaserverlessPlugin)
+enablePlugins(AkkaserverlessPlugin, JavaAppPackaging, DockerPlugin)
+dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"
+dockerUsername := sys.props.get("docker.username")
+dockerRepository := sys.props.get("docker.registry")
+ThisBuild / dynverSeparator := "-"
+
+libraryDependencies ++= Seq(
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+)
 
 Compile / scalacOptions ++= Seq(
   "-target:11",

--- a/samples/scala-value-entity-customer-registry/build.sbt
+++ b/samples/scala-value-entity-customer-registry/build.sbt
@@ -14,10 +14,6 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 ThisBuild / dynverSeparator := "-"
 
-libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-)
-
 Compile / scalacOptions ++= Seq(
   "-target:11",
   "-deprecation",

--- a/samples/scala-value-entity-customer-registry/project/plugins.sbt
+++ b/samples/scala-value-entity-customer-registry/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.akkaserverless" % "sbt-akkaserverless" % System.getProperty("akkaserverless-sdk.version", "0.7.2"))
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")


### PR DESCRIPTION
I guess it makes most sense to add this to the sample/template
configuration, not configure it automatically from the Akkaserverless
plugin.

Seems to work
(https://hub.docker.com/repository/docker/raboof/customer-registry),
fails with the known ClassNotFoundError in AnySupport