### PR TITLE
chore: favor usage of FQN for proto component

### DIFF
--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/counter_api.proto
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/counter_api.proto
@@ -34,7 +34,7 @@ message CurrentCounter {
 service CounterService {
     option (akkaserverless.service) = {
         type : SERVICE_TYPE_ENTITY
-        component : ".domain.Counter"
+        component : "${package}.domain.Counter"
     };
 
     rpc Increase(IncreaseValue) returns (google.protobuf.Empty);

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/counter_api.proto
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/src/main/proto/__packageInPathFormat__/counter_api.proto
@@ -34,7 +34,7 @@ message CurrentCounter {
 service CounterService {
     option (akkaserverless.service) = {
         type : SERVICE_TYPE_ENTITY
-        component : ".domain.Counter"
+        component : "${package}.domain.Counter"
     };
 
     rpc Increase(IncreaseValue) returns (google.protobuf.Empty);


### PR DESCRIPTION
When I was preparing the value entity video, I found myself having to explain the syntax used to point to the component and came to the conclusion that this is an unnecessary complexity / distraction that we are imposing to the users. 

I still think that the annotation as we have today can be simplified to avoid this references, so maybe the change in this PR will become obsolete. Still, I would like to submit it to collect ideas. 

