### PR TITLE
chore: make sure to always return the full set of generated files

### DIFF
--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EntityServiceSourceGenerator.scala
@@ -66,16 +66,13 @@ object EntityServiceSourceGenerator {
     interfaceSourcePath.getParent.toFile.mkdirs()
     Files.write(interfaceSourcePath, interfaceSource(service, entity, packageName, className).getBytes(Charsets.UTF_8))
 
-    val implSourceFiles = if (!implSourcePath.toFile.exists()) {
+    if (!implSourcePath.toFile.exists()) {
       // Now we generate the entity
       implSourcePath.getParent.toFile.mkdirs()
       Files.write(
         implSourcePath,
         source(service, entity, packageName, implClassName, interfaceClassName, entity.entityType).getBytes(
           Charsets.UTF_8))
-      List(implSourcePath)
-    } else {
-      List.empty
     }
 
     val handlerClassName = className + "Handler"
@@ -105,7 +102,7 @@ object EntityServiceSourceGenerator {
     val integrationTestSourcePath =
       integrationTestSourceDirectory
         .resolve(packagePath.resolve(integrationTestClassName + ".java"))
-    val integrationTestSourceFiles = if (!integrationTestSourcePath.toFile.exists()) {
+    if (!integrationTestSourcePath.toFile.exists()) {
       integrationTestSourcePath.getParent.toFile.mkdirs()
       Files.write(
         integrationTestSourcePath,
@@ -116,12 +113,14 @@ object EntityServiceSourceGenerator {
           entity,
           packageName,
           integrationTestClassName).getBytes(Charsets.UTF_8))
-      List(integrationTestSourcePath)
-    } else {
-      List.empty
     }
 
-    implSourceFiles ++ testSourceFiles ++ integrationTestSourceFiles :+ interfaceSourcePath :+ providerSourcePath :+ handlerSourcePath
+    Seq(
+      implSourcePath,
+      integrationTestSourcePath,
+      interfaceSourcePath,
+      providerSourcePath,
+      handlerSourcePath) ++ testSourceFiles
   }
 
   private[codegen] def source(
@@ -265,7 +264,7 @@ object EntityServiceSourceGenerator {
         |  public static ${className}Provider of(Function<EventSourcedEntityContext, $className> entityFactory) {
         |    return new ${className}Provider(entityFactory, EventSourcedEntityOptions.defaults());
         |  }
-        | 
+        |
         |  private ${className}Provider(
         |      Function<EventSourcedEntityContext, $className> entityFactory,
         |      EventSourcedEntityOptions options) {
@@ -277,7 +276,7 @@ object EntityServiceSourceGenerator {
         |  public final EventSourcedEntityOptions options() {
         |    return options;
         |  }
-        | 
+        |
         |  public final ${className}Provider withOptions(EventSourcedEntityOptions options) {
         |    return new ${className}Provider(entityFactory, options);
         |  }

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/MainSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/MainSourceGenerator.scala
@@ -62,10 +62,8 @@ object MainSourceGenerator {
       Files.write(
         mainClassPath,
         mainSource(mainClassPackageName, mainClassName, model.entities, model.services).getBytes(Charsets.UTF_8))
-      List(akkaServerlessFactorySourcePath, mainClassPath)
-    } else {
-      List(akkaServerlessFactorySourcePath)
     }
+    List(akkaServerlessFactorySourcePath, mainClassPath)
   }
 
   private[codegen] def mainSource(

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ViewServiceSourceGenerator.scala
@@ -59,8 +59,8 @@ object ViewServiceSourceGenerator {
     if (!implSourcePath.toFile.exists()) {
       implSourcePath.getParent.toFile.mkdirs()
       Files.write(implSourcePath, viewSource(service, packageName).getBytes(Charsets.UTF_8))
-      generatedSources += implSourcePath
     }
+    generatedSources += implSourcePath
 
     val handlerSourcePath = generatedSourceDirectory.resolve(packagePath.resolve(service.handlerName + ".java"))
     Files.write(handlerSourcePath, viewHandler(service, packageName).getBytes(Charsets.UTF_8))


### PR DESCRIPTION
That's what `sourceGenerators` in sbt expects. Otherwise, those files will
be missing from the set of generated files and will not be included in
compilation. This will lead to error during incremental recompilation

(I noticed that compilation of java-gen-compilation-tests only worked the first time).