### PR TITLE
Only apply CustomerCreated once, on an empty state

### DIFF
--- a/samples/scala-eventsourced-customer-registry/src/main/scala/customer/view/CustomerByNameView.scala
+++ b/samples/scala-eventsourced-customer-registry/src/main/scala/customer/view/CustomerByNameView.scala
@@ -18,7 +18,7 @@ class CustomerByNameView(context: ViewContext) extends AbstractCustomerByNameVie
 
   override def processCustomerCreated(
     state: Customer, customerCreated: CustomerCreated): UpdateEffect[Customer] = // <3>
-    if (state != emptyState) effects.ignore() // already  created
+    if (state != emptyState) effects.ignore() // already created
     else effects.updateState(convertToApi(customerCreated.customer.get))
 
   override def processCustomerNameChanged(

--- a/samples/scala-eventsourced-customer-registry/src/main/scala/customer/view/CustomerByNameView.scala
+++ b/samples/scala-eventsourced-customer-registry/src/main/scala/customer/view/CustomerByNameView.scala
@@ -18,7 +18,7 @@ class CustomerByNameView(context: ViewContext) extends AbstractCustomerByNameVie
 
   override def processCustomerCreated(
     state: Customer, customerCreated: CustomerCreated): UpdateEffect[Customer] = // <3>
-    if (state == emptyState) effects.ignore() // already  created
+    if (state != emptyState) effects.ignore() // already  created
     else effects.updateState(convertToApi(customerCreated.customer.get))
 
   override def processCustomerNameChanged(


### PR DESCRIPTION
If we get a CustomerCreated and the state is already initialized (non-empty), do not apply twice.