### PR TITLE
Do not merge, example: feat(kafka): local kafka testing with docker-compose-kafka.yaml.

### DIFF
--- a/samples/scala-eventsourced-counter/docker-compose-kafka.yml
+++ b/samples/scala-eventsourced-counter/docker-compose-kafka.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  akka-serverless-proxy:
+    image: gcr.io/akkaserverless-public/akkaserverless-proxy:0.7.3-2-62d61975
+    command: -Dconfig.resource=dev-mode.conf -Dakkaserverless.proxy.eventing.support=kafka
+    ports:
+      - "9000:9000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
+      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      KAFKA_CONFIG_PROPERTIES: /conf/confluent.properties
+    volumes:
+      - .:/conf


### PR DESCRIPTION
Example of testing with Kafka, volume mounted to (scala-eventsourced-counter) project directory. 
It expects a 'confluent.properties' file in the project directory (scala-eventsourced-counter).
