### PR TITLE
docs: Paging with OFFSET and LIMIT

### DIFF
--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -488,8 +488,6 @@ SELECT * FROM customers OFFSET :start_from LIMIT :max_customers
 
 Note: Using numeric offsets can lead to missing or duplicated entries in the result if entries are added to or removed from the view between requests for the pages.
 
-`OFFSET` and `LIMIT` cannot be used in queries containing `OR`.
-
 ==== Token based offset ====
 
 The count based offset requires that you keep track of how far you got by adding the page size to the offset for each query.
@@ -521,8 +519,6 @@ FROM customers
 OFFSET page_token_offset(:page_token)
 LIMIT 10
 ----
-
-`OFFSET` and `LIMIT` cannot be used in queries containing `OR`.
 
 The token value is not meant to be parseable into any meaningful information other than being a token for reading the next page.
 

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -481,3 +481,5 @@ Or come from fields in the request message:
 ----
 SELECT * FROM customers OFFSET :start_from LIMIT :max_customers
 ----
+
+Note: `OFFSET` and `LIMIT` cannot be used in queries containing `OR`.

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -486,7 +486,7 @@ Or come from fields in the request message:
 SELECT * FROM customers OFFSET :start_from LIMIT :max_customers
 ----
 
-Note: Using numeric offsets can lead to missing or duplicated entries in the result if entries are added to or removed from the view between requests for the pages. The token based paging handles this better.
+Note: Using numeric offsets can lead to missing or duplicated entries in the result if entries are added to or removed from the view between requests for the pages.
 
 `OFFSET` and `LIMIT` cannot be used in queries containing `OR`.
 
@@ -494,9 +494,9 @@ Note: Using numeric offsets can lead to missing or duplicated entries in the res
 
 The count based offset requires that you keep track of how far you got by adding the page size to the offset for each query.
 
-An alternative is to use a token emitted by Akka Serverless identifying how far into the result set the paging has reached using the functions `next_page_token()` and `page_token_offset()`.
+An alternative is to use a string token emitted by Akka Serverless identifying how far into the result set the paging has reached using the functions `next_page_token()` and `page_token_offset()`.
 
-When reading the first page, an empty token is provided to `page_token_offset`. For each returned result page a new token that can be used to read the next page is returned by `next_page_token()`, once the last page has been read, an empty token is returned.
+When reading the first page, an empty token is provided to `page_token_offset`. For each returned result page a new token that can be used to read the next page is returned by `next_page_token()`, once the last page has been read, an empty token is returned (see also xref:has-more[has_more] for determining if the last page was reached).
 
 The size of each page can optionally be specified using `LIMIT`, if it is not present a default page size of 100 is used.
 
@@ -524,6 +524,9 @@ LIMIT 10
 
 `OFFSET` and `LIMIT` cannot be used in queries containing `OR`.
 
+The token value is not meant to be parseable into any meaningful information other than being a token for reading the next page.
+
+[#has-more]
 ==== Check if there are more pages ====
 
 To check if there are more pages left, you can use the function `has_more()` providing a boolean value for the result. This works both for the count and token based offset paging, and also when only using `LIMIT` without any `OFFSET`:
@@ -534,4 +537,3 @@ SELECT * AS customers, has_more() AS more_customers FROM customers LIMIT 10
 ----
 
 This query will return `more_customers = true` when the view contains more than 10 customers.
-

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -463,7 +463,7 @@ SELECT * FROM customers WHERE
 
 === Paging
 
-Reading through a query result one "page" at a time rather than returning the entire result at once is possible in two ways, with a count based offset or a token based offset.
+Reading through a query result one "page" at a time rather than returning the entire result at once is possible in two ways, with a count based offset.
 
 In both cases `OFFSET` and `LIMIT` are used.
 
@@ -491,7 +491,7 @@ Note: Using numeric offsets can lead to missing or duplicated entries in the res
 [#has-more]
 ==== Check if there are more pages ====
 
-To check if there are more pages left, you can use the function `has_more()` providing a boolean value for the result. This works both for the count and token based offset paging, and also when only using `LIMIT` without any `OFFSET`:
+To check if there are more pages left, you can use the function `has_more()` providing a boolean value for the result. This works both for the count offset paging and also when only using `LIMIT` without any `OFFSET`:
 
 [source,proto,indent=0]
 ----

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -460,3 +460,24 @@ SELECT * FROM customers WHERE
   name = :customer_name AND address.city = 'New York' OR
   name = :customer_name AND address.city = 'San Francisco'
 ----
+
+=== Paging
+
+Reading through a query result one "page" at a time rather than returning the entire result at once is possible with `OFFSET` and `LIMIT`.
+
+`OFFSET` specifies at which offset in the result to start
+
+`LIMIT` specifies a maximum number of results to return
+
+The values can either be static, defined up front in the query:
+
+[source,proto,indent=0]
+----
+SELECT * FROM customers LIMIT 10
+----
+
+Or come from fields in the request message:
+[source,proto,indent=0]
+----
+SELECT * FROM customers OFFSET :start_from LIMIT :max_customers
+----

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -463,11 +463,15 @@ SELECT * FROM customers WHERE
 
 === Paging
 
-Reading through a query result one "page" at a time rather than returning the entire result at once is possible with `OFFSET` and `LIMIT`.
+Reading through a query result one "page" at a time rather than returning the entire result at once is possible in two ways, with a count based offset or a token based offset.
+
+In both cases `OFFSET` and `LIMIT` are used.
 
 `OFFSET` specifies at which offset in the result to start
 
 `LIMIT` specifies a maximum number of results to return
+
+==== Count based offset ====
 
 The values can either be static, defined up front in the query:
 
@@ -483,3 +487,48 @@ SELECT * FROM customers OFFSET :start_from LIMIT :max_customers
 ----
 
 Note: `OFFSET` and `LIMIT` cannot be used in queries containing `OR`.
+
+==== Token based offset ====
+
+The count based offset requires that you keep track of how far you got by adding the page size to the offset for each query.
+
+An alternative is to use a token emitted by Akka Serverless identifying how far into the result set the paging has reached using the functions `next_page_token()` and `page_token_offset()`.
+
+When reading the first page, an empty token is provided to `page_token_offset`. For each returned result page a new token that can be used to read the next page is returned by `next_page_token()`, once the last page has been read, an empty token is returned.
+
+The size of each page can optionally be specified using `LIMIT`, if it is not present a default page size of 100 is used.
+
+With a request and response message for the view like this:
+[source,proto,indent=0]
+----
+message Request {
+    string page_token = 1;
+}
+
+message Response {
+    repeated Customer customers = 1;
+    string next_page_token = 2;
+}
+----
+
+A query like this will allow for reading through the view in pages, each containing 10 customers:
+[source,proto,indent=0]
+----
+SELECT * AS customers, next_page_token() AS next_page_token
+FROM customers
+OFFSET page_token_offset(:page_token)
+LIMIT 10
+----
+
+
+==== Check if there are more pages ====
+
+To check if there are more pages left, you can use the function `has_more()` providing a boolean value for the result. This works both for the count and token based offset paging, and also when only using `LIMIT` without any `OFFSET`:
+
+[source,proto,indent=0]
+----
+SELECT * AS customers, has_more() AS more_customers FROM customers LIMIT 10
+----
+
+This query will return `more_customers = true` when the view contains more than 10 customers.
+

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -486,7 +486,9 @@ Or come from fields in the request message:
 SELECT * FROM customers OFFSET :start_from LIMIT :max_customers
 ----
 
-Note: `OFFSET` and `LIMIT` cannot be used in queries containing `OR`.
+Note: Using numeric offsets can lead to missing or duplicated entries in the result if entries are added to or removed from the view between requests for the pages. The token based paging handles this better.
+
+`OFFSET` and `LIMIT` cannot be used in queries containing `OR`.
 
 ==== Token based offset ====
 
@@ -520,6 +522,7 @@ OFFSET page_token_offset(:page_token)
 LIMIT 10
 ----
 
+`OFFSET` and `LIMIT` cannot be used in queries containing `OR`.
 
 ==== Check if there are more pages ====
 

--- a/docs/src/modules/java/pages/views.adoc
+++ b/docs/src/modules/java/pages/views.adoc
@@ -488,40 +488,6 @@ SELECT * FROM customers OFFSET :start_from LIMIT :max_customers
 
 Note: Using numeric offsets can lead to missing or duplicated entries in the result if entries are added to or removed from the view between requests for the pages.
 
-==== Token based offset ====
-
-The count based offset requires that you keep track of how far you got by adding the page size to the offset for each query.
-
-An alternative is to use a string token emitted by Akka Serverless identifying how far into the result set the paging has reached using the functions `next_page_token()` and `page_token_offset()`.
-
-When reading the first page, an empty token is provided to `page_token_offset`. For each returned result page a new token that can be used to read the next page is returned by `next_page_token()`, once the last page has been read, an empty token is returned (see also xref:has-more[has_more] for determining if the last page was reached).
-
-The size of each page can optionally be specified using `LIMIT`, if it is not present a default page size of 100 is used.
-
-With a request and response message for the view like this:
-[source,proto,indent=0]
-----
-message Request {
-    string page_token = 1;
-}
-
-message Response {
-    repeated Customer customers = 1;
-    string next_page_token = 2;
-}
-----
-
-A query like this will allow for reading through the view in pages, each containing 10 customers:
-[source,proto,indent=0]
-----
-SELECT * AS customers, next_page_token() AS next_page_token
-FROM customers
-OFFSET page_token_offset(:page_token)
-LIMIT 10
-----
-
-The token value is not meant to be parseable into any meaningful information other than being a token for reading the next page.
-
 [#has-more]
 ==== Check if there are more pages ====
 


### PR DESCRIPTION
Covers https://github.com/lightbend/akkaserverless-framework/pull/1043 and https://github.com/lightbend/akkaserverless-framework/pull/1049 so no need to merge until those are released and deployed.

I think the query language overview should move in the main docs and not in the SDK since it will be the same across SDKs.