### PR TITLE
chore: ExampleSuite tests for views (new codegen)

### DIFF
--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/ModelBuilderSuite.scala
@@ -120,7 +120,8 @@ abstract class ModelBuilderSuite(val config: ModelBuilderSuite.Config) extends m
               command(
                 "CreatePrePopulated",
                 fullyQualifiedName("NewCart", shoppingCartPackage),
-                fullyQualifiedName("NewCartCreated", shoppingCartPackage))))))
+                fullyQualifiedName("NewCartCreated", shoppingCartPackage))),
+            None)))
     }.get
   }
 
@@ -192,7 +193,8 @@ abstract class ModelBuilderSuite(val config: ModelBuilderSuite.Config) extends m
             "ShoppingCartViewService",
             transformedUpdates,
             transformedUpdates,
-            queries)))
+            queries,
+            None)))
     }.get
   }
 
@@ -747,17 +749,17 @@ class ModelBuilderWithCodegenAnnotationSuite extends ModelBuilderSuite(ModelBuil
       // So we need to build one for them since they are declared in a Service annotation,
       // we stay with this package, but we do resolve their FQN.
       // The package that the user asks may no be the same as the Service
-      val derivedShoppingCartPackage =
-        shoppingCartPackage.asJavaMultiFiles
-          .copy(protoPackage = "com.example.shoppingcart.controllers")
+      val derivedShoppingCartPackage = shoppingCartPackage.asJavaMultiFiles
+
+      val userDefinedNamePackage =
+        derivedShoppingCartPackage.copy(protoPackage = "com.example.shoppingcart.controllers")
 
       assertEquals(
         model.services,
         Map(
-          "com.example.shoppingcart.controllers.ShoppingCartController" ->
+          "com.example.shoppingcart.ShoppingCartAction" ->
           ModelBuilder.ActionService(
-            // this is the name as defined in the proto file
-            fullyQualifiedName("ShoppingCartController", derivedShoppingCartPackage),
+            fullyQualifiedName("ShoppingCartAction", derivedShoppingCartPackage),
             List(
               command(
                 "InitializeCart",
@@ -767,7 +769,8 @@ class ModelBuilderWithCodegenAnnotationSuite extends ModelBuilderSuite(ModelBuil
                 "CreatePrePopulated",
                 fullyQualifiedName("NewCart", shoppingCartPackage),
                 fullyQualifiedName("NewCartCreated", shoppingCartPackage))),
-            transformName = false)))
+            // this is the name as defined in the proto file
+            Some(fullyQualifiedName("ShoppingCartController", userDefinedNamePackage)))))
     }.get
   }
 
@@ -809,6 +812,9 @@ class ModelBuilderWithCodegenAnnotationSuite extends ModelBuilderSuite(ModelBuil
       // we stay with this package.
       val derivedShoppingCartPackage = shoppingCartPackage.asJavaMultiFiles
 
+      val userDefinedNamePackage =
+        derivedShoppingCartPackage.copy(protoPackage = "com.example.shoppingcart.view")
+
       val transformedUpdates =
         List(
           command(
@@ -833,12 +839,11 @@ class ModelBuilderWithCodegenAnnotationSuite extends ModelBuilderSuite(ModelBuil
       assertEquals(
         model.services,
         Map(
-          "com.example.shoppingcart.view.ShoppingCartView" ->
+          "com.example.shoppingcart.view.ShoppingCartViewService" ->
           ModelBuilder.ViewService(
-            // this is the name as defined in the proto file
             FullyQualifiedName(
-              "ShoppingCartView",
-              "ShoppingCartView",
+              "ShoppingCartViewService",
+              "ShoppingCartViewService",
               derivedShoppingCartPackage,
               TestData.guessDescriptor("ShoppingCartViewService", shoppingCartPackage)),
             transformedUpdates ++ queries,
@@ -846,7 +851,8 @@ class ModelBuilderWithCodegenAnnotationSuite extends ModelBuilderSuite(ModelBuil
             transformedUpdates,
             transformedUpdates,
             queries,
-            transformName = false)))
+            // this is the name as defined in the proto file
+            Some(fullyQualifiedName("ShoppingCartView", userDefinedNamePackage)))))
     }.get
   }
 }

--- a/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
+++ b/codegen/core/src/test/scala/com/lightbend/akkasls/codegen/TestData.scala
@@ -160,7 +160,8 @@ class TestData(val packageNamingTemplate: PackageNaming) {
           fullyQualifiedName("MyRequest", proto),
           fullyQualifiedName("Empty", externalProto),
           streamedInput = true,
-          streamedOutput = true)))
+          streamedOutput = true)),
+      None)
   }
 
   def simpleJsonPubSubActionService(proto: PackageNaming = serviceProto()): ModelBuilder.ActionService = {
@@ -176,7 +177,8 @@ class TestData(val packageNamingTemplate: PackageNaming) {
           "OutToTopic",
           fullyQualifiedName("EntityUpdated", domainProto()),
           fullyQualifiedName("Any", googleProto),
-          outToTopic = true)))
+          outToTopic = true)),
+      None)
   }
 
   def simpleViewService(proto: PackageNaming = serviceProto(), suffix: String = ""): ModelBuilder.ViewService = {
@@ -211,7 +213,8 @@ class TestData(val packageNamingTemplate: PackageNaming) {
         command(
           "Query",
           fullyQualifiedName("QueryRequest", domainProto(suffix)),
-          fullyQualifiedName("ViewState", proto))))
+          fullyQualifiedName("ViewState", proto))),
+      None)
   }
 
   def eventSourcedEntity(suffix: String = ""): ModelBuilder.EventSourcedEntity =

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/AkkaServerlessFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/AkkaServerlessFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import com.akkaserverless.javasdk.view.ViewCreationContext;
+import org.example.named.view.MyUserByNameView;
+import org.example.named.view.MyUserByNameViewProvider;
+import org.example.named.view.UserViewModel;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class AkkaServerlessFactory {
+
+  public static AkkaServerless withComponents(
+      Function<ViewCreationContext, MyUserByNameView> createMyUserByNameView) {
+    AkkaServerless akkaServerless = new AkkaServerless();
+    return akkaServerless
+      .register(MyUserByNameViewProvider.of(createMyUserByNameView));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/Components.java
@@ -1,0 +1,18 @@
+package org.example;
+
+import com.akkaserverless.javasdk.DeferredCall;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  MyUserByNameViewCalls myUserByNameView();
+
+  interface MyUserByNameViewCalls {
+    DeferredCall<org.example.named.view.UserViewModel.ByNameRequest, org.example.named.view.UserViewModel.UserResponse> getUserByName(org.example.named.view.UserViewModel.ByNameRequest byNameRequest);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,45 @@
+package org.example;
+
+import com.akkaserverless.javasdk.Context;
+import com.akkaserverless.javasdk.DeferredCall;
+import com.akkaserverless.javasdk.impl.DeferredCallImpl;
+import com.akkaserverless.javasdk.impl.InternalContext;
+import com.akkaserverless.javasdk.impl.MetadataImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  @Override
+  public Components.MyUserByNameViewCalls myUserByNameView() {
+    return new MyUserByNameViewCallsImpl();
+  }
+
+  private final class MyUserByNameViewCallsImpl implements Components.MyUserByNameViewCalls {
+     @Override
+    public DeferredCall<org.example.named.view.UserViewModel.ByNameRequest, org.example.named.view.UserViewModel.UserResponse> getUserByName(org.example.named.view.UserViewModel.ByNameRequest byNameRequest) {
+      return new DeferredCallImpl<>(
+        byNameRequest,
+        MetadataImpl.Empty(),
+        "org.example.named.view.UserByName",
+        "GetUserByName",
+        () -> getGrpcClient(org.example.named.view.UserByName.class).getUserByName(byNameRequest)
+      );
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/AbstractMyUserByNameView.java
@@ -1,0 +1,18 @@
+package org.example.named.view;
+
+import com.akkaserverless.javasdk.view.View;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public abstract class AbstractMyUserByNameView extends View<UserViewModel.UserState> {
+
+  @Override
+  public UserViewModel.UserState emptyState() {
+    return null; // emptyState is only used with transform_updates=true
+  }
+
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewProvider.java
@@ -1,0 +1,72 @@
+package org.example.named.view;
+
+import com.akkaserverless.javasdk.view.ViewCreationContext;
+import com.akkaserverless.javasdk.view.ViewOptions;
+import com.akkaserverless.javasdk.view.ViewProvider;
+import com.google.protobuf.Descriptors;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class MyUserByNameViewProvider implements ViewProvider<UserViewModel.UserState, MyUserByNameView> {
+
+  private final Function<ViewCreationContext, MyUserByNameView> viewFactory;
+  private final String viewId;
+  private final ViewOptions options;
+
+  /** Factory method of MyUserByNameView */
+  public static MyUserByNameViewProvider of(
+      Function<ViewCreationContext, MyUserByNameView> viewFactory) {
+    return new MyUserByNameViewProvider(viewFactory, "UserByName", ViewOptions.defaults());
+  }
+
+  private MyUserByNameViewProvider(
+      Function<ViewCreationContext, MyUserByNameView> viewFactory,
+      String viewId,
+      ViewOptions options) {
+    this.viewFactory = viewFactory;
+    this.viewId = viewId;
+    this.options = options;
+  }
+
+  @Override
+  public String viewId() {
+    return viewId;
+  }
+
+  @Override
+  public final ViewOptions options() {
+    return options;
+  }
+
+  public final MyUserByNameViewProvider withOptions(ViewOptions options) {
+    return new MyUserByNameViewProvider(viewFactory, viewId, options);
+  }
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  public MyUserByNameViewProvider withViewId(String viewId) {
+    return new MyUserByNameViewProvider(viewFactory, viewId, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return UserViewModel.getDescriptor().findServiceByName("UserByName");
+  }
+
+  @Override
+  public final MyUserByNameViewRouter newRouter(ViewCreationContext context) {
+    return new MyUserByNameViewRouter(viewFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {UserViewModel.getDescriptor()};
+  }
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-managed/org/example/named/view/MyUserByNameViewRouter.java
@@ -1,0 +1,32 @@
+package org.example.named.view;
+
+import com.akkaserverless.javasdk.impl.view.UpdateHandlerNotFound;
+import com.akkaserverless.javasdk.impl.view.ViewRouter;
+import com.akkaserverless.javasdk.view.View;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/** A view handler */
+public class MyUserByNameViewRouter extends ViewRouter<UserViewModel.UserState, MyUserByNameView> {
+
+  public MyUserByNameViewRouter(MyUserByNameView view) {
+    super(view);
+  }
+
+  @Override
+  public View.UpdateEffect<UserViewModel.UserState> handleUpdate(
+      String eventName,
+      UserViewModel.UserState state,
+      Object event) {
+
+    switch (eventName) {
+
+      default:
+        throw new UpdateHandlerNotFound(eventName);
+    }
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import org.example.named.view.MyUserByNameView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static AkkaServerless createAkkaServerless() {
+    // The AkkaServerlessFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new AkkaServerless()` instance.
+    return AkkaServerlessFactory.withComponents(
+      MyUserByNameView::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Akka Serverless service");
+    createAkkaServerless().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-unmanaged/org/example/named/view/MyUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/generated-unmanaged/org/example/named/view/MyUserByNameView.java
@@ -1,0 +1,16 @@
+package org.example.named.view;
+
+import com.akkaserverless.javasdk.view.ViewContext;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class MyUserByNameView extends AbstractMyUserByNameView {
+
+  public MyUserByNameView(ViewContext context) {}
+
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/proto/example-named-views.proto
+++ b/codegen/java-gen/src/test/resources/tests/view-service/named-new-style/proto/example-named-views.proto
@@ -1,0 +1,57 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.named.view;
+
+option java_outer_classname = "UserViewModel";
+
+import "akkaserverless/annotations.proto";
+
+
+message ByNameRequest {
+  string user_name = 1;
+}
+
+message UserResponse {
+  string name = 1;
+}
+
+message UserState {
+  string name = 1;
+}
+
+service UserByName {
+  option (akkaserverless.codegen) = {
+    view: {
+      name: "MyUserByNameView"
+    }
+  };
+
+
+  rpc UpdateCustomer(UserState) returns (UserState) {
+
+    option (akkaserverless.method).view.update = {
+      table: "users"
+    };
+  }
+
+  rpc GetUserByName(ByNameRequest) returns (UserResponse) {
+    option (akkaserverless.method).view.query = {
+      query: "SELECT name  FROM users WHERE name = :name"
+    };
+  }
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/AkkaServerlessFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/AkkaServerlessFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import com.akkaserverless.javasdk.view.ViewCreationContext;
+import org.example.unnamed.view.UserByNameView;
+import org.example.unnamed.view.UserByNameViewProvider;
+import org.example.unnamed.view.UserViewModel;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class AkkaServerlessFactory {
+
+  public static AkkaServerless withComponents(
+      Function<ViewCreationContext, UserByNameView> createUserByNameView) {
+    AkkaServerless akkaServerless = new AkkaServerless();
+    return akkaServerless
+      .register(UserByNameViewProvider.of(createUserByNameView));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/Components.java
@@ -1,0 +1,18 @@
+package org.example;
+
+import com.akkaserverless.javasdk.DeferredCall;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  UserByNameViewCalls userByNameView();
+
+  interface UserByNameViewCalls {
+    DeferredCall<org.example.unnamed.view.UserViewModel.ByNameRequest, org.example.unnamed.view.UserViewModel.UserResponse> getUserByName(org.example.unnamed.view.UserViewModel.ByNameRequest byNameRequest);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,45 @@
+package org.example;
+
+import com.akkaserverless.javasdk.Context;
+import com.akkaserverless.javasdk.DeferredCall;
+import com.akkaserverless.javasdk.impl.DeferredCallImpl;
+import com.akkaserverless.javasdk.impl.InternalContext;
+import com.akkaserverless.javasdk.impl.MetadataImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  @Override
+  public Components.UserByNameViewCalls userByNameView() {
+    return new UserByNameViewCallsImpl();
+  }
+
+  private final class UserByNameViewCallsImpl implements Components.UserByNameViewCalls {
+     @Override
+    public DeferredCall<org.example.unnamed.view.UserViewModel.ByNameRequest, org.example.unnamed.view.UserViewModel.UserResponse> getUserByName(org.example.unnamed.view.UserViewModel.ByNameRequest byNameRequest) {
+      return new DeferredCallImpl<>(
+        byNameRequest,
+        MetadataImpl.Empty(),
+        "org.example.unnamed.view.UserByName",
+        "GetUserByName",
+        () -> getGrpcClient(org.example.unnamed.view.UserByName.class).getUserByName(byNameRequest)
+      );
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/AbstractUserByNameView.java
@@ -1,0 +1,18 @@
+package org.example.unnamed.view;
+
+import com.akkaserverless.javasdk.view.View;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public abstract class AbstractUserByNameView extends View<UserViewModel.UserState> {
+
+  @Override
+  public UserViewModel.UserState emptyState() {
+    return null; // emptyState is only used with transform_updates=true
+  }
+
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewProvider.java
@@ -1,0 +1,72 @@
+package org.example.unnamed.view;
+
+import com.akkaserverless.javasdk.view.ViewCreationContext;
+import com.akkaserverless.javasdk.view.ViewOptions;
+import com.akkaserverless.javasdk.view.ViewProvider;
+import com.google.protobuf.Descriptors;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class UserByNameViewProvider implements ViewProvider<UserViewModel.UserState, UserByNameView> {
+
+  private final Function<ViewCreationContext, UserByNameView> viewFactory;
+  private final String viewId;
+  private final ViewOptions options;
+
+  /** Factory method of UserByNameView */
+  public static UserByNameViewProvider of(
+      Function<ViewCreationContext, UserByNameView> viewFactory) {
+    return new UserByNameViewProvider(viewFactory, "UserByName", ViewOptions.defaults());
+  }
+
+  private UserByNameViewProvider(
+      Function<ViewCreationContext, UserByNameView> viewFactory,
+      String viewId,
+      ViewOptions options) {
+    this.viewFactory = viewFactory;
+    this.viewId = viewId;
+    this.options = options;
+  }
+
+  @Override
+  public String viewId() {
+    return viewId;
+  }
+
+  @Override
+  public final ViewOptions options() {
+    return options;
+  }
+
+  public final UserByNameViewProvider withOptions(ViewOptions options) {
+    return new UserByNameViewProvider(viewFactory, viewId, options);
+  }
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  public UserByNameViewProvider withViewId(String viewId) {
+    return new UserByNameViewProvider(viewFactory, viewId, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return UserViewModel.getDescriptor().findServiceByName("UserByName");
+  }
+
+  @Override
+  public final UserByNameViewRouter newRouter(ViewCreationContext context) {
+    return new UserByNameViewRouter(viewFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {UserViewModel.getDescriptor()};
+  }
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-managed/org/example/unnamed/view/UserByNameViewRouter.java
@@ -1,0 +1,32 @@
+package org.example.unnamed.view;
+
+import com.akkaserverless.javasdk.impl.view.UpdateHandlerNotFound;
+import com.akkaserverless.javasdk.impl.view.ViewRouter;
+import com.akkaserverless.javasdk.view.View;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/** A view handler */
+public class UserByNameViewRouter extends ViewRouter<UserViewModel.UserState, UserByNameView> {
+
+  public UserByNameViewRouter(UserByNameView view) {
+    super(view);
+  }
+
+  @Override
+  public View.UpdateEffect<UserViewModel.UserState> handleUpdate(
+      String eventName,
+      UserViewModel.UserState state,
+      Object event) {
+
+    switch (eventName) {
+
+      default:
+        throw new UpdateHandlerNotFound(eventName);
+    }
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import org.example.unnamed.view.UserByNameView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static AkkaServerless createAkkaServerless() {
+    // The AkkaServerlessFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new AkkaServerless()` instance.
+    return AkkaServerlessFactory.withComponents(
+      UserByNameView::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Akka Serverless service");
+    createAkkaServerless().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-unmanaged/org/example/unnamed/view/UserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/generated-unmanaged/org/example/unnamed/view/UserByNameView.java
@@ -1,0 +1,16 @@
+package org.example.unnamed.view;
+
+import com.akkaserverless.javasdk.view.ViewContext;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class UserByNameView extends AbstractUserByNameView {
+
+  public UserByNameView(ViewContext context) {}
+
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/proto/example-unnamed-views.proto
+++ b/codegen/java-gen/src/test/resources/tests/view-service/unnamed-new-style/proto/example-unnamed-views.proto
@@ -1,0 +1,55 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.unnamed.view;
+
+option java_outer_classname = "UserViewModel";
+
+import "akkaserverless/annotations.proto";
+
+
+message ByNameRequest {
+  string user_name = 1;
+}
+
+message UserResponse {
+  string name = 1;
+}
+
+message UserState {
+  string name = 1;
+}
+
+service UserByName {
+  option (akkaserverless.codegen) = {
+    view: {}
+  };
+
+
+  rpc UpdateCustomer(UserState) returns (UserState) {
+
+    option (akkaserverless.method).view.update = {
+      table: "users"
+    };
+  }
+
+  rpc GetUserByName(ByNameRequest) returns (UserResponse) {
+    option (akkaserverless.method).view.query = {
+      query: "SELECT name  FROM users WHERE name = :name"
+    };
+  }
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/AkkaServerlessFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/AkkaServerlessFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import com.akkaserverless.javasdk.view.ViewCreationContext;
+import org.example.view.UserByNameViewImpl;
+import org.example.view.UserByNameViewProvider;
+import org.example.view.UserViewModel;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class AkkaServerlessFactory {
+
+  public static AkkaServerless withComponents(
+      Function<ViewCreationContext, UserByNameViewImpl> createUserByNameViewImpl) {
+    AkkaServerless akkaServerless = new AkkaServerless();
+    return akkaServerless
+      .register(UserByNameViewProvider.of(createUserByNameViewImpl));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/Components.java
@@ -1,0 +1,18 @@
+package org.example;
+
+import com.akkaserverless.javasdk.DeferredCall;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  UserByNameViewImplCalls userByNameViewImpl();
+
+  interface UserByNameViewImplCalls {
+    DeferredCall<org.example.view.UserViewModel.ByNameRequest, org.example.view.UserViewModel.UserResponse> getUserByName(org.example.view.UserViewModel.ByNameRequest byNameRequest);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,45 @@
+package org.example;
+
+import com.akkaserverless.javasdk.Context;
+import com.akkaserverless.javasdk.DeferredCall;
+import com.akkaserverless.javasdk.impl.DeferredCallImpl;
+import com.akkaserverless.javasdk.impl.InternalContext;
+import com.akkaserverless.javasdk.impl.MetadataImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  @Override
+  public Components.UserByNameViewImplCalls userByNameViewImpl() {
+    return new UserByNameViewImplCallsImpl();
+  }
+
+  private final class UserByNameViewImplCallsImpl implements Components.UserByNameViewImplCalls {
+     @Override
+    public DeferredCall<org.example.view.UserViewModel.ByNameRequest, org.example.view.UserViewModel.UserResponse> getUserByName(org.example.view.UserViewModel.ByNameRequest byNameRequest) {
+      return new DeferredCallImpl<>(
+        byNameRequest,
+        MetadataImpl.Empty(),
+        "org.example.view.UserByNameView",
+        "GetUserByName",
+        () -> getGrpcClient(org.example.view.UserByNameView.class).getUserByName(byNameRequest)
+      );
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/AbstractUserByNameView.java
@@ -1,0 +1,18 @@
+package org.example.view;
+
+import com.akkaserverless.javasdk.view.View;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public abstract class AbstractUserByNameView extends View<UserViewModel.UserState> {
+
+  @Override
+  public UserViewModel.UserState emptyState() {
+    return null; // emptyState is only used with transform_updates=true
+  }
+
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewProvider.java
@@ -1,0 +1,72 @@
+package org.example.view;
+
+import com.akkaserverless.javasdk.view.ViewCreationContext;
+import com.akkaserverless.javasdk.view.ViewOptions;
+import com.akkaserverless.javasdk.view.ViewProvider;
+import com.google.protobuf.Descriptors;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public class UserByNameViewProvider implements ViewProvider<UserViewModel.UserState, UserByNameViewImpl> {
+
+  private final Function<ViewCreationContext, UserByNameViewImpl> viewFactory;
+  private final String viewId;
+  private final ViewOptions options;
+
+  /** Factory method of UserByNameViewImpl */
+  public static UserByNameViewProvider of(
+      Function<ViewCreationContext, UserByNameViewImpl> viewFactory) {
+    return new UserByNameViewProvider(viewFactory, "UserByNameView", ViewOptions.defaults());
+  }
+
+  private UserByNameViewProvider(
+      Function<ViewCreationContext, UserByNameViewImpl> viewFactory,
+      String viewId,
+      ViewOptions options) {
+    this.viewFactory = viewFactory;
+    this.viewId = viewId;
+    this.options = options;
+  }
+
+  @Override
+  public String viewId() {
+    return viewId;
+  }
+
+  @Override
+  public final ViewOptions options() {
+    return options;
+  }
+
+  public final UserByNameViewProvider withOptions(ViewOptions options) {
+    return new UserByNameViewProvider(viewFactory, viewId, options);
+  }
+
+  /**
+   * Use a custom view identifier. By default, the viewId is the same as the proto service name.
+   * A different identifier can be needed when making rolling updates with changes to the view definition.
+   */
+  public UserByNameViewProvider withViewId(String viewId) {
+    return new UserByNameViewProvider(viewFactory, viewId, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return UserViewModel.getDescriptor().findServiceByName("UserByNameView");
+  }
+
+  @Override
+  public final UserByNameViewRouter newRouter(ViewCreationContext context) {
+    return new UserByNameViewRouter(viewFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {UserViewModel.getDescriptor()};
+  }
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-managed/org/example/view/UserByNameViewRouter.java
@@ -1,0 +1,32 @@
+package org.example.view;
+
+import com.akkaserverless.javasdk.impl.view.UpdateHandlerNotFound;
+import com.akkaserverless.javasdk.impl.view.ViewRouter;
+import com.akkaserverless.javasdk.view.View;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/** A view handler */
+public class UserByNameViewRouter extends ViewRouter<UserViewModel.UserState, UserByNameViewImpl> {
+
+  public UserByNameViewRouter(UserByNameViewImpl view) {
+    super(view);
+  }
+
+  @Override
+  public View.UpdateEffect<UserViewModel.UserState> handleUpdate(
+      String eventName,
+      UserViewModel.UserState state,
+      Object event) {
+
+    switch (eventName) {
+
+      default:
+        throw new UpdateHandlerNotFound(eventName);
+    }
+  }
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import org.example.view.UserByNameViewImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static AkkaServerless createAkkaServerless() {
+    // The AkkaServerlessFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new AkkaServerless()` instance.
+    return AkkaServerlessFactory.withComponents(
+      UserByNameViewImpl::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Akka Serverless service");
+    createAkkaServerless().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-unmanaged/org/example/view/UserByNameViewImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/generated-unmanaged/org/example/view/UserByNameViewImpl.java
@@ -1,0 +1,16 @@
+package org.example.view;
+
+import com.akkaserverless.javasdk.view.ViewContext;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class UserByNameViewImpl extends AbstractUserByNameView {
+
+  public UserByNameViewImpl(ViewContext context) {}
+
+
+}
+

--- a/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/proto/example-views.proto
+++ b/codegen/java-gen/src/test/resources/tests/view-service/view-in-name-new-style/proto/example-views.proto
@@ -1,0 +1,55 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.view;
+
+option java_outer_classname = "UserViewModel";
+
+import "akkaserverless/annotations.proto";
+
+
+message ByNameRequest {
+  string user_name = 1;
+}
+
+message UserResponse {
+  string name = 1;
+}
+
+message UserState {
+  string name = 1;
+}
+
+service UserByNameView {
+  option (akkaserverless.codegen) = {
+    view: {}
+  };
+
+
+  rpc UpdateCustomer(UserState) returns (UserState) {
+
+    option (akkaserverless.method).view.update = {
+      table: "users"
+    };
+  }
+
+  rpc GetUserByName(ByNameRequest) returns (UserResponse) {
+    option (akkaserverless.method).view.query = {
+      query: "SELECT name  FROM users WHERE name = :name"
+    };
+  }
+}
+


### PR DESCRIPTION
I will send separated PRs per component types to avoid sending too large PRs. 

In this PR, I'm only exercising the views using the codegen annotation. 

We test the output for: 
* unnamed views
* unnamed views with 'View' in the name
* named views

Will fix #761