### PR TITLE
fix: Failing integration test #766

### DIFF
--- a/samples/java-customer-registry-views-quickstart/src/it/java/customer/view/CustomerByEmailIntegrationTest.java
+++ b/samples/java-customer-registry-views-quickstart/src/it/java/customer/view/CustomerByEmailIntegrationTest.java
@@ -54,7 +54,7 @@ public class CustomerByEmailIntegrationTest {
         CustomerViewModel.ByEmailRequest.newBuilder().setEmail("foo@example.com").build();
 
     // // the view is eventually updated
-    await().atMost(10, SECONDS).until(() -> viewClient.getCustomer(req).toCompletableFuture()
+    await().ignoreExceptions().atMost(10, SECONDS).until(() -> viewClient.getCustomer(req).toCompletableFuture()
         .get(3, SECONDS).getCustomerId().equals(id));
   }
 


### PR DESCRIPTION
References #766

Turns out that awaiter library does not quite like Akka testkit await out of the box but will fail on exception unless explicitly asked to ignore exceptions.