### PR TITLE
chore: Fix scala eventsourced customer registry docker build

### DIFF
--- a/samples/scala-eventsourced-customer-registry/build.sbt
+++ b/samples/scala-eventsourced-customer-registry/build.sbt
@@ -1,6 +1,6 @@
-name := "eventsourced-customer-registry"
+name := "customer-registry"
 
-organization := "com.akkaseverless.samples"
+organization := "com.akkaserverless.samples"
 organizationHomepage := Some(url("https://akkaserverless.com"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
@@ -10,6 +10,8 @@ enablePlugins(AkkaserverlessPlugin, JavaAppPackaging, DockerPlugin)
 dockerBaseImage := "docker.io/library/adoptopenjdk:11-jre-hotspot"
 dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
+// two Main files in this project changes entry point
+dockerEntrypoint := Seq("bin/main")
 ThisBuild / dynverSeparator := "-"
 
 Compile / scalacOptions ++= Seq(

--- a/samples/scala-valueentity-customer-registry/build.sbt
+++ b/samples/scala-valueentity-customer-registry/build.sbt
@@ -26,6 +26,11 @@ Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oDF")
 Test / logBuffered := false
 
+Compile / run := {
+  // needed for the proxy to access the user function on all platforms
+  sys.props += "akkaserverless.user-function-interface" -> "0.0.0.0"
+  (Compile / run).evaluated
+}
 run / fork := false
 Global / cancelable := false // ctrl-c
 


### PR DESCRIPTION
Refs #682

Two main classes lead to entry points not matching the auto-generated one so it could not actually be deployed.

Also, align the two scala customer registry projects a little bit

