### PR TITLE
chore: extra compile tests

### DIFF
--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/domain_in_service_package/user_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/domain_in_service_package/user_api.proto
@@ -1,0 +1,57 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the public API offered by your entity.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.domain_in_service_package;
+
+option java_outer_classname = "UserApi";
+
+message CreateUser {
+  string user_id = 1 [(akkaserverless.field).entity_key = true];
+  string name = 2;
+}
+
+
+message GetUser {
+  string user_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentUser {
+  int32 value = 1;
+}
+
+message UserState {
+  string name = 1;
+}
+
+service UserService {
+
+  option (akkaserverless.codegen) = {
+    value_entity: {
+      // Entity is generated in same package as this service
+      name: "User"
+      entity_type: "user"
+      // state is defined in same package as this service (in this file)
+      state: "UserState"
+    }
+  };
+
+  rpc Create (CreateUser) returns (google.protobuf.Empty);
+  rpc GetCurrentUser (GetUser) returns (CurrentUser);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/named/view/user_view.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/named/view/user_view.proto
@@ -1,0 +1,79 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.named.view;
+
+option java_outer_classname = "UserViewModel";
+
+import "com/example/valueentity/domain/user_domain.proto";
+import "akkaserverless/annotations.proto";  
+
+service UserByName {
+  option (akkaserverless.codegen) = {
+    view: {
+      name: "MyUserByNameView"
+    }
+  };
+
+  // purposely using a projection query up top to detect using the wrong state type
+  rpc GetCustomersProjected(ByNameRequest) returns (stream UserProjection) {
+    option (akkaserverless.method).view.query = {
+      query: "SELECT name  FROM users WHERE name = :name"
+    };
+  }
+
+  rpc UpdateCustomer(valueentity.domain.UserState) returns (valueentity.domain.UserState) {
+    option (akkaserverless.method).eventing.in = {
+      value_entity: "users"
+    };
+    option (akkaserverless.method).view.update = {
+      table: "users"
+      transform_updates: true
+    };
+  }
+
+  rpc GetCustomers(ByNameRequest) returns (stream valueentity.domain.UserState) {
+    option (akkaserverless.method).view.query = {
+      query: "SELECT * FROM users WHERE name = :name"
+    };
+  }
+}
+
+message ByNameRequest {
+  string user_name = 1;
+}
+
+message UserProjection {
+  string name = 1;
+}
+
+// test coverage for a view with no transformations
+service AdditionalView {
+  option (akkaserverless.codegen) = {
+    view: {
+      name: "MyAdditionalView"
+    }
+  };
+
+  rpc UpdateCustomer(valueentity.domain.UserState) returns (valueentity.domain.UserState) {
+    option (akkaserverless.method).eventing.in = {
+      value_entity: "users_no_transform"
+    };
+    option (akkaserverless.method).view.update = {
+      table: "users_no_transform"
+    };
+  }
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/eventsourcedentity/counter_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/eventsourcedentity/counter_api.proto
@@ -1,0 +1,60 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the public API offered by your entity.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.eventsourcedentity;
+
+option java_outer_classname = "CounterApi";
+
+message IncreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message DecreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message ResetValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message GetCounter {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentCounter {
+  int32 value = 1;
+}
+
+service CounterService { 
+  option (akkaserverless.codegen) = {
+    event_sourced_entity: {
+      entity_type: "counter"
+      state: ".domain.CounterState"
+      events: [".domain.Increased", ".domain.Decreased"]
+    }
+  };
+
+  rpc Increase (IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease (DecreaseValue) returns (google.protobuf.Empty);
+  rpc Reset (ResetValue) returns (google.protobuf.Empty);
+  rpc GetCurrentCounter (GetCounter) returns (CurrentCounter);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/eventsourcedentity/domain/counter_domain.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/eventsourcedentity/domain/counter_domain.proto
@@ -1,0 +1,31 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.unnamed.eventsourcedentity.domain;
+
+option java_outer_classname = "CounterDomain";
+
+message CounterState {
+  int32 value = 1;
+}
+
+message Increased {
+  int32 value = 1;
+}
+
+message Decreased {
+  int32 value = 1;
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/counter/counter_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/counter/counter_api.proto
@@ -1,0 +1,53 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.replicated.counter;
+
+option java_outer_classname = "SomeCounterApi";
+
+message IncreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message DecreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message GetValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentValue {
+  int32 value = 1;
+}
+
+service CounterService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-counter"
+      replicated_counter: {}
+    }
+  };
+
+  rpc Increase(IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease(DecreaseValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/countermap/counter_map_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/countermap/counter_map_api.proto
@@ -1,0 +1,84 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.replicated.countermap;
+
+option java_outer_classname = "SomeCounterMapApi";
+
+message IncreaseValue {
+  string counter_map_id = 1 [(akkaserverless.field).entity_key = true];
+  string key = 2;
+  int32 value = 3;
+}
+
+message DecreaseValue {
+  string counter_map_id = 1 [(akkaserverless.field).entity_key = true];
+  string key = 2;
+  int32 value = 3;
+}
+
+message GetValue {
+  string counter_map_id = 1 [(akkaserverless.field).entity_key = true];
+  string key = 2;
+}
+
+message CurrentValue {
+  int32 value = 1;
+}
+
+message GetAllValues {
+  string counter_map_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentValues {
+  map<string, int32> values = 1;
+}
+
+service CounterMapService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-counter-map"
+      replicated_counter_map: {
+        key: ".domain.SomeKey"
+      }
+    }
+  };
+
+  rpc Increase(IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease(DecreaseValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+  rpc GetAll(GetAllValues) returns (CurrentValues);
+}
+
+service ScalarCounterMapService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-scalar-counter-map"
+      replicated_counter_map: {
+        key: "int64"
+      }
+    }
+  };
+
+
+  rpc Increase(IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease(DecreaseValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+  rpc GetAll(GetAllValues) returns (CurrentValues);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/countermap/domain/counter_map_domain.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/countermap/domain/counter_map_domain.proto
@@ -1,0 +1,25 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.unnamed.replicated.countermap.domain;
+
+import "akkaserverless/annotations.proto";
+
+option java_outer_classname = "SomeCounterMapDomain";
+
+message SomeKey {
+  string key = 1;
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/map/domain/map_domain.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/map/domain/map_domain.proto
@@ -1,0 +1,23 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.unnamed.replicated.map.domain;
+
+option java_outer_classname = "SomeMapDomain";
+
+message SomeKey {
+  string key = 1;
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/map/map_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/map/map_api.proto
@@ -1,0 +1,93 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.replicated.map;
+
+option java_outer_classname = "SomeMapApi";
+
+message IncreaseFooValue {
+  string map_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message DecreaseFooValue {
+  string map_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message SetBarValue {
+  string map_id = 1 [(akkaserverless.field).entity_key = true];
+  string value = 2;
+}
+
+message AddBazValue {
+  string map_id = 1 [(akkaserverless.field).entity_key = true];
+  string value = 2;
+}
+
+message RemoveBazValue {
+  string map_id = 1 [(akkaserverless.field).entity_key = true];
+  string value = 2;
+}
+
+message GetValues {
+  string map_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentValues {
+  int32 foo = 1;
+  string bar = 2;
+  repeated string baz = 3;
+}
+
+service MapService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-map"
+      replicated_map: {
+        key: ".domain.SomeKey"
+      }
+    }
+  };
+
+  rpc IncreaseFoo(IncreaseFooValue) returns (google.protobuf.Empty);
+  rpc DecreaseFoo(DecreaseFooValue) returns (google.protobuf.Empty);
+  rpc SetBar(SetBarValue) returns (google.protobuf.Empty);
+  rpc AddBaz(AddBazValue) returns (google.protobuf.Empty);
+  rpc RemoveBaz(RemoveBazValue) returns (google.protobuf.Empty);
+  rpc Get(GetValues) returns (CurrentValues);
+}
+
+service ScalarMapService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-scalar-map"
+      replicated_map: {
+        key: "string"
+      }
+    }
+  };
+
+  rpc IncreaseFoo(IncreaseFooValue) returns (google.protobuf.Empty);
+  rpc DecreaseFoo(DecreaseFooValue) returns (google.protobuf.Empty);
+  rpc SetBar(SetBarValue) returns (google.protobuf.Empty);
+  rpc AddBaz(AddBazValue) returns (google.protobuf.Empty);
+  rpc RemoveBaz(RemoveBazValue) returns (google.protobuf.Empty);
+  rpc Get(GetValues) returns (CurrentValues);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/multimap/domain/multi_map_domain.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/multimap/domain/multi_map_domain.proto
@@ -1,0 +1,27 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.unnamed.replicated.multimap.domain;
+
+option java_outer_classname = "SomeMultiMapDomain";
+
+message SomeKey {
+  string key = 1;
+}
+
+message SomeValue {
+  string value = 1;
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/multimap/multi_map_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/multimap/multi_map_api.proto
@@ -1,0 +1,95 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.replicated.multimap;
+
+option java_outer_classname = "SomeMultiMapApi";
+
+message Key {
+  string key = 1;
+}
+
+message Value {
+  string value = 1;
+}
+
+message PutValue {
+  string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
+  Key key = 2;
+  Value value = 3;
+}
+
+message RemoveValue {
+  string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
+  Key key = 2;
+  Value value = 3;
+}
+
+message GetValues {
+  string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
+  Key key = 2;
+}
+
+message CurrentValues {
+  Key key = 1;
+  repeated Value values = 2;
+}
+
+message GetAllValues {
+  string multi_map_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message AllCurrentValues {
+  repeated CurrentValues all_values = 1;
+}
+
+service MultiMapService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-multi-map"
+      replicated_multi_map: {
+        key: ".domain.SomeKey"
+        value: ".domain.SomeValue"
+      }
+    }
+  };
+
+  rpc Put(PutValue) returns (google.protobuf.Empty);
+  rpc Remove(RemoveValue) returns (google.protobuf.Empty);
+  rpc Get(GetValues) returns (CurrentValues);
+  rpc GetAll(GetAllValues) returns (AllCurrentValues);
+}
+
+service ScalarMultiMapService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-scalar-multi-map"
+      replicated_multi_map: {
+        key: "string"
+        value: "double"
+      }
+    }
+  };
+
+
+  rpc Put(PutValue) returns (google.protobuf.Empty);
+  rpc Remove(RemoveValue) returns (google.protobuf.Empty);
+  rpc Get(GetValues) returns (CurrentValues);
+  rpc GetAll(GetAllValues) returns (AllCurrentValues);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/register/domain/register_domain.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/register/domain/register_domain.proto
@@ -1,0 +1,23 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.unnamed.replicated.register.domain;
+
+option java_outer_classname = "SomeRegisterDomain";
+
+message SomeValue {
+  string value = 1;
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/register/register_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/register/register_api.proto
@@ -1,0 +1,64 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.replicated.register;
+
+option java_outer_classname = "SomeRegisterApi";
+
+message SetValue {
+  string register_id = 1 [(akkaserverless.field).entity_key = true];
+  string value = 2;
+}
+
+message GetValue {
+  string register_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentValue {
+  string value = 1;
+}
+
+service RegisterService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-register"
+      replicated_register: {
+        value: ".domain.SomeValue"
+      }
+    }
+  };
+
+  rpc Set(SetValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+}
+
+service ScalarRegisterService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-scalar-register"
+      replicated_register: {
+        value: "bytes"
+      }
+    }
+  };
+
+
+  rpc Set(SetValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/registermap/domain/register_map_domain.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/registermap/domain/register_map_domain.proto
@@ -1,0 +1,27 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.unnamed.replicated.registermap.domain;
+
+option java_outer_classname = "SomeRegisterMapDomain";
+
+message SomeKey {
+  string key = 1;
+}
+
+message SomeValue {
+  string value = 1;
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/registermap/register_map_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/registermap/register_map_api.proto
@@ -1,0 +1,87 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.replicated.registermap;
+
+option java_outer_classname = "SomeRegisterMapApi";
+
+message Key {
+  string key = 1;
+}
+
+message Value {
+  string value = 1;
+}
+
+message SetValue {
+  string register_map_id = 1 [(akkaserverless.field).entity_key = true];
+  Key key = 2;
+  Value value = 3;
+}
+
+message GetValue {
+  string register_map_id = 1 [(akkaserverless.field).entity_key = true];
+  Key key = 2;
+}
+
+message CurrentValue {
+  Key key = 1;
+  Value value = 2;
+}
+
+message GetAllValues {
+  string register_map_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentValues {
+  repeated CurrentValue values = 1;
+}
+
+service RegisterMapService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-register-map"
+      replicated_register_map: {
+        key: ".domain.SomeKey"
+        value: ".domain.SomeValue"
+      }
+    }
+  };
+
+
+  rpc Set(SetValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+  rpc GetAll(GetAllValues) returns (CurrentValues);
+}
+
+service ScalarRegisterMapService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-scalar-register-map"
+      replicated_register_map: {
+        key: "sint32"
+        value: "string"
+      }
+    }
+  };
+
+  rpc Set(SetValue) returns (google.protobuf.Empty);
+  rpc Get(GetValue) returns (CurrentValue);
+  rpc GetAll(GetAllValues) returns (CurrentValues);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/set/domain/set_domain.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/set/domain/set_domain.proto
@@ -1,0 +1,23 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.unnamed.replicated.set.domain;
+
+option java_outer_classname = "SomeSetDomain";
+
+message SomeElement {
+  string value = 1;
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/set/set_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/replicated/set/set_api.proto
@@ -1,0 +1,74 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.replicated.set;
+
+option java_outer_classname = "SomeSetApi";
+
+message Element {
+  string value = 1;
+}
+
+message AddElement {
+  string set_id = 1 [(akkaserverless.field).entity_key = true];
+  Element element = 2;
+}
+
+message RemoveElement {
+  string set_id = 1 [(akkaserverless.field).entity_key = true];
+  Element element = 2;
+}
+
+message GetElements {
+  string set_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentElements {
+  repeated Element elements = 1;
+}
+
+service SetService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-set"
+      replicated_set: {
+        element: ".domain.SomeElement"
+      }
+    }
+  };
+
+  rpc Add(AddElement) returns (google.protobuf.Empty);
+  rpc Remove(RemoveElement) returns (google.protobuf.Empty);
+  rpc Get(GetElements) returns (CurrentElements);
+}
+
+service ScalarSetService {
+  option (akkaserverless.codegen) = {
+    replicated_entity: {
+      entity_type: "some-scalar-set"
+      replicated_set: {
+        element: "string"
+      }
+    }
+  };
+
+  rpc Add(AddElement) returns (google.protobuf.Empty);
+  rpc Remove(RemoveElement) returns (google.protobuf.Empty);
+  rpc Get(GetElements) returns (CurrentElements);
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/valueentity/domain/user_domain.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/valueentity/domain/user_domain.proto
@@ -1,0 +1,23 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example.unnamed.valueentity.domain;
+
+option java_outer_classname = "UserDomain";
+
+message UserState {
+  string name = 1;
+}

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/valueentity/user_api.proto
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/src/main/protobuf/com/example/unnamed/valueentity/user_api.proto
@@ -1,0 +1,49 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the public API offered by your entity.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package com.example.unnamed.valueentity;
+
+option java_outer_classname = "UserApi";
+
+message CreateUser {
+  string user_id = 1 [(akkaserverless.field).entity_key = true];
+  string name = 2;
+}
+
+
+message GetUser {
+  string user_id = 1 [(akkaserverless.field).entity_key = true];
+}
+
+message CurrentUser {
+  int32 value = 1;
+}
+
+service UserService {
+  option (akkaserverless.codegen) = {
+    value_entity: {
+      entity_type: "user"
+      state: ".domain.UserState"
+    }
+  };
+
+  rpc Create (CreateUser) returns (google.protobuf.Empty);
+  rpc GetCurrentUser (GetUser) returns (CurrentUser);
+}


### PR DESCRIPTION
This adds some extra compile time tests to exercise some new feature:

* entities (ES, Value and Replicate) can be unnamed
* views and actions can get an explicit name

However, action with explicit name is broken, see https://github.com/lightbend/akkaserverless-java-sdk/pull/762

There are some other functionality that we could also add extra tests, for instance domain classes lookup. But we have already enough test touching this indirectly. For instances, all samples use fully-qualified names and all compile time tests use relative lookups, eg: `.domain.Foo`.  
