### PR TITLE
Fix Scala components package name clash 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,6 +571,26 @@ jobs:
             rm -rf src/main/scala src/test/scala src/it/scala
             sbt -Dakkaserverless-sdk.version=$SDK_VERSION test:compile
 
+  scala-customer-registry-quickstart:
+    machine: true
+    steps:
+      - checkout-and-merge-to-main
+      - setup_sbt
+      - restore_deps_cache
+      # note: depends on publish local as separate job before this
+      - copy-from-workspace
+      - set-sdk-version
+      - run:
+          name: Scala Customer Registry Quickstart
+          command: |
+            cd samples/scala-customer-registry-quickstart
+            echo "Running sbt with SDK version: '$SDK_VERSION'"
+            sbt -Dakkaserverless-sdk.version=$SDK_VERSION test
+            # FIXME integration tests
+            echo "==== Verifying that generated unmanaged sources compile ===="
+            rm -rf src/main/scala src/test/scala src/it/scala
+            sbt -Dakkaserverless-sdk.version=$SDK_VERSION test:compile
+
   sample-scala-eventsourced-customer-registry:
     machine: true
     steps:
@@ -902,6 +922,10 @@ workflows:
             - checks
             - publish-local
       - sample-scala-valueentity-shopping-cart:
+          requires:
+            - checks
+            - publish-local
+      - scala-customer-registry-quickstart:
           requires:
             - checks
             - publish-local


### PR DESCRIPTION
The Scala quickstart was broken because of having a top package that has the same name as one of the components (`customer`)

We didn't catch it since the quickstart was not part of CI validation.