### PR TITLE
chore: remove double space in curl/grpcurl

### DIFF
--- a/samples/java-eventsourced-shopping-cart/README.md
+++ b/samples/java-eventsourced-shopping-cart/README.md
@@ -50,13 +50,13 @@ For example, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 * Send an AddItem command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000  com.example.shoppingcart.ShoppingCartService/AddItem
+grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000 com.example.shoppingcart.ShoppingCartService/AddItem
 ```
 
 * Send a GetCart command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000  com.example.shoppingcart.ShoppingCartService/GetCart
+grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000 com.example.shoppingcart.ShoppingCartService/GetCart
 ```
 
 * Send a RemoveItem command:

--- a/samples/java-replicatedentity-shopping-cart/README.md
+++ b/samples/java-replicatedentity-shopping-cart/README.md
@@ -49,13 +49,13 @@ For example, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 * Send an AddItem command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000  com.example.shoppingcart.ShoppingCartService/AddItem
+grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000 com.example.shoppingcart.ShoppingCartService/AddItem
 ```
 
 * Send a GetCart command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000  com.example.shoppingcart.ShoppingCartService/GetCart
+grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000 com.example.shoppingcart.ShoppingCartService/GetCart
 ```
 
 * Send a RemoveItem command:

--- a/samples/java-valueentity-shopping-cart/README.md
+++ b/samples/java-valueentity-shopping-cart/README.md
@@ -50,13 +50,13 @@ For example, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 * Send an AddItem command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000  com.example.shoppingcart.ShoppingCartService/AddItem
+grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000 com.example.shoppingcart.ShoppingCartService/AddItem
 ```
 
 * Send a GetCart command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000  com.example.shoppingcart.ShoppingCartService/GetCart
+grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000 com.example.shoppingcart.ShoppingCartService/GetCart
 ```
 
 * Send a RemoveItem command:

--- a/samples/scala-eventsourced-shopping-cart/README.md
+++ b/samples/scala-eventsourced-shopping-cart/README.md
@@ -54,13 +54,13 @@ For example, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 * Send an AddItem command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000  com.example.shoppingcart.ShoppingCartService/AddItem
+grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000 com.example.shoppingcart.ShoppingCartService/AddItem
 ```
 
 * Send a GetCart command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000  com.example.shoppingcart.ShoppingCartService/GetCart
+grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000 com.example.shoppingcart.ShoppingCartService/GetCart
 ```
 
 * Send a RemoveItem command:

--- a/samples/scala-replicatedentity-shopping-cart/README.md
+++ b/samples/scala-replicatedentity-shopping-cart/README.md
@@ -52,13 +52,13 @@ For example, given [`grpcurl`](https://github.com/fullstorydev/grpcurl):
 * Send an AddItem command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000  com.example.shoppingcart.ShoppingCartService/AddItem
+grpcurl --plaintext -d '{"cart_id": "cart1", "product_id": "akka-tshirt", "name": "Akka t-shirt", "quantity": 3}' localhost:9000 com.example.shoppingcart.ShoppingCartService/AddItem
 ```
 
 * Send a GetCart command:
 
 ```shell
-grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000  com.example.shoppingcart.ShoppingCartService/GetCart
+grpcurl --plaintext -d '{"cart_id": "cart1"}' localhost:9000 com.example.shoppingcart.ShoppingCartService/GetCart
 ```
 
 * Send a RemoveItem command:


### PR DESCRIPTION
just clean up, as pointed out in https://github.com/lightbend/akkaserverless-java-sdk/pull/649