### PR TITLE
chore: move quickstart pages to sdk

### DIFF
--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-java.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-java.adoc
@@ -1,0 +1,231 @@
+= Quickstart: Customer Registry in Java
+
+include::java:partial$attributes.adoc[]
+
+Learn how to create a customer registry in Java, package it into a container, and run it on Akka Serverless.
+
+== Before you begin
+
+* If you're new to Akka Serverless, {console}[create an account, window="console"] so you can try out Akka Serverless for free.
+* You'll also need to install the xref:akkasls:install-akkasls.adoc[Akka Serverless CLI, window="new-doc"] if you want to deploy from a terminal window.
+* For this quickstart, you'll also need
+** https://docs.docker.com/engine/install[Docker {minimum_docker_version} or higher, window="new"]
+** Java {java-version} or higher
+** https://maven.apache.org/download.cgi[Maven 3.x or higher, window="new"]
+** https://github.com/fullstorydev/grpcurl#installation[`grpcurl`, window="new"]
+
+[NOTE]
+====
+If you want to bypass writing code and jump straight to the deployment:
+
+. Download the source code using the Akka Serverless CLI: 
+`akkasls quickstart download customer-registry-java`
+
+. Skip to <<Package and deploy your service>>.
+====
+
+== Writing the Customer Registry
+
+. From the command line, create a directory for your project.
++
+[source,command line]
+----
+mkdir customerregistry
+----
+
+. Change into the project directory.
++
+[source,command line]
+----
+cd customerregistry
+----
+
+. Download the `pom.xml` file
++
+[source,command line]
+----
+curl -OL https://raw.githubusercontent.com/lightbend/akkaserverless-java-sdk/main/samples/java-customer-registry-quickstart/pom.xml
+----
+
+. Update the `dockerImage` property (line 13 of the `pom.xml` file) with your container registry name.
+
+== Define the external API
+
+The Customer Registry service will create or retrieve a customer, including their email, phone number and mailing address. The `customer_api.proto` will contain the external API your clients will invoke.
+
+. In your project, create two directories for you protobuf files, `src/main/proto/customer/domain` and `src/main/proto/customer/api`.
+[.tabset]
+Linux or macOS::
++
+--
+[source,command line]
+----
+mkdir -p ./src/main/proto/customer/api
+mkdir -p ./src/main/proto/customer/domain
+----
+--
+Windows 10+::
++
+--
+[source,command line]
+----
+mkdir src/main/proto/customer/api
+mkdir src/main/proto/customer/domain
+----
+--
+
+. Create a `customer_api.proto` file and save it in the `src/main/proto/customer/api` directory.
+
+. Add declarations for:
++
+* The protobuf syntax version, `proto3`.
+* The package name, `customer.api`.
+* The required Java outer classname, `CustomerAPI`. Messages defined in this file will be generated as inner classes.
+* Import `google/protobuf/empty.proto` and Akka Serverless `akkaserverless/annotations.proto`.
++
+[source,proto,indent=0]
+.src/main/proto/customer/api/customer_api.proto
+----
+include::java:example$java-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto[tag=declarations]
+----
+
+. Add the service endpoint
++
+[source,proto,indent=0]
+.src/main/proto/customer/api/customer_api.proto
+----
+include::java:example$java-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto[tag=service]
+----
+
+. Add messages to define the fields that comprise a `Customer` object (and its compound `Address`)
++
+[source,proto,indent=0]
+.src/main/proto/customer/api/customer_api.proto
+----
+include::java:example$java-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto[tag=messages]
+----
+
+. Add the message that will identify which customer to retrieve for the `GetCustomer` message:
++
+[source,proto,indent=0]
+.src/main/proto/customer/api/customer_api.proto
+----
+include::java:example$java-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto[tag=method-messages]
+----
+
+== Define the domain model
+
+The `customer_domain.proto` contains all the internal data objects (xref:reference:glossary.adoc#entity[Entities, window="new"]). The xref:reference:glossary.adoc#value_entity[Value Entity, window="new"] in this quickstart is a Key/Value store that stores only the latest updates.
+
+. Create a `customer_domain.proto` file and save it in the `src/main/proto/customer/domain` directory.
+
+. Add declarations for the proto syntax, Akka Serverless annotations, and domain model:attribute: value
++
+* The package name, `customer.domain`.
+* The Java outer classname, `CustomerDomain`.
++
+[source,proto,indent=0]
+.src/main/proto/customer/domain/customer_domain.proto
+----
+include::java:example$java-customer-registry-quickstart/src/main/proto/customer/domain/customer_domain.proto[tag=declarations]
+----
+
+. Add the option that the Maven plugin will use to generate the `Customer` Value entity, which will be of type `customers` and whose state will be defined in a `CustomerState` message:
++
+[source,proto,indent=0]
+.src/main/proto/customer/domain/customer_domain.proto
+----
+include::java:example$java-customer-registry-quickstart/src/main/proto/customer/domain/customer_domain.proto[tag=entity]
+----
+
+. Add the `CustomerState` message with fields for entity data, and the `Address` message that defines the compound address:
++
+[source,proto,indent=0]
+.src/main/proto/customer/domain/customer_domain.proto
+----
+include::java:example$java-customer-registry-quickstart/src/main/proto/customer/domain/customer_domain.proto[tag=domain]
+----
+
+. Run `mvn compile` from the project root directory to generate source classes in which you add business logic.
++
+----
+mvn compile
+----
+
+== Create command handlers
+
+Command handlers, as the name suggests, handle incoming requests before persisting them.
+
+. If it's not open already, open `src/main/java/customer/domain/Customer.java` for editing.
+
+. Modify the `create` method by adding the logic to handle the command. The complete method should include the following:
++
+[source, java]
+.src/main/java/customer/domain/Customer.java
+----
+include::java:example$java-customer-registry-quickstart/src/main/java/customer/domain/Customer.java[tag=create]
+----
++
+* The incoming message contains the request data from your client and the command handler updates the state of the customer.
+* The `convertToDomain` and `convertAddressToDomain` methods convert the incoming request to your domain model.
+
+. Modify the `getCustomer` method as follows to handle the `GetCustomerRequest` command:
++
+[source, java, indent=0]
+.src/main/java/customer/domain/Customer.java
+----
+include::java:example$java-customer-registry-quickstart/src/main/java/customer/domain/Customer.java[tag=getCustomer]
+----
++
+* If that customer doesn't exist, processing the command fails.
+* If the customer exists, the reply message contains the customer's information.
+* The `convertToApi` method converts the state of the customer to a response message for your external API.
++
+
+[NOTE]
+====
+The `src/main/java/customer/Main.java` file already contains the required code to start your service and register it with Akka Serverless.
+====
+
+== Package and deploy your service
+
+To compile, build the container image, and publish it to your container registry, follow these steps
+
+. From the root project directory, compile the source code using Maven:
++
+[source, command line]
+----
+mvn compile
+----
+
+. Use the `deploy` target to build the container image and publish it to your container registry. At the end of this command Maven will show you the container image URL you'll need in the next part of this quickstart.
++
+[source, command line]
+----
+mvn deploy
+----
+
+. Sign in to your Akka Serverless account at: {console}
+. If you do not have a project, click *Add Project* to create one, otherwise choose the project you want to deploy your service to.
+. On the project dashboard click the "+" next to *services* to start the deployment wizard
+. Choose a name for your service and click *Next*
+. Enter the container image URL from the above step and click *Next*
+. Click *Next* (no environment variables are needed for these samples)
+. Check both _Add a route to this service_ and _Enable CORS_ and click *Next*
+. Click *Finish* to start the deployment
+. Click *Go to Service* to see your newly deployed service
+
+== Invoke your service
+
+Now that you have deployed your service, the next step is to invoke it using gRPCurl
+
+. From the "_Service Explorer_" click on the method you want to invoke
+. Click on "_gRPCurl_"
+. In the bottom section of the dialog, fill in the values you want to send to your service
+. In the top section of the dialog, click the "_Copy to clipboard_" button
+. Open a new command line and paste the content you just copied
+
+== Next steps
+
+* You can learn more about Value Entities in the xref:java:value-entity.adoc[reference documentation].
+* Continue this example by xref:cr-value-entity-views-java.adoc[adding Views], which makes it possible to query the customer registry.

--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-scala.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-scala.adoc
@@ -1,0 +1,237 @@
+= Quickstart: Customer Registry in Scala
+
+include::java:partial$attributes.adoc[]
+
+Learn how to create a customer registry in Scala, package it into a container, and run it on Akka Serverless.
+
+== Before you begin
+
+* If you're new to Akka Serverless, {console}[create an account, window="console"] so you can try out Akka Serverless for free.
+* You'll also need to install the xref:akkasls:install-akkasls.adoc[Akka Serverless CLI, window="new-doc"] if you want to deploy from a terminal window.
+* For this quickstart, you'll also need
+** https://docs.docker.com/engine/install[Docker {minimum_docker_version} or higher, window="new"]
+** Java {java-version} or higher
+** https://www.scala-sbt.org/download.html[sbt 1.4 or higher, window="new"]
+** https://github.com/fullstorydev/grpcurl#installation[`grpcurl`, window="new"]
+
+[NOTE]
+====
+If you want to bypass writing code and jump straight to the deployment:
+
+. Download the source code using the Akka Serverless CLI: 
+`akkasls quickstart download customer-registry-scala`
+
+. Skip to <<Package and deploy your service>>.
+====
+
+== Writing the Customer Registry
+
+. From the command line, create a directory for your project.
++
+[source,command line]
+----
+mkdir customerregistry
+----
+
+. Change into the project directory.
++
+[source,command line]
+----
+cd customerregistry
+----
+
+. Download the `build.sbt` file
++
+[source,command line]
+----
+curl -OL https://raw.githubusercontent.com/lightbend/akkaserverless-java-sdk/main/samples/scala-customer-registry-quickstart/build.sbt
+----
+
+. Create the sbt `project` directory
++
+[source,command line]
+----
+mkdir project
+----
+
+. Download the `plugins.sbt`
+[source,command line]
+----
+curl -L https://raw.githubusercontent.com/lightbend/akkaserverless-java-sdk/main/samples/scala-customer-registry-quickstart/project/plugins.sbt -o project/plugins.sbt
+----
+
+
+== Define the external API
+
+The Customer Registry service will create or retrieve a customer, including their email, phone number and mailing address. The `customer_api.proto` will contain the external API your clients will invoke.
+
+. In your project, create two directories for you protobuf files, `src/main/proto/customer/domain` and `src/main/proto/customer/api`.
+[.tabset]
+Linux or macOS::
++
+--
+[source,command line]
+----
+mkdir -p ./src/main/proto/customer/api
+mkdir -p ./src/main/proto/customer/domain
+----
+--
+Windows 10+::
++
+--
+[source,command line]
+----
+mkdir src/main/proto/customer/api
+mkdir src/main/proto/customer/domain
+----
+--
+
+. Create a `customer_api.proto` file and save it in the `src/main/proto/customer/api` directory.
+
+. Add declarations for:
++
+* The protobuf syntax version, `proto3`.
+* The package name, `customer.api`.
+* Import `google/protobuf/empty.proto` and Akka Serverless `akkaserverless/annotations.proto`.
++
+[source,proto,indent=0]
+.src/main/proto/customer/api/customer_api.proto
+----
+include::java:example$scala-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto[tag=declarations]
+----
+
+. Add the service endpoint
++
+[source,proto,indent=0]
+.src/main/proto/customer/api/customer_api.proto
+----
+include::java:example$scala-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto[tag=service]
+----
+
+. Add messages to define the fields that comprise a `Customer` object (and its compound `Address`)
++
+[source,proto,indent=0]
+.src/main/proto/customer/api/customer_api.proto
+----
+include::java:example$scala-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto[tag=messages]
+----
+
+. Add the message that will identify which customer to retrieve for the `GetCustomer` message:
++
+[source,proto,indent=0]
+.src/main/proto/customer/api/customer_api.proto
+----
+include::java:example$scala-customer-registry-quickstart/src/main/proto/customer/api/customer_api.proto[tag=method-messages]
+----
+
+== Define the domain model
+
+The `customer_domain.proto` contains all the internal data objects (xref:reference:glossary.adoc#entity[Entities, window="new"]). The xref:reference:glossary.adoc#value_entity[Value Entity, window="new"] in this quickstart is a Key/Value store that stores only the latest updates.
+
+. Create a `customer_domain.proto` file and save it in the `src/main/proto/customer/domain` directory.
+
+. Add declarations for the proto syntax, Akka Serverless annotations, and domain model:attribute: value
++
+* The package name, `customer.domain`.
+* The Java outer classname, `CustomerDomain`.
++
+[source,proto,indent=0]
+.src/main/proto/customer/domain/customer_domain.proto
+----
+include::java:example$scala-customer-registry-quickstart/src/main/proto/customer/domain/customer_domain.proto[tag=declarations]
+----
+
+. Add the option that the sbt plugin will use to generate the `Customer` Value entity, which will be of type `customers` and whose state will be defined in a `CustomerState` message:
++
+[source,proto,indent=0]
+.src/main/proto/customer/domain/customer_domain.proto
+----
+include::java:example$scala-customer-registry-quickstart/src/main/proto/customer/domain/customer_domain.proto[tag=entity]
+----
+
+. Add the `CustomerState` message with fields for entity data, and the `Address` message that defines the compound address:
++
+[source,proto,indent=0]
+.src/main/proto/customer/domain/customer_domain.proto
+----
+include::java:example$scala-customer-registry-quickstart/src/main/proto/customer/domain/customer_domain.proto[tag=domain]
+----
+
+. Run `sbt compile` from the project root directory to generate source classes in which you add business logic.
++
+----
+sbt compile
+----
+
+== Create command handlers
+
+Command handlers, as the name suggests, handle incoming requests before persisting them.
+
+. If it's not open already, open `src/main/scala/customer/domain/Customer.scala` for editing.
+
+. Modify the `create` method by adding the logic to handle the command. The complete method should include the following:
++
+[source, scala]
+.src/main/scala/customer/domain/Customer.scala
+----
+include::java:example$scala-customer-registry-quickstart/src/main/scala/customer/domain/Customer.scala[tag=create]
+----
++
+* The incoming message contains the request data from your client and the command handler updates the state of the customer.
+* The `convertToDomain` and `convertAddressToDomain` methods convert the incoming request to your domain model.
+
+. Modify the `getCustomer` method as follows to handle the `GetCustomerRequest` command:
++
+[source, scala, indent=0]
+.src/main/scala/customer/domain/Customer.scala
+----
+include::java:example$scala-customer-registry-quickstart/src/main/scala/customer/domain/Customer.scala[tag=getCustomer]
+----
++
+* If that customer doesn't exist, processing the command fails.
+* If the customer exists, the reply message contains the customer's information.
+* The `convertToApi` method converts the state of the customer to a response message for your external API.
++
+
+[NOTE]
+====
+The `src/main/scala/customer/Main.scala` file already contains the required code to start your service and register it with Akka Serverless.
+====
+
+== Package and deploy your service
+
+To compile, build the container image, and publish it to your container registry, follow these steps
+
+. From the root project directory, compile the source code using sbt:
++
+[source, command line]
+----
+sbt compile
+----
+
+. Use the `deploy` task to build the container image and publish it to your container registry. At the end of this command sbt will show you the container image URL you'll need in the next part of this quickstart.
++
+[source, command line]
+----
+sbt docker:publish -Ddocker.username=[your-docker-hub-username]
+----
+
+. Sign in to your Akka Serverless account at: {console}
+. If you do not have a project, click *Add Project* to create one, otherwise choose the project you want to deploy your service to.
+. On the project dashboard click the "+" next to *services* to start the deployment wizard
+. Choose a name for your service and click *Next*
+. Enter the container image URL from the above step and click *Next*
+. Click *Next* (no environment variables are needed for these samples)
+. Check both _Add a route to this service_ and _Enable CORS_ and click *Next*
+. Click *Finish* to start the deployment
+. Click *Go to Service* to see your newly deployed service
+
+== Invoke your service
+
+Now that you have deployed your service, the next step is to invoke it using gRPCurl
+
+. From the "_Service Explorer_" click on the method you want to invoke
+. Click on "_gRPCurl_"
+. In the bottom section of the dialog, fill in the values you want to send to your service
+. In the top section of the dialog, click the "_Copy to clipboard_" button
+. Open a new command line and paste the content you just copied

--- a/docs/src/modules/java/pages/quickstart/cr-value-entity-views-java.adoc
+++ b/docs/src/modules/java/pages/quickstart/cr-value-entity-views-java.adoc
@@ -1,0 +1,196 @@
+= Quickstart: Customer Registry with Views in Java
+
+include::java:partial$attributes.adoc[]
+
+Create a customer registry that includes queries in Java, package it into a container, and run it on Akka Serverless.
+
+== In this Quickstart you will learn:
+
+* How to add additional functionality, allowing customers to be queried by name and email.
+* How to package the customer registry into a container.
+* How to deploy and run the customer registry on Akka Serverless.
+
+== Before you begin
+
+* If you're new to Akka Serverless, {console}[create an account, window="console"] so you can try out Akka Serverless for free.
+* You'll also need to install the xref:akkasls:install-akkasls.adoc[Akka Serverless CLI, window="new-doc"] if you want to deploy from a terminal window.
+* For this quickstart, you'll also need
+** https://docs.docker.com/engine/install[Docker {minimum_docker_version} or higher, window="new"]
+** Java {java-version} or higher
+** https://maven.apache.org/download.cgi[Maven 3.x or higher, window="new"]
+** https://github.com/fullstorydev/grpcurl#installation[`grpcurl`, window="new"]
+
+[NOTE]
+====
+If you want to bypass writing code and jump straight to the deployment:
+
+. Download the source code using the Akka Serverless CLI: 
+`akkasls quickstart download customer-registry-views-java`
+
+. Skip to <<Package and deploy your service>>.
+====
+
+== Start from the Customer Registry Entity
+
+Start by downloading the  xref:cr-value-entity-java.adoc[Customer Registry Quickstart] source code using the Akka Serverless CLI:
+
+[source,command line]
+----
+akkasls quickstart download customer-registry-java
+----
+
+You can access the `Customer` xref:reference:glossary.adoc#entity[Entity] with its xref:reference:glossary.adoc#entity_key[Entity key]. In this guide we will describe how to retrieve customers by email or name instead.
+
+== Define the CustomerByEmail View
+
+. In your project, create a directory for your views protobuf files, `src/main/proto/customer/view`.
+[.tabset]
+Linux or macOS::
++
+--
+[source,command line]
+----
+mkdir -p ./src/main/proto/customer/view
+----
+--
+Windows 10+::
++
+--
+[source,command line]
+----
+mkdir src/main/proto/customer/view
+----
+--
+
+. Create a `customer_view.proto` file and save it in the `src/main/proto/customer/view` directory.
+
++
+[source,proto,indent=0]
+.src/main/proto/customer/view/customer_view.proto
+----
+include::java:example$java-customer-registry-views-quickstart/src/main/proto/customer/view/customer_view.proto[tag=declarations]
+----
+<1> The protobuf syntax version, `proto3`.
+<2> The package name, `customer.view`.
+<3> The Java outer classname, `CustomerViewModel`. Messages defined in this file will be generated as inner classes, for example `CustomerViewModel.ByEmailRequest`.
+<4> Import the proto files for your domain model `customer/domain/customer_domain.proto` and Akka Serverless annotations `akkaserverless/annotations.proto`.
+
+. Add the service endpoint
++
+[source,proto,indent=0]
+.src/main/proto/customer/view/customer_view.proto
+----
+include::java:example$java-customer-registry-views-quickstart/src/main/proto/customer/view/customer_view.proto[tag=CustomerByEmail]
+----
+<1> The Protobuf `service` for the View.
+<2> The option that the Maven plugin will use to generate the `CustomerByEmail` View.
+<3> The `UpdateCustomer` method defines how Akka Serverless will update the view.
+<4> The source of the View is the `"customers"` Value Entity. This identifier is defined in the `entity_type: "customers"` property of the `(akkaserverless.file).value_entity` option in the `customer_domain.proto` file.
+<5> The `(akkaserverless.method).view.update` annotation defines that this method is used for updating the View. You must define the `table` attribute for the table to be used in the query. Pick any name and use it in the query `SELECT` statement.
+<6> The `GetCustomers` method defines the query to retrieve a customer by email.
+<7> The `(akkaserverless.method).view.query` annotation defines that this method is used as a query of the View.
++
+NOTE: In this sample we use the internal `domain.CustomerState` as the state of the view. This is convenient since it allows automatic updates of the view without any logic but has the draw back that it implicitly makes the `domain.CustomerState` type a part of the public service API. Transforming the state to another type than the incoming update will be illustrated in the `CustomerByName` example.
+
+. Run `mvn compile` from the project root directory to generate source classes from the Protobuf definitions.
++
+----
+mvn compile
+----
++
+This will result in a compilation error in the `Main` class. That is expected because you added a new component. Fix the compilation error by adding `CustomerByEmailView::new` as the second parameter to `AkkaServerlessFactory.withComponents` in `src/main/java/customer/Main.java`.
+
+[#deploy]
+== Package and deploy your service
+
+To compile, build the container image, and publish it to your container registry, follow these steps
+
+. From the root project directory, compile the source code using Maven:
++
+[source, command line]
+----
+mvn compile
+----
+
+. Use the `deploy` target to build the container image and publish it to your container registry. At the end of this command Maven will show you the container image URL you'll need in the next part of this quickstart.
++
+[source, command line]
+----
+mvn deploy
+----
+
+. Sign in to your Akka Serverless account at: {console}
+. If you do not have a project, click *Add Project* to create one, otherwise choose the project you want to deploy your service to.
+. On the project dashboard click the "+" next to *services* to start the deployment wizard
+. Choose a name for your service and click *Next*
+. Enter the container image URL from the above step and click *Next*
+. Click *Next* (no environment variables are needed for these samples)
+. Check both _Add a route to this service_ and _Enable CORS_ and click *Next*
+. Click *Finish* to start the deployment
+. Click *Go to Service* to see your newly deployed service
+
+[#invoke]
+== Invoke your service
+
+Now that you have deployed your service, the next step is to create a Customer using gRPCurl:
+
+. From the "_Service Explorer_" click on the `Create` method in `CustomerService`
+. Click on "_gRPCurl_"
+. In the bottom section of the dialog, fill in the values you want to send to your service
+. In the top section of the dialog, click the "_Copy to clipboard_" button
+. Open a new command line and paste the content you just copied
+
+Then you can try to find the Customer by email using gRPCurl as described above but with the `GetCustomer` method in `CustomerByEmail` instead.
+
+
+== Define the CustomerByName View
+
+. In the same `src/main/proto/customer/view/customer_view.proto` file add another View for finding customers by name.
++
+Add the service endpoint
++
+[source,proto,indent=0]
+.src/main/proto/customer/view/customer_view.proto
+----
+include::java:example$java-customer-registry-views-quickstart/src/main/proto/customer/view/customer_view.proto[tag=CustomerByName]
+----
+<1> The `UpdateCustomer` method defines how Akka Serverless will update the view. In this case use a `CustomerViewState` that is different from the incoming `domain.CustomerState`.
+<2> `transform_updates: true` defines that you want custom code in the `UpdateCustomer` method.
+<3> The `GetCustomers` method defines the query to retrieve customers by name.
+
+. Run `mvn compile` from the project root directory to generate source classes from the Protobuf definitions.
++
+----
+mvn compile
+----
++
+Again, this will result in a compilation error in the `Main` class. That is expected because you added a new component. Fix the compilation error by adding `CustomerByNameView::new` as the third parameter to `AkkaServerlessFactory.withComponents` in `src/main/java/customer/Main.java`.
+
+== Implement UpdateCustomer
+
+. Implement the `emptyState` and `updateCustomer` method in `CustomerByEmailView`:
++
+[source, java, indent=0]
+.src/main/java/customer/view/CustomerByEmailView.java
+----
+include::java:example$java-customer-registry-views-quickstart/src/main/java/customer/view/CustomerByNameView.java[tag=view]
+----
+<1> Empty state that will be used if no previous state has been stored for the View.
+<2> From the incoming `CustomerDomain.CustomerState` that represents the change from the Value Entity create a `CustomerViewModel.CustomerViewState`.
+<3> Return `effects().updateState` with the new state for the View.
++
+NOTE: The state of the View is still per Entity. The `CustomerDomain.CustomerState customerState` parameter represents the changed state of a specific Value Entity. The `state` parameter is the existing state, if any, of the View for the Entity, i.e. the state that was previously returned via `effects().updateState`. If no previous state has been stored the `emptyState()` is used.
+
+== Deploy the updated service
+
+. Deploy the updated service by repeating the steps in <<deploy>>.
+
+== Invoke the CustomerByName
+
+. Similar to the steps in <<invoke>>
+. Create several customers with same name
+. Use the new `CustomerByName` instead of `CustomerByEmail` and then you should see multiple results from `CustomerByName/GetCustomers` for customers with the same name
+
+== Next steps
+
+* You can read more about Views in the xref:java:views.adoc[reference documentation].

--- a/docs/src/modules/java/pages/quickstart/sc-eventsourced-entity-java.adoc
+++ b/docs/src/modules/java/pages/quickstart/sc-eventsourced-entity-java.adoc
@@ -1,0 +1,286 @@
+= Quickstart: Shopping Cart in Java
+
+include::java:partial$attributes.adoc[]
+
+Learn how to create a shopping cart in Java, package it into a container, and run it on Akka Serverless.
+
+== Before you begin
+
+* If you're new to Akka Serverless, {console}[create an account, window="console"] so you can try out Akka Serverless for free.
+* You'll also need to install the xref:akkasls:install-akkasls.adoc[Akka Serverless CLI, window="new-doc"] if you want to deploy from a terminal window.
+* For this quickstart, you'll also need
+** https://docs.docker.com/engine/install[Docker {minimum_docker_version} or higher, window="new"]
+** Java {java-version} or higher
+** https://maven.apache.org/download.cgi[Maven 3.x or higher, window="new"]
+** https://github.com/fullstorydev/grpcurl#installation[`grpcurl`, window="new"]
+
+[NOTE]
+====
+If you want to bypass writing code and jump straight to the deployment:
+
+. Download the source code using the Akka Serverless CLI:
+`akkasls quickstart download shopping-cart-java`
+
+. Skip to <<Package and deploy your service>>.
+====
+
+== Writing the Shopping Cart
+
+. From the command line, create a directory for your project.
++
+[source,command line]
+----
+mkdir shoppingcart
+----
+
+. Change into the project directory.
++
+[source,command line]
+----
+cd shoppingcart
+----
+
+. Download the `pom.xml` file
++
+[source,command line]
+----
+curl -OL https://raw.githubusercontent.com/lightbend/akkaserverless-java-sdk/main/samples/java-shopping-cart-quickstart/pom.xml
+----
+
+. Update the `dockerImage` property (line 13 of the `pom.xml` file) with your container registry name.
+
+== Define the external API
+
+The Shopping Cart service will store shopping carts for your customers, including the items in those carts. The `shoppingcart_api.proto` will contain the external API your clients will invoke.
+
+. In your project, create a `src/main/proto/shopping/cart/api` and a `src/main/proto/shopping/cart/domain` directory.
+[.tabset]
+Linux or macOS::
++
+--
+[source,command line]
+----
+mkdir -p ./src/main/proto/shopping/cart/api
+mkdir -p ./src/main/proto/shopping/cart/domain
+----
+--
+Windows 10+::
++
+--
+[source,command line]
+----
+mkdir src/main/proto/shopping/cart/api
+mkdir src/main/proto/shopping/cart/domain
+----
+--
+
+. Create a `shopping_cart_api.proto` file and save it in the `src/main/proto/shopping/cart/api` directory.
+
+. Add declarations for:
++
+* The protobuf syntax version, `proto3`.
+* The package name, `shopping.cart.api`.
+* The required Java outer classname, `ShoppingCartAPI`. Messages defined in this file will be generated as inner classes.
+* Import `google/protobuf/empty.proto` and Akka Serverless `akkaserverless/annotations.proto`.
++
+[source,proto,indent=0]
+.src/main/proto/shopping/cart/shopping_cart_api.proto
+----
+include::java:example$java-shopping-cart-quickstart/src/main/proto/shopping/cart/api/shopping_cart_api.proto[tag=declarations]
+----
+
+. Add the service endpoint
++
+[source,proto,indent=0]
+.src/main/proto/shopping/cart/api/shopping_cart_api.proto
+----
+include::java:example$java-shopping-cart-quickstart/src/main/proto/shopping/cart/api/shopping_cart_api.proto[tag=service]
+----
+
+. Add messages to define the fields that comprise a `Cart` object (and its compound `LineItem`)
++
+[source,proto,indent=0]
+.src/main/proto/shopping/cart/api/shopping_cart_api.proto
+----
+include::java:example$java-shopping-cart-quickstart/src/main/proto/shopping/cart/api/shopping_cart_api.proto[tag=messages]
+----
+
+. Add the messages to carry the arguments for the service calls:
++
+[source,proto,indent=0]
+.src/main/proto/shopping/cart/api/shopping_cart_api.proto
+----
+include::java:example$java-shopping-cart-quickstart/src/main/proto/shopping/cart/api/shopping_cart_api.proto[tag=method-messages]
+----
+
+== Define the domain model
+
+The `shopping_cart_domain.proto` contains all the internal data objects (xref:reference:glossary.adoc#entity[Entities, window="new"]). The xref:reference:glossary.adoc#event_sourced_entity[Event Sourced Entity, window="new"] in this quickstart keeps all events sent for a specific shopping cart in a journal.
+
+. Create a `shopping_cart_domain.proto` file and save it in the `src/main/proto/shopping/cart/domain` directory.
+
+. Add declarations for the proto syntax, the Akka Serverless annotations, and package name
++
+[source,proto,indent=0]
+.src/main/proto/shopping/cart/domain/shopping_cart_domain.proto
+----
+include::java:example$java-shopping-cart-quickstart/src/main/proto/shopping/cart/domain/shopping_cart_domain.proto[tag=declarations]
+----
+
+. Add the `CartState` message with fields for entity data and the `LineItem` message that defines the compound line item:
++
+[source,proto,indent=0]
+.src/main/proto/shopping/cart/domain/shopping_cart_domain.proto
+----
+include::java:example$java-shopping-cart-quickstart/src/main/proto/shopping/cart/domain/shopping_cart_domain.proto[tag=state]
+----
+
+. Event Sourced entities work based on events. Add the events that can occur in this quickstart:
++
+[source,proto,indent=0]
+.src/main/proto/shopping/cart/domain/shopping_cart_domain.proto
+----
+include::java:example$java-shopping-cart-quickstart/src/main/proto/shopping/cart/domain/shopping_cart_domain.proto[tag=events]
+----
+
+. Run `mvn compile` from the project root directory to generate source classes in which you add business logic.
++
+----
+mvn compile
+----
+
+== Create command handlers
+
+Command handlers, as the name suggests, handle incoming API requests. State is not updated directly by command handlers.
+Instead, if state should be updated, an event is persisted that describes the intended transaction.
+
+. Open `src/main/java/shopping/cart/domain/ShoppingCartEntity.java` for editing.
+
+. Add some imports that are needed later:
++
+[source, java]
+.src/main/java/shopping/cart/domain/ShoppingCartEntity.java
+----
+include::java:example$java-shopping-cart-quickstart/src/main/java/shopping/cart/domain/ShoppingCartEntity.java[tag=imports]
+----
++
+
+
+. Modify the `emptyState` method to return the initial state for the entity. The method should look
+  like this:
++
+[source, java]
+.src/main/java/shopping/cart/domain/ShoppingCartEntity.java
+----
+include::java:example$java-shopping-cart-quickstart/src/main/java/shopping/cart/domain/ShoppingCartEntity.java[tag=emptyState]
+----
++
+
+. Modify the `addItem` method by adding the logic to handle the command. The complete method should include the following:
++
+[source, java]
+.src/main/java/shopping/cart/domain/ShoppingCartEntity.java
+----
+include::java:example$java-shopping-cart-quickstart/src/main/java/shopping/cart/domain/ShoppingCartEntity.java[tag=addItem]
+----
++
+* This method will handle an incoming API request. It gets passed the current state and the request
+  argument.
+* It checks the input parameters and fails using an `error` effect if the precondition fails.
+* Otherwise, it creates an `ItemAdded` event that is persisted by using the `emitEvent` effect.
+
+. Modify the `getCart` method as follows to handle the `GetShoppingCart` command:
++
+[source, java, indent=0]
+.src/main/java/shopping/cart/domain/ShoppingCartEntity.java
+----
+include::java:example$java-shopping-cart-quickstart/src/main/java/shopping/cart/domain/ShoppingCartEntity.java[tag=getCart]
+----
++
+* The method takes the current internal state and converts it to the API model.
+* Each `LineItem` in the state is converted to its corresponding API form using the `convert` method.
++
+
+. Modify the `removeItem` method by adding the logic to handle removing an item. The complete method should include the following:
++
+[source, java]
+.src/main/java/shopping/cart/domain/ShoppingCartEntity.java
+----
+include::java:example$java-shopping-cart-quickstart/src/main/java/shopping/cart/domain/ShoppingCartEntity.java[tag=removeItem]
+----
++
+* This method will handle removing an item from the shopping cart. It will first check the precondition whether the requested item
+  can be currently found in the shopping cart. If not, the API call returns an error effect.
+* If the item is found, the handler creates an `ItemRemoved` event that is persisted by using the `emitEvent` effect.
+
+== Create event handlers
+
+Event handlers maintain the state of an entity by sequentially applying the effects of events to the local state.
+
+. Modify the `itemAdded` event handling method by adding the logic to apply the event to the state:
++
+[source, java, indent=0]
+.src/main/java/shopping/cart/domain/ShoppingCartEntity.java
+----
+include::java:example$java-shopping-cart-quickstart/src/main/java/shopping/cart/domain/ShoppingCartEntity.java[tag=itemAdded]
+----
++
+* First, the method looks for an existing line item for the newly added product.
+* If an existing item is found, its quantity is adjusted.
+* Otherwise, the new item can be directly added to the cart (after conversion from API to domain types)
+* Finally, the new cart state is returned.
+* Several helper methods convert between API and domain types and help with management of state.
+
+. Modify the `itemRemoved` event handling method by adding the logic to apply the event to the state:
++
+[source, java, indent=0]
+.src/main/java/shopping/cart/domain/ShoppingCartEntity.java
+----
+include::java:example$java-shopping-cart-quickstart/src/main/java/shopping/cart/domain/ShoppingCartEntity.java[tag=itemRemoved]
+----
++
+* The method removes the given product from the cart and returns the new state.
+
+
+[NOTE]
+====
+The `src/main/java/shopping/cart/Main.java` file already contains the required code to start your service and register it with Akka Serverless.
+====
+
+== Package and deploy your service
+
+To compile, build the container image, and publish it to your container registry, follow these steps
+
+. From the root project directory, compile the source code using Maven:
++
+[source, command line]
+----
+mvn compile
+----
+
+. Use the `deploy` target to build the container image and publish it to your container registry. At the end of this command Maven will show you the container image URL you'll need in the next part of this quickstart.
++
+[source, command line]
+----
+mvn deploy
+----
+
+. Sign in to your Akka Serverless account at: {console}
+. If you do not have a project, click *Add Project* to create one, otherwise choose the project you want to deploy your service to.
+. On the project dashboard click the "+" next to *services* to start the deployment wizard
+. Choose a name for your service and click *Next*
+. Enter the container image URL from the above step and click *Next*
+. Click *Next* (no environment variables are needed for these samples)
+. Check both _Add a route to this service_ and _Enable CORS_ and click *Next*
+. Click *Finish* to start the deployment
+. Click *Go to Service* to see your newly deployed service
+
+== Invoke your service
+
+Now that you have deployed your service, the next step is to invoke it using gRPCurl
+
+. From the "_Service Explorer_" click on the method you want to invoke
+. Click on "_gRPCurl_"
+. In the bottom section of the dialog, fill in the values you want to send to your service
+. In the top section of the dialog, click the "_Copy to clipboard_" button
+. Open a new command line and paste the content you just copied


### PR DESCRIPTION
Moving here some pages that are in the https://github.com/lightbend/akkaserverless-docs/, but should be here. They import files from the samples and therefore must be include in the build here. Otherwise we risk to break them easily. 

The same will need to be done on the javascript sdk. 

I will also PR the docs to remove the pages there. 

There is one thing though, the pages in the `akkaserverless-docs` have a `include::ROOT:partial$include.adoc[]` and it's not clear to me why we have this file. 
In any case, it doesn't seem to make a difference. I could build the full documentation locally and didn't notice a difference. This file is probably added already in all pages and therefore this include is probably obsolete. 

It will be good to have someone with some more experience with Antora to clarify this. 