### PR TITLE
fix(sbt-plugin): rely on Akka gRPC-generated model classes

### DIFF
--- a/sbt-plugin/src/main/scala/com/akkaserverless/sbt/AkkaserverlessPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/akkaserverless/sbt/AkkaserverlessPlugin.scala
@@ -17,7 +17,8 @@
 package com.akkaserverless.sbt
 
 import akka.grpc.sbt.AkkaGrpcPlugin
-import akka.grpc.sbt.AkkaGrpcPlugin.autoImport.akkaGrpcCodeGeneratorSettings
+import akka.grpc.sbt.AkkaGrpcPlugin.autoImport.{ akkaGrpcCodeGeneratorSettings, akkaGrpcGeneratedSources }
+import akka.grpc.sbt.AkkaGrpcPlugin.autoImport.AkkaGrpc
 
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -51,6 +52,10 @@ object AkkaserverlessPlugin extends AutoPlugin {
       gen(
         akkaGrpcCodeGeneratorSettings.value :+ AkkaserverlessGenerator.enableDebug) -> (Compile / sourceManaged).value / "akkaserverless",
     Compile / temporaryUnmanagedDirectory := (Compile / baseDirectory).value / "target" / "akkaserverless-unmanaged",
+    // FIXME there is a name clash between the Akka gRPC server-side service 'handler'
+    // and the Akka Serverless 'handler'. For now working around it by only generating
+    // the client, but we should probably resolve this before the first public release.
+    Compile / akkaGrpcGeneratedSources := Seq(AkkaGrpc.Client),
     Compile / PB.targets ++= Seq(genUnmanaged(
       akkaGrpcCodeGeneratorSettings.value :+ AkkaserverlessGenerator.enableDebug) -> (Compile / temporaryUnmanagedDirectory).value),
     Test / PB.protoSources ++= (Compile / PB.protoSources).value,

--- a/sbt-plugin/src/main/scala/com/akkaserverless/sbt/AkkaserverlessPlugin.scala
+++ b/sbt-plugin/src/main/scala/com/akkaserverless/sbt/AkkaserverlessPlugin.scala
@@ -17,6 +17,7 @@
 package com.akkaserverless.sbt
 
 import akka.grpc.sbt.AkkaGrpcPlugin
+import akka.grpc.sbt.AkkaGrpcPlugin.autoImport.akkaGrpcCodeGeneratorSettings
 
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -47,15 +48,15 @@ object AkkaserverlessPlugin extends AutoPlugin {
       "com.akkaserverless" % "akkaserverless-sdk-protocol" % "0.7.0-beta.19" % "protobuf-src",
       "com.google.protobuf" % "protobuf-java" % "3.17.3" % "protobuf"),
     Compile / PB.targets +=
-      gen(Seq(AkkaserverlessGenerator.enableDebug)) -> (Compile / sourceManaged).value / "akkaserverless",
+      gen(
+        akkaGrpcCodeGeneratorSettings.value :+ AkkaserverlessGenerator.enableDebug) -> (Compile / sourceManaged).value / "akkaserverless",
     Compile / temporaryUnmanagedDirectory := (Compile / baseDirectory).value / "target" / "akkaserverless-unmanaged",
-    Compile / PB.targets ++= Seq(
-      // TODO allow user to customize options
-      scalapb.gen(grpc = false) -> (Compile / sourceManaged).value / "scalapb",
-      genUnmanaged(Seq(AkkaserverlessGenerator.enableDebug)) -> (Compile / temporaryUnmanagedDirectory).value),
+    Compile / PB.targets ++= Seq(genUnmanaged(
+      akkaGrpcCodeGeneratorSettings.value :+ AkkaserverlessGenerator.enableDebug) -> (Compile / temporaryUnmanagedDirectory).value),
     Test / PB.protoSources ++= (Compile / PB.protoSources).value,
     Test / PB.targets +=
-      genTests(Seq(AkkaserverlessGenerator.enableDebug)) -> (Test / sourceManaged).value / "akkaserverless",
+      genTests(
+        akkaGrpcCodeGeneratorSettings.value :+ AkkaserverlessGenerator.enableDebug) -> (Test / sourceManaged).value / "akkaserverless",
     Compile / generateUnmanaged := {
       Files.createDirectories(Paths.get((Compile / temporaryUnmanagedDirectory).value.toURI))
       // Make sure generation has happened

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/basic/test
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/basic/test
@@ -4,65 +4,65 @@ $ exists src/main/scala/com/example/Main.scala
 $ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/AkkaServerlessFactory.scala
 
 # com/example/echo_action.proto
-$ exists src/main/scala/com/example/echo_action/EchoActionImpl.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/echo_action/AbstractEchoAction.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/echo_action/EchoActionProvider.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/echo_action/EchoActionHandler.scala
+$ exists src/main/scala/com/example/EchoActionImpl.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/AbstractEchoAction.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/EchoActionProvider.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/EchoActionHandler.scala
 
 # com/example/action/all_commands_api.proto
-$ exists src/main/scala/com/example/action/all_commands_api/AllCommandsActionImpl.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action/all_commands_api/AbstractAllCommandsAction.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action/all_commands_api/AllCommandsActionHandler.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action/all_commands_api/AllCommandsActionProvider.scala
+$ exists src/main/scala/com/example/action/AllCommandsActionImpl.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action/AbstractAllCommandsAction.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action/AllCommandsActionHandler.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action/AllCommandsActionProvider.scala
 
 # com/example/action1/simple_action.proto
-$ exists src/main/scala/com/example/action1/simple_action/SimpleActionImpl.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action1/simple_action/AbstractSimpleAction.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action1/simple_action/SimpleActionHandler.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action1/simple_action/SimpleActionProvider.scala
+$ exists src/main/scala/com/example/action1/SimpleActionImpl.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action1/AbstractSimpleAction.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action1/SimpleActionHandler.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action1/SimpleActionProvider.scala
 
 # com/example/action2/simple_action_api.proto
-$ exists src/main/scala/com/example/action2/simple_action_api/AnotherSimpleActionImpl.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action2/simple_action_api/AbstractAnotherSimpleAction.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action2/simple_action_api/AnotherSimpleActionProvider.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action2/simple_action_api/AnotherSimpleActionHandler.scala
+$ exists src/main/scala/com/example/action2/AnotherSimpleActionImpl.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action2/AbstractAnotherSimpleAction.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action2/AnotherSimpleActionProvider.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action2/AnotherSimpleActionHandler.scala
 
 # com/example/action3/some_action.proto
-$ exists src/main/scala/com/example/action3/some_action/SomeActionImpl.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action3/some_action/AbstractSomeAction.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action3/some_action/SomeActionHandler.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action3/some_action/SomeActionProvider.scala
+$ exists src/main/scala/com/example/action3/SomeActionImpl.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action3/AbstractSomeAction.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action3/SomeActionHandler.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action3/SomeActionProvider.scala
 
 # com/example/action4/some_other_action_api.proto
-$ exists src/main/scala/com/example/action4/some_other_action_api/SomeOtherActionImpl.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action4/some_other_action_api/AbstractSomeOtherAction.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action4/some_other_action_api/SomeOtherActionHandler.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action4/some_other_action_api/SomeOtherActionProvider.scala
+$ exists src/main/scala/com/example/action4/SomeOtherActionImpl.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action4/AbstractSomeOtherAction.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action4/SomeOtherActionHandler.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action4/SomeOtherActionProvider.scala
 
 # com/example/action5/yet_another_action.proto
-$ exists src/main/scala/com/example/action5/yet_another_action/YetAnotherActionImpl.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action5/yet_another_action/AbstractYetAnotherAction.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action5/yet_another_action/YetAnotherActionHandler.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action5/yet_another_action/YetAnotherActionProvider.scala
+$ exists src/main/scala/com/example/action5/YetAnotherActionImpl.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action5/AbstractYetAnotherAction.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action5/YetAnotherActionHandler.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/action5/YetAnotherActionProvider.scala
 
 # com/example/view/user_view.proto
-$ exists src/main/scala/com/example/view/user_view/UserByNameView.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/user_view/AbstractUserByNameView.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/user_view/UserByNameViewHandler.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/user_view/UserByNameViewProvider.scala
-$ exists src/main/scala/com/example/view/user_view/AdditionalViewImpl.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/user_view/AbstractAdditionalView.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/user_view/AdditionalViewProvider.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/user_view/AdditionalViewHandler.scala
+$ exists src/main/scala/com/example/view/UserByNameView.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/AbstractUserByNameView.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/UserByNameViewHandler.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/UserByNameViewProvider.scala
+$ exists src/main/scala/com/example/view/AdditionalViewImpl.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/AbstractAdditionalView.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/AdditionalViewProvider.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/view/AdditionalViewHandler.scala
 
 # com/example/valueentity/some_value_entity_api.proto
 # com/example/valueentity/domain/some_value_entity_domain.proto
-$ exists src/main/scala/com/example/valueentity/domain/some_value_entity_domain/SomeValueEntity.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/valueentity/domain/some_value_entity_domain/AbstractSomeValueEntity.scala
+$ exists src/main/scala/com/example/valueentity/domain/SomeValueEntity.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/valueentity/domain/AbstractSomeValueEntity.scala
 
 # com/example/valueentity/user_api.proto
 # com/example/valueentity/domain/user_domain.proto
-$ exists src/main/scala/com/example/valueentity/domain/user_domain/User.scala
-$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/valueentity/domain/user_domain/AbstractUser.scala
+$ exists src/main/scala/com/example/valueentity/domain/User.scala
+$ exists target/scala-2.13/src_managed/main/akkaserverless/com/example/valueentity/domain/AbstractUser.scala
 
 > Test/compile


### PR DESCRIPTION
Don't generate the Akka gRPC server for now, as its handlers clash with Akkaserverless-generated handlers