### PR TITLE
chore: update publishing and running java tck to new project name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,7 +689,7 @@ jobs:
       - setup_sbt
       - restore_deps_cache
       - run: bin/docker-login-public-gcr.sh
-      - run: sbt tck/Docker/publish
+      - run: sbt tckJava/Docker/publish
       - save_deps_cache
 
   publish-docs:

--- a/tck/README.md
+++ b/tck/README.md
@@ -3,5 +3,5 @@
 Run the TCK (against the Akka Serverless TCK docker image):
 
 ```
-sbt tck/Test/run
+sbt tckJava/Test/run
 ```


### PR DESCRIPTION
Resolves #646. Java TCK was moved in #607.

Could also add a `tck` parent project so that `sbt tck/Docker/publish` still works, and can publish both Java and Scala TCK implementations.