### PR TITLE
feat(scalasdk): access to components for Scala entities

### DIFF
--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
@@ -108,6 +108,8 @@ class TestData(val packageNamingTemplate: PackageNaming) {
       "com.example.service.domain",
       javaOuterClassnameOption = packageNamingTemplate.javaOuterClassnameOption.map(_ => s"EntityOuterClass$suffix"))
 
+  val mainPackage: PackageNaming = PackageNaming.noDescriptor("com.example")
+
   val externalProto: PackageNaming =
     PackageNaming(
       "external_domain.proto",

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/EventSourcedEntitySourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/EventSourcedEntitySourceGenerator.scala
@@ -17,7 +17,9 @@
 package com.akkaserverless.codegen.scalasdk.impl
 
 import com.akkaserverless.codegen.scalasdk.File
+import com.lightbend.akkasls.codegen.FullyQualifiedName
 import com.lightbend.akkasls.codegen.ModelBuilder
+import com.lightbend.akkasls.codegen.PackageNaming
 
 object EventSourcedEntitySourceGenerator {
   import ScalaGeneratorUtils._
@@ -30,15 +32,17 @@ object EventSourcedEntitySourceGenerator {
 
   def generateManaged(
       eventSourcedEntity: ModelBuilder.EventSourcedEntity,
-      service: ModelBuilder.EntityService): Seq[File] =
+      service: ModelBuilder.EntityService,
+      mainPackageName: PackageNaming): Seq[File] =
     Seq(
-      abstractEntity(eventSourcedEntity, service),
+      abstractEntity(eventSourcedEntity, service, mainPackageName),
       handler(eventSourcedEntity, service),
       provider(eventSourcedEntity, service))
 
   private[codegen] def abstractEntity(
       eventSourcedEntity: ModelBuilder.EventSourcedEntity,
-      service: ModelBuilder.EntityService): File = {
+      service: ModelBuilder.EntityService,
+      mainPackageName: PackageNaming): File = {
     import Types.EventSourcedEntity._
     val abstractEntityName = eventSourcedEntity.abstractEntityName
 
@@ -60,6 +64,9 @@ object EventSourcedEntitySourceGenerator {
           }
       }
 
+    val Components = FullyQualifiedName.noDescriptor(mainPackageName.javaPackage + ".Components")
+    val ComponentsImpl = FullyQualifiedName.noDescriptor(mainPackageName.javaPackage + ".ComponentsImpl")
+
     generate(
       eventSourcedEntity.fqn.parent,
       abstractEntityName,
@@ -67,6 +74,9 @@ object EventSourcedEntitySourceGenerator {
           |
           |/** An event sourced entity. */
           |abstract class $abstractEntityName extends $EventSourcedEntity[$stateType] {
+          |
+          |  def components: $Components =
+          |    new ${ComponentsImpl}(commandContext())
           |
           |  $commandHandlers
           |  $eventHandlers

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/SourceGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/SourceGenerator.scala
@@ -36,9 +36,9 @@ object SourceGenerator {
         case service: ModelBuilder.EntityService =>
           model.lookupEntity(service) match {
             case entity: ModelBuilder.ValueEntity =>
-              ValueEntitySourceGenerator.generateManaged(entity, service)
+              ValueEntitySourceGenerator.generateManaged(entity, service, mainPackageName)
             case entity: ModelBuilder.EventSourcedEntity =>
-              EventSourcedEntitySourceGenerator.generateManaged(entity, service)
+              EventSourcedEntitySourceGenerator.generateManaged(entity, service, mainPackageName)
             case entity: ModelBuilder.ReplicatedEntity =>
               ReplicatedEntitySourceGenerator.generateManaged(entity, service)
           }

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/EventSourcedEntitySourceGeneratorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/EventSourcedEntitySourceGeneratorSuite.scala
@@ -58,12 +58,15 @@ class EventSourcedEntitySourceGeneratorSuite extends munit.FunSuite {
          |""".stripMargin)
   }
   test("it can generate an abstract event sourced entity implementation") {
-    val str = abstractEntity(testData.eventSourcedEntity(), testData.simpleEntityService()).content
+    val str =
+      abstractEntity(testData.eventSourcedEntity(), testData.simpleEntityService(), testData.mainPackage).content
     assertNoDiff(
       str,
       s"""|package com.example.service.domain
           |
           |import com.akkaserverless.scalasdk.eventsourcedentity.EventSourcedEntity
+          |import com.example.Components
+          |import com.example.ComponentsImpl
           |import com.example.service
           |import com.external.Empty
           |
@@ -73,6 +76,9 @@ class EventSourcedEntitySourceGeneratorSuite extends munit.FunSuite {
           |
           |/** An event sourced entity. */
           |abstract class AbstractMyEntity extends EventSourcedEntity[MyState] {
+          |
+          |  def components: Components =
+          |    new ComponentsImpl(commandContext())
           |
           |  def set(currentState: MyState, setValue: service.SetValue): EventSourcedEntity.Effect[Empty]
           |

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ValueEntitySourceGeneratorSuite.scala
@@ -58,12 +58,14 @@ class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
          |""".stripMargin)
   }
   test("it can generate an abstract value entity implementation") {
-    val str = abstractEntity(testData.valueEntity(), testData.simpleEntityService()).content
+    val str = abstractEntity(testData.valueEntity(), testData.simpleEntityService(), testData.mainPackage).content
     assertNoDiff(
       str,
       s"""package com.example.service.domain
           |
           |import com.akkaserverless.scalasdk.valueentity.ValueEntity
+          |import com.example.Components
+          |import com.example.ComponentsImpl
           |import com.example.service
           |import com.external.Empty
           |
@@ -73,6 +75,9 @@ class ValueEntitySourceGeneratorSuite extends munit.FunSuite {
           |
           |/** A value entity. */
           |abstract class AbstractMyValueEntity extends ValueEntity[MyState] {
+          |
+          |  def components: Components =
+          |    new ComponentsImpl(commandContext())
           |
           |  /** Command handler for "Set". */
           |  def set(currentState: MyState, setValue: service.SetValue): ValueEntity.Effect[Empty]


### PR DESCRIPTION
I had missed adding component access to the Scala entities when I noticed it was needed for the TCK and did the same for the Java side earlier.