### PR TITLE
chore: consolidate apidocs build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,12 +41,9 @@ attributes:
 
 apidocs:
 	mkdir -p "${managed_attachments}"
-	cd .. && sbt sdkJava/doc
-	cd .. && sbt sdkJavaTestKit/doc
+	cd .. && sbt sdkJava/doc sdkJavaTestKit/doc sdkScala/doc sdkScalaTestKit/doc
 	rsync -a ../sdk/java-sdk/target/api/ "${managed_attachments}/api/"
 	rsync -a ../testkit-java/target/api/ "${managed_attachments}/testkit/"
-	cd .. && sbt sdkScala/doc
-	cd .. && sbt sdkScalaTestKit/doc
 	rsync -a ../sdk/scala-sdk/target/scala-2.13/api/ "${managed_attachments}/scala-api/"
 	rsync -a ../sdk/scala-sdk-testkit/target/scala-2.13/api/ "${managed_attachments}/scala-testkit-api/"
 


### PR DESCRIPTION
Refs #523. Following improvements in #537, noticed that the docs build is running each apidocs build separately, and sbt recompiles the SDK sources for each of these builds. Haven't looked at why it hasn't manage to cache the compilation fully, but let's see how it is with these consolidated into one sbt session.