### PR TITLE
chore: assert replicated files for scala get generated

### DIFF
--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/test
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/test
@@ -65,6 +65,84 @@ $ exists target/scala-2.13/src_managed/main/com/example/valueentity/domain/Abstr
 $ exists src/main/scala/com/example/valueentity/domain/User.scala
 $ exists target/scala-2.13/src_managed/main/com/example/valueentity/domain/AbstractUser.scala
 
+# com/example/replicated/counter/counter_api.proto
+# com/example/replicated/counter/domain/counter_domain.proto
+# com/example/replicated/countermap/counter_map_api.proto
+$ exists src/main/scala/com/example/replicated/counter/domain/SomeCounter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/counter/domain/SomeCounterRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/counter/domain/SomeCounterProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/counter/domain/AbstractSomeCounter.scala
+
+# com/example/replicated/countermap/domain/counter_map_domain.proto
+# com/example/replicated/countermap/domain/counter_map_domain_scalar.proto
+$ exists src/main/scala/com/example/replicated/countermap/domain/SomeScalarCounterMap.scala
+$ exists src/main/scala/com/example/replicated/countermap/domain/SomeCounterMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/countermap/domain/SomeCounterMapProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/countermap/domain/SomeCounterMapRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/countermap/domain/SomeScalarCounterMapRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/countermap/domain/SomeScalarCounterMapProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/countermap/domain/AbstractSomeCounterMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/countermap/domain/AbstractSomeScalarCounterMap.scala
+
+# com/example/replicated/map/map_api.proto
+# com/example/replicated/map/domain/map_domain.proto
+# com/example/replicated/map/domain/map_domain_scalar.proto
+$ exists src/main/scala/com/example/replicated/map/domain/SomeMap.scala
+$ exists src/main/scala/com/example/replicated/map/domain/SomeScalarMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/map/domain/SomeMapRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/map/domain/SomeMapProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/map/domain/SomeScalarMapRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/map/domain/AbstractSomeMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/map/domain/AbstractSomeScalarMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/map/domain/SomeScalarMapProvider.scala
+
+# com/example/replicated/multimap/multi_map_api.proto
+# com/example/replicated/multimap/domain/multi_map_domain.proto
+# com/example/replicated/multimap/domain/multi_map_domain_scalar.proto
+$ exists src/main/scala/com/example/replicated/multimap/domain/SomeScalarMultiMap.scala
+$ exists src/main/scala/com/example/replicated/multimap/domain/SomeMultiMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/multimap/domain/AbstractSomeScalarMultiMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/multimap/domain/AbstractSomeMultiMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/multimap/domain/SomeMultiMapRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/multimap/domain/SomeMultiMapProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/multimap/domain/SomeScalarMultiMapProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/multimap/domain/SomeScalarMultiMapRouter.scala
+
+# com/example/replicated/register/register_api.proto
+# com/example/replicated/register/domain/register_domain.proto
+# com/example/replicated/register/domain/register_domain_scalar.proto
+$ exists src/main/scala/com/example/replicated/register/domain/SomeRegister.scala
+$ exists src/main/scala/com/example/replicated/register/domain/SomeScalarRegister.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/register/domain/SomeScalarRegisterProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/register/domain/SomeRegisterProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/register/domain/SomeRegisterRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/register/domain/AbstractSomeRegister.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/register/domain/AbstractSomeScalarRegister.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/register/domain/SomeScalarRegisterRouter.scala
+
+# com/example/replicated/registermap/register_map_api.proto
+# com/example/replicated/registermap/domain/register_map_domain_scalar.proto
+$ exists src/main/scala/com/example/replicated/registermap/domain/SomeRegisterMap.scala
+$ exists src/main/scala/com/example/replicated/registermap/domain/SomeScalarRegisterMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/registermap/domain/SomeRegisterMapRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/registermap/domain/SomeScalarRegisterMapRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/registermap/domain/AbstractSomeScalarRegisterMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/registermap/domain/SomeRegisterMapProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/registermap/domain/AbstractSomeRegisterMap.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/registermap/domain/SomeScalarRegisterMapProvider.scala
+
+# com/example/replicated/set/set_api.proto
+# com/example/replicated/set/domain/set_domain.proto
+# com/example/replicated/set/domain/set_domain_scalar.proto
+$ exists src/main/scala/com/example/replicated/set/domain/SomeSet.scala
+$ exists src/main/scala/com/example/replicated/set/domain/SomeScalarSet.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/set/domain/SomeScalarSetRouter.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/set/domain/SomeScalarSetProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/set/domain/SomeSetProvider.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/set/domain/AbstractSomeSet.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/set/domain/AbstractSomeScalarSet.scala
+$ exists target/scala-2.13/src_managed/main/com/example/replicated/set/domain/SomeSetRouter.scala
+
 > Test/compile
 
 # com/example/valueentity/some_value_entity_api.proto


### PR DESCRIPTION
This was missing on the PR that generated the file replicated files for Scala