### PR TITLE
fix: samples using wrong snapshot version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,10 +222,10 @@ jobs:
       - checkout-and-merge-to-main
       - restore_deps_cache
       - setup_sbt
-      - set-sdk-version
       # note: depends on publish local as separate job before this
-      
-      - run: 
+      - copy-from-workspace
+      - set-sdk-version
+      - run:
           name: Run integration tests for Value Entity Archetype
           command: |
             cd maven-java
@@ -249,6 +249,7 @@ jobs:
       - restore_deps_cache
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Customer Registry quickstart
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,15 @@ commands:
       - run: 
           name: "Set SDK version"
           command: |
-            # tail 2 + head 1 because CircleCI adds an extra line
-            # the SDK_VERSION is later used to run the maven tests (see below)
-            echo 'export SDK_VERSION='`sbt "print sdkJava/version" | tail -n 2 | head -n 1` >> $BASH_ENV
+            if [ -e workspace/published-version ]; then
+              echo "Extracting version from previous publish step"
+              echo 'export SDK_VERSION='`cat workspace/published-version` >> $BASH_ENV
+            else
+              # tail 2 + head 1 because CircleCI adds an extra line
+              # the SDK_VERSION is later used to run the maven tests (see below)
+              echo "Extracting version from sbt build"
+              echo 'export SDK_VERSION='`sbt "print sdkJava/version" | tail -n 2 | head -n 1` >> $BASH_ENV
+            fi
 
   publish-local:
     description: Build and publish artifacts and plugins locally for other tests to use
@@ -89,12 +95,14 @@ commands:
       - run: mkdir -p workspace
       - run: cp -r ~/.m2 workspace/
       - run: cp -r ~/.ivy2 workspace/
+      - run: echo $SDK_VERSION workspace/published-version
       # copy published files to workspace for other jobs to pick up rather than build their own
       - persist_to_workspace:
           root: workspace
           paths:
             - .m2
             - .ivy2
+            - published-version
   copy-from-workspace:
     description: Copy locally published artifacts from workspace
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ commands:
       - run: mkdir -p workspace
       - run: cp -r ~/.m2 workspace/
       - run: cp -r ~/.ivy2 workspace/
-      - run: echo $SDK_VERSION workspace/published-version
+      - run: echo $SDK_VERSION > workspace/published-version
       # copy published files to workspace for other jobs to pick up rather than build their own
       - persist_to_workspace:
           root: workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
       - setup_sbt
       - set-sdk-version
       # note: depends on publish local as separate job before this
-      - copy-from-workspace
+      
       - run: 
           name: Run integration tests for Value Entity Archetype
           command: |
@@ -247,7 +247,6 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
       - run:
@@ -268,9 +267,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Fibonacci Action
           command: |
@@ -288,9 +287,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Doc snippets
           command: |
@@ -304,9 +303,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java first-service by archetype
           command: |
@@ -323,9 +322,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Value Entity Views "Customer Registry" sample
           command: |
@@ -343,9 +342,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Event Sourced Views "Customer Registry" sample
           command: |
@@ -363,9 +362,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Value Entity "Shopping Cart" sample
           command: |
@@ -383,9 +382,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Event Sourced Entity "Shopping Cart" sample
           command: |
@@ -403,9 +402,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Replicated Entity "Shopping Cart" sample
           command: |
@@ -423,9 +422,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Event Sourced "Counter" sample
           command: |
@@ -445,9 +444,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Value Entity "Counter" sample
           command: |
@@ -465,9 +464,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Java Replicated Entity examples
           command: |
@@ -485,9 +484,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Scala Fibonacci Action
           command: |
@@ -505,9 +504,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Scala Value Entity Customer Registry
           command: |
@@ -525,9 +524,9 @@ jobs:
       - checkout-and-merge-to-main
       - setup_sbt
       - restore_deps_cache
-      - set-sdk-version
       # note: depends on publish local as separate job before this
       - copy-from-workspace
+      - set-sdk-version
       - run:
           name: Scala Value Entity Counter
           command: |


### PR DESCRIPTION
I didn't figure out the reason, but something we merged touched the files somewhere between publishing locally and other jobs trying to determine SDK version and picking that up from the circle ci workspace, so that the SDK version published and the one the samples tried to use were not the same.

This change writes the version number, that was published locally, to a file in the workspace and jobs that wants to use the built artifact read that file instead of trying to use sbt to figure out what the current snapshot version is.