### PR TITLE
chore: align command names

### DIFF
--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGenerator.scala
@@ -55,7 +55,8 @@ object ReplicatedEntitySourceGenerator {
       val inputType = cmd.inputType.fullName
       val outputType = cmd.outputType.fullName
       s"""|@Override
-          |public Effect<$outputType> ${lowerFirst(methodName)}($parameterizedDataType currentData, $inputType command) {
+          |public Effect<$outputType> ${lowerFirst(
+        methodName)}($parameterizedDataType currentData, $inputType ${lowerFirst(cmd.inputType.name)}) {
           |  return effects().error("The command handler for `$methodName` is not implemented, yet");
           |}
           |""".stripMargin

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
@@ -43,7 +43,8 @@ object ValueEntitySourceGenerator {
       val outputType = qualifiedType(cmd.outputType)
 
       s"""|@Override
-          |public Effect<$outputType> ${lowerFirst(methodName)}($stateType currentState, $inputType command) {
+          |public Effect<$outputType> ${lowerFirst(methodName)}($stateType currentState, $inputType ${lowerFirst(
+        cmd.inputType.name)}) {
           |  return effects().error("The command handler for `$methodName` is not implemented, yet");
           |}
           |""".stripMargin

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ReplicatedEntitySourceGeneratorSuite.scala
@@ -62,12 +62,12 @@ class ReplicatedEntitySourceGeneratorSuite extends munit.FunSuite {
             |  }
             |$expectedEmptyValue
             |  @Override
-            |  public Effect<Empty> set($expectedDataType currentData, ServiceOuterClass.SetValue command) {
+            |  public Effect<Empty> set($expectedDataType currentData, ServiceOuterClass.SetValue setValue) {
             |    return effects().error("The command handler for `Set` is not implemented, yet");
             |  }
             |
             |  @Override
-            |  public Effect<ServiceOuterClass.MyState> get($expectedDataType currentData, ServiceOuterClass.GetValue command) {
+            |  public Effect<ServiceOuterClass.MyState> get($expectedDataType currentData, ServiceOuterClass.GetValue getValue) {
             |    return effects().error("The command handler for `Get` is not implemented, yet");
             |  }
             |}

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGeneratorSuite.scala
@@ -61,12 +61,12 @@ class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
          |  }
          |
          |  @Override
-         |  public Effect<Empty> set(EntityOuterClass.MyState currentState, ServiceOuterClass.SetValue command) {
+         |  public Effect<Empty> set(EntityOuterClass.MyState currentState, ServiceOuterClass.SetValue setValue) {
          |    return effects().error("The command handler for `Set` is not implemented, yet");
          |  }
          |
          |  @Override
-         |  public Effect<ServiceOuterClass.MyState> get(EntityOuterClass.MyState currentState, ServiceOuterClass.GetValue command) {
+         |  public Effect<ServiceOuterClass.MyState> get(EntityOuterClass.MyState currentState, ServiceOuterClass.GetValue getValue) {
          |    return effects().error("The command handler for `Get` is not implemented, yet");
          |  }
          |}

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ValueEntitySourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ValueEntitySourceGenerator.scala
@@ -189,8 +189,8 @@ object ValueEntitySourceGenerator {
         semi = false)
 
     val methods = service.commands.map { cmd =>
-      s"""|override def ${lowerFirst(cmd.name)}(currentState: ${typeName(valueEntity.state.fqn)}, command: ${typeName(
-        cmd.inputType)}): ValueEntity.Effect[${typeName(cmd.outputType)}] =
+      s"""|override def ${lowerFirst(cmd.name)}(currentState: ${typeName(valueEntity.state.fqn)}, ${lowerFirst(
+        cmd.inputType.name)}: ${typeName(cmd.inputType)}): ValueEntity.Effect[${typeName(cmd.outputType)}] =
           |  effects.error("The command handler for `${cmd.name}` is not implemented, yet")
           |""".stripMargin
     }

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
@@ -43,10 +43,10 @@ class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
          |  override def emptyState: MyState =
          |    throw new UnsupportedOperationException("Not implemented yet, replace with your empty entity state")
          |
-         |  override def set(currentState: MyState, command: service.SetValue): ValueEntity.Effect[Empty] =
+         |  override def set(currentState: MyState, setValue: service.SetValue): ValueEntity.Effect[Empty] =
          |    effects.error("The command handler for `Set` is not implemented, yet")
          |
-         |  override def get(currentState: MyState, command: service.GetValue): ValueEntity.Effect[service.MyState] =
+         |  override def get(currentState: MyState, getValue: service.GetValue): ValueEntity.Effect[service.MyState] =
          |    effects.error("The command handler for `Get` is not implemented, yet")
          |}
          |""".stripMargin)


### PR DESCRIPTION
Pure aesthetics, but nice to users...

Aligns the command names in the abstract and implementation classes. 

The 'issue' manifests as following: 

The abstract class will have methods defined as: 

`abstract public Effect<Empty> increase(CounterDomain.CounterState currentState, CounterApi.IncreaseValue increaseValue)`

The impl class will have: 

`public Effect<Empty> increase(CounterDomain.CounterState currentState, CounterApi.IncreaseValue command)`

Note the difference in the command name: `increaseValue` vs. `command`.

When we add a new method to proto file, the abstract class will get a new method with an argument with the name of the command. 

In IntelliJ, user gets an error in impl class and let the IDE generate the method for them. The new generated method will have an argument like `increaseValue` (following the abstract method name). Now, the impl class will have a mix of commands names as `command` and as `someCommandName`. 


