### PR TITLE
fix: make sure user-function.desc has actually been copied for Scala SDK projects

### DIFF
--- a/project/ReflectiveCodeGen.scala
+++ b/project/ReflectiveCodeGen.scala
@@ -152,7 +152,11 @@ object ReflectiveCodeGen extends AutoPlugin {
       "--descriptor_set_out",
       protobufDescriptorSetOut.value.getAbsolutePath,
       "--include_source_info"),
-    Compile / managedResources += protobufDescriptorSetOut.value,
+    Compile / managedResources += {
+      // make sure the file has been generated
+      val _ = (Compile / PB.generate).value
+      protobufDescriptorSetOut.value
+    },
     Compile / unmanagedResourceDirectories ++= (Compile / PB.protoSources).value,
     Compile / generateUnmanaged := {
       if ((Compile / copyUnmanagedSources).value) {

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/test
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/test
@@ -1,4 +1,4 @@
-> compile
+> products
 
 $ exists src/main/scala/com/example/Main.scala
 $ exists target/scala-2.13/src_managed/main/com/example/AkkaServerlessFactory.scala
@@ -148,6 +148,9 @@ $ exists target/scala-2.13/src_managed/main/com/example/replicated/set/domain/So
 # com/example/valueentity/domain/some_value_entity_domain.proto
 $ exists src/test/scala/com/example/valueentity/domain/SomeValueEntitySpec.scala
 $ exists src/test/scala/com/example/valueentity/SomeValueEntityServiceIntegrationSpec.scala
+
+# Descriptor set must be included in classpath
+$ must-mirror target/scala-2.13/classes/protobuf/descriptor-sets/user-function.desc target/scala-2.13/resource_managed/main/protobuf/descriptor-sets/user-function.desc
 
 > Test/compile
 $ exists target/scala-2.13/src_managed/test/com/example/valueentity/domain/SomeValueEntityTestKit.scala


### PR DESCRIPTION
Follow up to #701.

If it worked before then only by chance, because there was a race condition between `user-function.desc` being generated and being copied to the `target/scala_2.13/classes` folder.