### PR TITLE
chore: use more fully-qualified names, so that an action can actually be called "Action"

### DIFF
--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionServiceSourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionServiceSourceGenerator.scala
@@ -218,7 +218,7 @@ object ActionServiceSourceGenerator {
       val inputTypeFullName = cmd.inputType.fullName
 
       s"""|case "$methodName":
-          |  return (Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed>)(Object) action()
+          |  return (Source<Effect<?>, NotUsed>)(Object) action()
           |           .${lowerFirst(methodName)}(($inputTypeFullName) message.payload());
           |""".stripMargin
     }
@@ -238,7 +238,7 @@ object ActionServiceSourceGenerator {
       val inputTypeFullName = cmd.inputType.fullName
 
       s"""|case "$methodName":
-          |  return (Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed>)(Object) action()
+          |  return (Source<Effect<?>, NotUsed>)(Object) action()
           |           .${lowerFirst(methodName)}(stream.map(el -> ($inputTypeFullName) el.payload()));
           |""".stripMargin
     }
@@ -249,6 +249,7 @@ object ActionServiceSourceGenerator {
       otherImports = Seq(
         "akka.NotUsed",
         "akka.stream.javadsl.Source",
+        "com.akkaserverless.javasdk.action.Action.Effect",
         "com.akkaserverless.javasdk.action.MessageEnvelope",
         "com.akkaserverless.javasdk.impl.action.ActionHandler"))
 
@@ -265,7 +266,7 @@ object ActionServiceSourceGenerator {
         |  }
         |
         |  @Override
-        |  public com.akkaserverless.javasdk.action.Action.Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
+        |  public Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
         |    switch (commandName) {
         |      ${Format.indent(unaryCases, 6)}
         |      default:
@@ -275,7 +276,7 @@ object ActionServiceSourceGenerator {
         |
         |  @Override
         |  @SuppressWarnings("unchecked")
-        |  public Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed> handleStreamedOut(String commandName, MessageEnvelope<Object> message) {
+        |  public Source<Effect<?>, NotUsed> handleStreamedOut(String commandName, MessageEnvelope<Object> message) {
         |    switch (commandName) {
         |      ${Format.indent(streamOutCases, 6)}
         |      default:
@@ -284,7 +285,7 @@ object ActionServiceSourceGenerator {
         |  }
         |
         |  @Override
-        |  public com.akkaserverless.javasdk.action.Action.Effect<?> handleStreamedIn(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
+        |  public Effect<?> handleStreamedIn(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
         |    switch (commandName) {
         |      ${Format.indent(streamInCases, 6)}
         |      default:
@@ -294,7 +295,7 @@ object ActionServiceSourceGenerator {
         |
         |  @Override
         |  @SuppressWarnings("unchecked")
-        |  public Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed> handleStreamed(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
+        |  public Source<Effect<?>, NotUsed> handleStreamed(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
         |    switch (commandName) {
         |      ${Format.indent(streamInOutCases, 6)}
         |      default:

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ActionServiceSourceGeneratorSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ActionServiceSourceGeneratorSuite.scala
@@ -209,6 +209,7 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |
         |import akka.NotUsed;
         |import akka.stream.javadsl.Source;
+        |import com.akkaserverless.javasdk.action.Action.Effect;
         |import com.akkaserverless.javasdk.action.MessageEnvelope;
         |import com.akkaserverless.javasdk.impl.action.ActionHandler;
         |import com.external.Empty;
@@ -224,7 +225,7 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |  }
         |
         |  @Override
-        |  public com.akkaserverless.javasdk.action.Action.Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
+        |  public Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
         |    switch (commandName) {
         |      case "SimpleMethod":
         |        return action()
@@ -236,10 +237,10 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |
         |  @Override
         |  @SuppressWarnings("unchecked")
-        |  public Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed> handleStreamedOut(String commandName, MessageEnvelope<Object> message) {
+        |  public Source<Effect<?>, NotUsed> handleStreamedOut(String commandName, MessageEnvelope<Object> message) {
         |    switch (commandName) {
         |      case "StreamedOutputMethod":
-        |        return (Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed>)(Object) action()
+        |        return (Source<Effect<?>, NotUsed>)(Object) action()
         |                 .streamedOutputMethod((ServiceOuterClass.MyRequest) message.payload());
         |      default:
         |        throw new ActionHandler.HandlerNotFound(commandName);
@@ -247,7 +248,7 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |  }
         |
         |  @Override
-        |  public com.akkaserverless.javasdk.action.Action.Effect<?> handleStreamedIn(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
+        |  public Effect<?> handleStreamedIn(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
         |    switch (commandName) {
         |      case "StreamedInputMethod":
         |        return action()
@@ -259,10 +260,10 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |
         |  @Override
         |  @SuppressWarnings("unchecked")
-        |  public Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed> handleStreamed(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
+        |  public Source<Effect<?>, NotUsed> handleStreamed(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
         |    switch (commandName) {
         |      case "FullStreamedMethod":
-        |        return (Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed>)(Object) action()
+        |        return (Source<Effect<?>, NotUsed>)(Object) action()
         |                 .fullStreamedMethod(stream.map(el -> (ServiceOuterClass.MyRequest) el.payload()));
         |      default:
         |        throw new ActionHandler.HandlerNotFound(commandName);
@@ -285,6 +286,7 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |
         |import akka.NotUsed;
         |import akka.stream.javadsl.Source;
+        |import com.akkaserverless.javasdk.action.Action.Effect;
         |import com.akkaserverless.javasdk.action.MessageEnvelope;
         |import com.akkaserverless.javasdk.impl.action.ActionHandler;
         |import com.external.Empty;
@@ -300,7 +302,7 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |  }
         |
         |  @Override
-        |  public com.akkaserverless.javasdk.action.Action.Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
+        |  public Effect<?> handleUnary(String commandName, MessageEnvelope<Object> message) {
         |    switch (commandName) {
         |      case "SimpleMethod":
         |        return action()
@@ -312,10 +314,10 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |
         |  @Override
         |  @SuppressWarnings("unchecked")
-        |  public Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed> handleStreamedOut(String commandName, MessageEnvelope<Object> message) {
+        |  public Source<Effect<?>, NotUsed> handleStreamedOut(String commandName, MessageEnvelope<Object> message) {
         |    switch (commandName) {
         |      case "StreamedOutputMethod":
-        |        return (Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed>)(Object) action()
+        |        return (Source<Effect<?>, NotUsed>)(Object) action()
         |                 .streamedOutputMethod((ServiceOuterClass.MyRequest) message.payload());
         |      default:
         |        throw new ActionHandler.HandlerNotFound(commandName);
@@ -323,7 +325,7 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |  }
         |
         |  @Override
-        |  public com.akkaserverless.javasdk.action.Action.Effect<?> handleStreamedIn(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
+        |  public Effect<?> handleStreamedIn(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
         |    switch (commandName) {
         |      case "StreamedInputMethod":
         |        return action()
@@ -335,10 +337,10 @@ class ActionServiceSourceGeneratorSuite extends munit.FunSuite {
         |
         |  @Override
         |  @SuppressWarnings("unchecked")
-        |  public Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed> handleStreamed(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
+        |  public Source<Effect<?>, NotUsed> handleStreamed(String commandName, Source<MessageEnvelope<Object>, NotUsed> stream) {
         |    switch (commandName) {
         |      case "FullStreamedMethod":
-        |        return (Source<com.akkaserverless.javasdk.action.Action.Effect<?>, NotUsed>)(Object) action()
+        |        return (Source<Effect<?>, NotUsed>)(Object) action()
         |                 .fullStreamedMethod(stream.map(el -> (ServiceOuterClass.MyRequest) el.payload()));
         |      default:
         |        throw new ActionHandler.HandlerNotFound(commandName);


### PR DESCRIPTION
The TCK service defined in the framework (https://github.com/lightbend/akkaserverless-framework/blob/0de0598276015466b4a7ae97e9d63052919869dd/protocols/tck/src/main/protobuf/akkaserverless/tck/model/action/action.proto) is called Action, so names clash if we want to generate stubs for it.

`Action` might be generic and short enough that users might also stumble over this. Using more fully-qualified names in code generation avoids this issue.

It's a common problem in code generation that you can get naming clashes. We could go all in and use only FQNs for our fixed symbols but that seems a bit of overkill. Changing it for something like `Action` on the other hand might be useful. WDYT?