### PR TITLE
fix: avoiding match error

### DIFF
--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/eventsourcedentity/EventSourcedEntityEffectImpl.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/eventsourcedentity/EventSourcedEntityEffectImpl.scala
@@ -80,7 +80,9 @@ private[scalasdk] final case class EventSourcedEntityEffectImpl[R, S](
     }.asJavaCollection))
 
   def thenAddSideEffect(sideEffect: S => SideEffect): EventSourcedEntity.Effect.OnSuccessBuilder[S] =
-    EventSourcedEntityEffectImpl(javasdkEffect.thenAddSideEffect { case ScalaSideEffectAdapter(s) => s })
+    EventSourcedEntityEffectImpl(javasdkEffect.thenAddSideEffect { s =>
+      sideEffect(s) match { case ScalaSideEffectAdapter(s) => s }
+    })
 
   def thenForward[T](serviceCall: S => DeferredCall[_, T]): EventSourcedEntity.Effect[T] = EventSourcedEntityEffectImpl(
     javasdkEffect.thenForward[T] { s =>


### PR DESCRIPTION
When implementing 
```
class Counter(context: EventSourcedEntityContext) extends AbstractCounter {
  override def emptyState: CounterState = CounterState()

   override def increaseWithSideEffect(
      currentState: CounterState,
      increaseValue: example.IncreaseValue): EventSourcedEntity.Effect[Empty] =
    if (increaseValue.value < 0) {
      effects.error("Value must be a zero or a positive number")
    } else {
      effects
        .emitEvent(ValueIncreased(increaseValue.value))
        .thenAddSideEffect(_ => SideEffect(components.counter.increase(example.IncreaseValue(context.entityId,increaseValue.value * 2))))
        .thenReply(_ => Empty())
    } 
```

it was throwing the following error.
```
[info]   scala.MatchError: CounterState(1,UnknownFieldSet(Map())) (of class com.example.domain.CounterState)
[info]   at com.akkaserverless.scalasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl.$anonfun$thenAddSideEffect$1(EventSourcedEntityEffectImpl.scala:83)
[info]   at com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl.$anonfun$secondaryEffect$1(EventSourcedEntityEffectImpl.scala:62)
```
References #322