### PR TITLE
chore: docs section title.

### DIFF
--- a/docs/src/modules/java/pages/index.adoc
+++ b/docs/src/modules/java/pages/index.adoc
@@ -116,7 +116,7 @@ include::example$scala-valueentity-customer-registry/src/main/scala/customer/Mai
 
 == What's next
 
-This section provides details on how to accomplish common tasks in Java:
+This section provides details on how to accomplish common tasks:
 
 * xref:quickstart-template.adoc[]
 * xref:proto.adoc[]


### PR DESCRIPTION
Very minor fix, the what's next section points to pages in Java and/or Scala, so better to omit 'in Java'.