### PR TITLE
chore: ExampleSuite tests for ES entities (new codegen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ tags
 target
 dependency-reduced-pom.xml
 *.versionsBackup
+regenerate

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntitySourceGenerator.scala
@@ -19,8 +19,8 @@ package com.lightbend.akkasls.codegen.java
 import com.lightbend.akkasls.codegen.Format
 import com.lightbend.akkasls.codegen.Imports
 import com.lightbend.akkasls.codegen.ModelBuilder
+import com.lightbend.akkasls.codegen.SourceGeneratorUtils.allMessageTypes
 import com.lightbend.akkasls.codegen.SourceGeneratorUtils.collectRelevantTypes
-import com.lightbend.akkasls.codegen.SourceGeneratorUtils.generateCommandImports
 import com.lightbend.akkasls.codegen.SourceGeneratorUtils.generateImports
 import com.lightbend.akkasls.codegen.SourceGeneratorUtils.lowerFirst
 import com.lightbend.akkasls.codegen.SourceGeneratorUtils.managedComment
@@ -36,9 +36,8 @@ object EventSourcedEntitySourceGenerator {
       packageName: String,
       className: String): String = {
 
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       otherImports = Seq(
         "com.akkaserverless.javasdk.eventsourcedentity.CommandContext",
@@ -112,11 +111,8 @@ object EventSourcedEntitySourceGenerator {
       entity: ModelBuilder.EventSourcedEntity,
       packageName: String,
       className: String): String = {
-    val relevantTypes = {
-      service.commands.flatMap { cmd =>
-        cmd.inputType :: cmd.outputType :: Nil
-      }.toSeq ++ entity.events.map(_.fqn) :+ entity.state.fqn
-    }
+
+    val relevantTypes = allMessageTypes(service, entity)
 
     implicit val imports: Imports = generateImports(
       relevantTypes ++ relevantTypes.map(_.descriptorImport),
@@ -203,13 +199,9 @@ object EventSourcedEntitySourceGenerator {
       packageName: String,
       className: String,
       interfaceClassName: String): String = {
-    val messageTypes = service.commands.toSeq
-      .flatMap(command => Seq(command.inputType, command.outputType)) ++
-      entity.events.map(_.fqn) :+ entity.state.fqn
 
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       Seq(
         "com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext",
@@ -274,9 +266,9 @@ object EventSourcedEntitySourceGenerator {
       packageName: String,
       className: String,
       mainPackageName: String): String = {
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       Seq(
         "com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity",

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/EventSourcedEntityTestKitGenerator.scala
@@ -36,9 +36,8 @@ object EventSourcedEntityTestKitGenerator {
       entity: ModelBuilder.EventSourcedEntity,
       packageName: String,
       className: String): String = {
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       otherImports = Seq(
         "com.google.protobuf.Empty",
@@ -157,9 +156,8 @@ object EventSourcedEntityTestKitGenerator {
 
   def generateTestSources(service: ModelBuilder.EntityService, entity: ModelBuilder.EventSourcedEntity): String = {
     val packageName = entity.fqn.parent.javaPackage
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       otherImports = Seq(
         "com.google.protobuf.Empty",

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntitySourceGenerator.scala
@@ -29,9 +29,8 @@ object ValueEntitySourceGenerator {
       packageName: String,
       className: String): String = {
 
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       otherImports = Seq("com.akkaserverless.javasdk.valueentity.ValueEntityContext"))
 
@@ -81,9 +80,8 @@ object ValueEntitySourceGenerator {
       packageName: String,
       className: String): String = {
 
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       otherImports = Seq(
         "com.akkaserverless.javasdk.valueentity.CommandContext",
@@ -234,9 +232,8 @@ object ValueEntitySourceGenerator {
 
     val stateType = entity.state.fqn
 
-    implicit val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+    implicit val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       otherImports = Seq(
         "com.akkaserverless.javasdk.valueentity.ValueEntity",

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ValueEntityTestKitGenerator.scala
@@ -38,9 +38,9 @@ object ValueEntityTestKitGenerator {
       service: ModelBuilder.EntityService,
       entity: ModelBuilder.ValueEntity,
       packageName: String): String = {
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       otherImports = Seq(
         "com.google.protobuf.Empty",
@@ -147,9 +147,9 @@ object ValueEntityTestKitGenerator {
       service: ModelBuilder.EntityService,
       entity: ModelBuilder.ValueEntity,
       packageName: String): String = {
-    val imports = generateCommandImports(
-      service.commands,
-      entity.state,
+
+    val imports = generateImports(
+      allMessageTypes(service, entity),
       packageName,
       otherImports = Seq(
         "com.google.protobuf.Empty",

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-integration-unmanaged/org/example/eventsourcedentity/CounterIntegrationTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-integration-unmanaged/org/example/eventsourcedentity/CounterIntegrationTest.java
@@ -1,0 +1,50 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.testkit.junit.AkkaServerlessTestKitResource;
+import com.google.protobuf.Empty;
+import org.example.Main;
+import org.example.state.OuterCounterState;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+// Example of an integration test calling our service via the Akka Serverless proxy
+// Run all test classes ending with "IntegrationTest" using `mvn verify -Pit`
+public class CounterIntegrationTest {
+
+  /**
+   * The test kit starts both the service container and the Akka Serverless proxy.
+   */
+  @ClassRule
+  public static final AkkaServerlessTestKitResource testKit =
+    new AkkaServerlessTestKitResource(Main.createAkkaServerless());
+
+  /**
+   * Use the generated gRPC client to call the service through the Akka Serverless proxy.
+   */
+  private final CounterService client;
+
+  public CounterIntegrationTest() {
+    client = testKit.getGrpcClient(CounterService.class);
+  }
+
+  @Test
+  public void increaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.increase(CounterApi.IncreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+
+  @Test
+  public void decreaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.decrease(CounterApi.DecreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/AkkaServerlessFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/AkkaServerlessFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import org.example.domain.Counter;
+import org.example.domain.CounterProvider;
+import org.example.eventsourcedentity.CounterApi;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class AkkaServerlessFactory {
+
+  public static AkkaServerless withComponents(
+      Function<EventSourcedEntityContext, Counter> createCounter) {
+    AkkaServerless akkaServerless = new AkkaServerless();
+    return akkaServerless
+      .register(CounterProvider.of(createCounter));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/Components.java
@@ -1,0 +1,20 @@
+package org.example;
+
+import com.akkaserverless.javasdk.DeferredCall;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  CounterCalls counter();
+
+  interface CounterCalls {
+    DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue);
+
+    DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,55 @@
+package org.example;
+
+import com.akkaserverless.javasdk.Context;
+import com.akkaserverless.javasdk.DeferredCall;
+import com.akkaserverless.javasdk.impl.DeferredCallImpl;
+import com.akkaserverless.javasdk.impl.InternalContext;
+import com.akkaserverless.javasdk.impl.MetadataImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  @Override
+  public Components.CounterCalls counter() {
+    return new CounterCallsImpl();
+  }
+
+  private final class CounterCallsImpl implements Components.CounterCalls {
+     @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue) {
+      return new DeferredCallImpl<>(
+        increaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Increase",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).increase(increaseValue)
+      );
+    }
+    @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue) {
+      return new DeferredCallImpl<>(
+        decreaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Decrease",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).decrease(decreaseValue)
+      );
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/AbstractCounter.java
@@ -1,0 +1,34 @@
+package org.example.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.google.protobuf.Empty;
+import org.example.Components;
+import org.example.ComponentsImpl;
+import org.example.events.OuterCounterEvents;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.state.OuterCounterState;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/** An event sourced entity. */
+public abstract class AbstractCounter extends EventSourcedEntity<OuterCounterState.CounterState> {
+
+  protected final Components components() {
+    return new ComponentsImpl(commandContext());
+  }
+
+  /** Command handler for "Increase". */
+  public abstract Effect<Empty> increase(OuterCounterState.CounterState currentState, CounterApi.IncreaseValue increaseValue);
+
+  /** Command handler for "Decrease". */
+  public abstract Effect<Empty> decrease(OuterCounterState.CounterState currentState, CounterApi.DecreaseValue decreaseValue);
+
+  /** Event handler for "Increased". */
+  public abstract OuterCounterState.CounterState increased(OuterCounterState.CounterState currentState, OuterCounterEvents.Increased increased);
+
+  /** Event handler for "Decreased". */
+  public abstract OuterCounterState.CounterState decreased(OuterCounterState.CounterState currentState, OuterCounterEvents.Decreased decreased);
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/CounterProvider.java
@@ -1,0 +1,75 @@
+package org.example.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityOptions;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityProvider;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Empty;
+import com.google.protobuf.EmptyProto;
+import org.example.events.OuterCounterEvents;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.state.OuterCounterState;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity provider that defines how to register and create the entity for
+ * the Protobuf service <code>CounterService</code>.
+ *
+ * Should be used with the <code>register</code> method in {@link com.akkaserverless.javasdk.AkkaServerless}.
+ */
+public class CounterProvider implements EventSourcedEntityProvider<OuterCounterState.CounterState, Counter> {
+
+  private final Function<EventSourcedEntityContext, Counter> entityFactory;
+  private final EventSourcedEntityOptions options;
+
+  /** Factory method of CounterProvider */
+  public static CounterProvider of(Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return new CounterProvider(entityFactory, EventSourcedEntityOptions.defaults());
+  }
+
+  private CounterProvider(
+      Function<EventSourcedEntityContext, Counter> entityFactory,
+      EventSourcedEntityOptions options) {
+    this.entityFactory = entityFactory;
+    this.options = options;
+  }
+
+  @Override
+  public final EventSourcedEntityOptions options() {
+    return options;
+  }
+
+  public final CounterProvider withOptions(EventSourcedEntityOptions options) {
+    return new CounterProvider(entityFactory, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return CounterApi.getDescriptor().findServiceByName("CounterService");
+  }
+
+  @Override
+  public final String entityType() {
+    return "counter";
+  }
+
+  @Override
+  public final CounterRouter newRouter(EventSourcedEntityContext context) {
+    return new CounterRouter(entityFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {
+      CounterApi.getDescriptor(),
+      EmptyProto.getDescriptor(),
+      OuterCounterEvents.getDescriptor(),
+      OuterCounterState.getDescriptor()
+    };
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-managed/org/example/domain/CounterRouter.java
@@ -1,0 +1,51 @@
+package org.example.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.CommandContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityRouter;
+import com.google.protobuf.Empty;
+import org.example.events.OuterCounterEvents;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.state.OuterCounterState;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
+ * and the command and event handler methods in the <code>Counter</code> class.
+ */
+public class CounterRouter extends EventSourcedEntityRouter<OuterCounterState.CounterState, Counter> {
+
+  public CounterRouter(Counter entity) {
+    super(entity);
+  }
+
+  @Override
+  public OuterCounterState.CounterState handleEvent(OuterCounterState.CounterState state, Object event) {
+    if (event instanceof OuterCounterEvents.Increased) {
+      return entity().increased(state, (OuterCounterEvents.Increased) event);
+    } else if (event instanceof OuterCounterEvents.Decreased) {
+      return entity().decreased(state, (OuterCounterEvents.Decreased) event);
+    } else {
+      throw new EventSourcedEntityRouter.EventHandlerNotFound(event.getClass());
+    }
+  }
+
+  @Override
+  public EventSourcedEntity.Effect<?> handleCommand(
+      String commandName, OuterCounterState.CounterState state, Object command, CommandContext context) {
+    switch (commandName) {
+
+      case "Increase":
+        return entity().increase(state, (CounterApi.IncreaseValue) command);
+
+      case "Decrease":
+        return entity().decrease(state, (CounterApi.DecreaseValue) command);
+
+      default:
+        throw new EventSourcedEntityRouter.CommandHandlerNotFound(commandName);
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-managed/org/example/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-managed/org/example/domain/CounterTestKit.java
@@ -1,0 +1,80 @@
+package org.example.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl;
+import com.akkaserverless.javasdk.impl.effect.SecondaryEffectImpl;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedEntityEffectsRunner;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedResultImpl;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityCommandContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityEventContext;
+import com.google.protobuf.Empty;
+import org.example.events.OuterCounterEvents;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.state.OuterCounterState;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * TestKit for unit testing Counter
+ */
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<OuterCounterState.CounterState> {
+
+  /**
+   * Create a testkit instance of Counter
+   * @param entityFactory A function that creates a Counter based on the given EventSourcedEntityContext,
+   *                      a default entity id is used.
+   */
+  public static CounterTestKit of(Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return of("testkit-entity-id", entityFactory);
+  }
+
+  /**
+   * Create a testkit instance of Counter with a specific entity id.
+   */
+  public static CounterTestKit of(String entityId, Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return new CounterTestKit(entityFactory.apply(new TestKitEventSourcedEntityContext(entityId)));
+  }
+
+  private Counter entity;
+
+  /** Construction is done through the static CounterTestKit.of-methods */
+  private CounterTestKit(Counter entity) {
+     super(entity);
+     this.entity = entity;
+  }
+
+  public OuterCounterState.CounterState handleEvent(OuterCounterState.CounterState state, Object event) {
+    try {
+      entity._internalSetEventContext(Optional.of(new TestKitEventSourcedEntityEventContext()));
+      if (event instanceof OuterCounterEvents.Increased) {
+        return entity.increased(state, (OuterCounterEvents.Increased) event);
+      } else if (event instanceof OuterCounterEvents.Decreased) {
+        return entity.decreased(state, (OuterCounterEvents.Decreased) event);
+      } else {
+        throw new NoSuchElementException("Unknown event type [" + event.getClass() + "]");
+      }
+    } finally {
+      entity._internalSetEventContext(Optional.empty());
+    }
+  }
+
+  public EventSourcedResult<Empty> increase(CounterApi.IncreaseValue command) {
+    return interpretEffects(() -> entity.increase(getState(), command));
+  }
+
+  public EventSourcedResult<Empty> decrease(CounterApi.DecreaseValue command) {
+    return interpretEffects(() -> entity.decrease(getState(), command));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-test-unmanaged/org/example/domain/CounterTest.java
@@ -1,0 +1,50 @@
+package org.example.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.google.protobuf.Empty;
+import org.example.events.OuterCounterEvents;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.state.OuterCounterState;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CounterTest {
+
+  @Test
+  public void exampleTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // use the testkit to execute a command
+    // of events emitted, or a final updated state:
+    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
+    // verify the emitted events
+    // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
+    // assertEquals(expectedEvent, actualEvent)
+    // verify the final state after applying the events
+    // assertEquals(expectedState, testKit.getState());
+    // verify the response
+    // SomeResponse actualResponse = result.getReply();
+    // assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  public void increaseTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+  }
+
+
+  @Test
+  public void decreaseTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import org.example.domain.Counter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static AkkaServerless createAkkaServerless() {
+    // The AkkaServerlessFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new AkkaServerless()` instance.
+    return AkkaServerlessFactory.withComponents(
+      Counter::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Akka Serverless service");
+    createAkkaServerless().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-unmanaged/org/example/domain/Counter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/generated-unmanaged/org/example/domain/Counter.java
@@ -1,0 +1,50 @@
+package org.example.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity.Effect;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.google.protobuf.Empty;
+import org.example.events.OuterCounterEvents;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.state.OuterCounterState;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+/** An event sourced entity. */
+public class Counter extends AbstractCounter {
+
+  @SuppressWarnings("unused")
+  private final String entityId;
+
+  public Counter(EventSourcedEntityContext context) {
+    this.entityId = context.entityId();
+  }
+
+  @Override
+  public OuterCounterState.CounterState emptyState() {
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty entity state");
+  }
+
+  @Override
+  public Effect<Empty> increase(OuterCounterState.CounterState currentState, CounterApi.IncreaseValue increaseValue) {
+    return effects().error("The command handler for `Increase` is not implemented, yet");
+  }
+
+  @Override
+  public Effect<Empty> decrease(OuterCounterState.CounterState currentState, CounterApi.DecreaseValue decreaseValue) {
+    return effects().error("The command handler for `Decrease` is not implemented, yet");
+  }
+
+  @Override
+  public OuterCounterState.CounterState increased(OuterCounterState.CounterState currentState, OuterCounterEvents.Increased increased) {
+    throw new RuntimeException("The event handler for `Increased` is not implemented, yet");
+  }
+  @Override
+  public OuterCounterState.CounterState decreased(OuterCounterState.CounterState currentState, OuterCounterEvents.Decreased decreased) {
+    throw new RuntimeException("The event handler for `Decreased` is not implemented, yet");
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/proto/counter_api.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/proto/counter_api.proto
@@ -1,0 +1,50 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the public API offered by your entity.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package org.example.eventsourcedentity;
+
+option java_outer_classname = "CounterApi";
+
+message IncreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message DecreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+
+service CounterService { 
+  option (akkaserverless.codegen) = {
+    event_sourced_entity: {
+      name: "org.example.domain.Counter"
+      entity_type: "counter"
+      state: "org.example.state.CounterState"
+      events: [
+        "org.example.events.Increased",
+        "org.example.events.Decreased"]
+    }
+  };
+
+  rpc Increase (IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease (DecreaseValue) returns (google.protobuf.Empty);
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/proto/counter_events.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/proto/counter_events.proto
@@ -1,0 +1,27 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.events;
+
+option java_outer_classname = "OuterCounterEvents";
+
+message Increased {
+  int32 value = 1;
+}
+
+message Decreased {
+  int32 value = 1;
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/proto/counter_state.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/absolute-packages/proto/counter_state.proto
@@ -1,0 +1,23 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.state;
+
+option java_outer_classname = "OuterCounterState";
+
+message CounterState {
+  int32 value = 1;
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-integration-unmanaged/org/example/eventsourcedentity/CounterIntegrationTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-integration-unmanaged/org/example/eventsourcedentity/CounterIntegrationTest.java
@@ -1,0 +1,49 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.testkit.junit.AkkaServerlessTestKitResource;
+import com.google.protobuf.Empty;
+import org.example.Main;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+// Example of an integration test calling our service via the Akka Serverless proxy
+// Run all test classes ending with "IntegrationTest" using `mvn verify -Pit`
+public class CounterIntegrationTest {
+
+  /**
+   * The test kit starts both the service container and the Akka Serverless proxy.
+   */
+  @ClassRule
+  public static final AkkaServerlessTestKitResource testKit =
+    new AkkaServerlessTestKitResource(Main.createAkkaServerless());
+
+  /**
+   * Use the generated gRPC client to call the service through the Akka Serverless proxy.
+   */
+  private final CounterService client;
+
+  public CounterIntegrationTest() {
+    client = testKit.getGrpcClient(CounterService.class);
+  }
+
+  @Test
+  public void increaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.increase(CounterApi.IncreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+
+  @Test
+  public void decreaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.decrease(CounterApi.DecreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/AkkaServerlessFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/AkkaServerlessFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import org.example.eventsourcedentity.Counter;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.CounterProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class AkkaServerlessFactory {
+
+  public static AkkaServerless withComponents(
+      Function<EventSourcedEntityContext, Counter> createCounter) {
+    AkkaServerless akkaServerless = new AkkaServerless();
+    return akkaServerless
+      .register(CounterProvider.of(createCounter));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/Components.java
@@ -1,0 +1,20 @@
+package org.example;
+
+import com.akkaserverless.javasdk.DeferredCall;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  CounterCalls counter();
+
+  interface CounterCalls {
+    DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue);
+
+    DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,55 @@
+package org.example;
+
+import com.akkaserverless.javasdk.Context;
+import com.akkaserverless.javasdk.DeferredCall;
+import com.akkaserverless.javasdk.impl.DeferredCallImpl;
+import com.akkaserverless.javasdk.impl.InternalContext;
+import com.akkaserverless.javasdk.impl.MetadataImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  @Override
+  public Components.CounterCalls counter() {
+    return new CounterCallsImpl();
+  }
+
+  private final class CounterCallsImpl implements Components.CounterCalls {
+     @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue) {
+      return new DeferredCallImpl<>(
+        increaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Increase",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).increase(increaseValue)
+      );
+    }
+    @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue) {
+      return new DeferredCallImpl<>(
+        decreaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Decrease",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).decrease(decreaseValue)
+      );
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/AbstractCounter.java
@@ -1,0 +1,31 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.google.protobuf.Empty;
+import org.example.Components;
+import org.example.ComponentsImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/** An event sourced entity. */
+public abstract class AbstractCounter extends EventSourcedEntity<CounterDomain.CounterState> {
+
+  protected final Components components() {
+    return new ComponentsImpl(commandContext());
+  }
+
+  /** Command handler for "Increase". */
+  public abstract Effect<Empty> increase(CounterDomain.CounterState currentState, CounterApi.IncreaseValue increaseValue);
+
+  /** Command handler for "Decrease". */
+  public abstract Effect<Empty> decrease(CounterDomain.CounterState currentState, CounterApi.DecreaseValue decreaseValue);
+
+  /** Event handler for "Increased". */
+  public abstract CounterDomain.CounterState increased(CounterDomain.CounterState currentState, CounterDomain.Increased increased);
+
+  /** Event handler for "Decreased". */
+  public abstract CounterDomain.CounterState decreased(CounterDomain.CounterState currentState, CounterDomain.Decreased decreased);
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/CounterProvider.java
@@ -1,0 +1,71 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityOptions;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityProvider;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Empty;
+import com.google.protobuf.EmptyProto;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity provider that defines how to register and create the entity for
+ * the Protobuf service <code>CounterService</code>.
+ *
+ * Should be used with the <code>register</code> method in {@link com.akkaserverless.javasdk.AkkaServerless}.
+ */
+public class CounterProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Counter> {
+
+  private final Function<EventSourcedEntityContext, Counter> entityFactory;
+  private final EventSourcedEntityOptions options;
+
+  /** Factory method of CounterProvider */
+  public static CounterProvider of(Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return new CounterProvider(entityFactory, EventSourcedEntityOptions.defaults());
+  }
+
+  private CounterProvider(
+      Function<EventSourcedEntityContext, Counter> entityFactory,
+      EventSourcedEntityOptions options) {
+    this.entityFactory = entityFactory;
+    this.options = options;
+  }
+
+  @Override
+  public final EventSourcedEntityOptions options() {
+    return options;
+  }
+
+  public final CounterProvider withOptions(EventSourcedEntityOptions options) {
+    return new CounterProvider(entityFactory, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return CounterApi.getDescriptor().findServiceByName("CounterService");
+  }
+
+  @Override
+  public final String entityType() {
+    return "counter";
+  }
+
+  @Override
+  public final CounterRouter newRouter(EventSourcedEntityContext context) {
+    return new CounterRouter(entityFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {
+      CounterApi.getDescriptor(),
+      CounterDomain.getDescriptor(),
+      EmptyProto.getDescriptor()
+    };
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-managed/org/example/eventsourcedentity/CounterRouter.java
@@ -1,0 +1,48 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.CommandContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityRouter;
+import com.google.protobuf.Empty;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
+ * and the command and event handler methods in the <code>Counter</code> class.
+ */
+public class CounterRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Counter> {
+
+  public CounterRouter(Counter entity) {
+    super(entity);
+  }
+
+  @Override
+  public CounterDomain.CounterState handleEvent(CounterDomain.CounterState state, Object event) {
+    if (event instanceof CounterDomain.Increased) {
+      return entity().increased(state, (CounterDomain.Increased) event);
+    } else if (event instanceof CounterDomain.Decreased) {
+      return entity().decreased(state, (CounterDomain.Decreased) event);
+    } else {
+      throw new EventSourcedEntityRouter.EventHandlerNotFound(event.getClass());
+    }
+  }
+
+  @Override
+  public EventSourcedEntity.Effect<?> handleCommand(
+      String commandName, CounterDomain.CounterState state, Object command, CommandContext context) {
+    switch (commandName) {
+
+      case "Increase":
+        return entity().increase(state, (CounterApi.IncreaseValue) command);
+
+      case "Decrease":
+        return entity().decrease(state, (CounterApi.DecreaseValue) command);
+
+      default:
+        throw new EventSourcedEntityRouter.CommandHandlerNotFound(commandName);
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-managed/org/example/eventsourcedentity/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-managed/org/example/eventsourcedentity/CounterTestKit.java
@@ -1,0 +1,77 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl;
+import com.akkaserverless.javasdk.impl.effect.SecondaryEffectImpl;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedEntityEffectsRunner;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedResultImpl;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityCommandContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityEventContext;
+import com.google.protobuf.Empty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * TestKit for unit testing Counter
+ */
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState> {
+
+  /**
+   * Create a testkit instance of Counter
+   * @param entityFactory A function that creates a Counter based on the given EventSourcedEntityContext,
+   *                      a default entity id is used.
+   */
+  public static CounterTestKit of(Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return of("testkit-entity-id", entityFactory);
+  }
+
+  /**
+   * Create a testkit instance of Counter with a specific entity id.
+   */
+  public static CounterTestKit of(String entityId, Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return new CounterTestKit(entityFactory.apply(new TestKitEventSourcedEntityContext(entityId)));
+  }
+
+  private Counter entity;
+
+  /** Construction is done through the static CounterTestKit.of-methods */
+  private CounterTestKit(Counter entity) {
+     super(entity);
+     this.entity = entity;
+  }
+
+  public CounterDomain.CounterState handleEvent(CounterDomain.CounterState state, Object event) {
+    try {
+      entity._internalSetEventContext(Optional.of(new TestKitEventSourcedEntityEventContext()));
+      if (event instanceof CounterDomain.Increased) {
+        return entity.increased(state, (CounterDomain.Increased) event);
+      } else if (event instanceof CounterDomain.Decreased) {
+        return entity.decreased(state, (CounterDomain.Decreased) event);
+      } else {
+        throw new NoSuchElementException("Unknown event type [" + event.getClass() + "]");
+      }
+    } finally {
+      entity._internalSetEventContext(Optional.empty());
+    }
+  }
+
+  public EventSourcedResult<Empty> increase(CounterApi.IncreaseValue command) {
+    return interpretEffects(() -> entity.increase(getState(), command));
+  }
+
+  public EventSourcedResult<Empty> decrease(CounterApi.DecreaseValue command) {
+    return interpretEffects(() -> entity.decrease(getState(), command));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-unmanaged/org/example/eventsourcedentity/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-test-unmanaged/org/example/eventsourcedentity/CounterTest.java
@@ -1,0 +1,47 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.google.protobuf.Empty;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CounterTest {
+
+  @Test
+  public void exampleTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // use the testkit to execute a command
+    // of events emitted, or a final updated state:
+    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
+    // verify the emitted events
+    // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
+    // assertEquals(expectedEvent, actualEvent)
+    // verify the final state after applying the events
+    // assertEquals(expectedState, testKit.getState());
+    // verify the response
+    // SomeResponse actualResponse = result.getReply();
+    // assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  public void increaseTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+  }
+
+
+  @Test
+  public void decreaseTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import org.example.eventsourcedentity.Counter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static AkkaServerless createAkkaServerless() {
+    // The AkkaServerlessFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new AkkaServerless()` instance.
+    return AkkaServerlessFactory.withComponents(
+      Counter::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Akka Serverless service");
+    createAkkaServerless().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-unmanaged/org/example/eventsourcedentity/Counter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/generated-unmanaged/org/example/eventsourcedentity/Counter.java
@@ -1,0 +1,47 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity.Effect;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.google.protobuf.Empty;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+/** An event sourced entity. */
+public class Counter extends AbstractCounter {
+
+  @SuppressWarnings("unused")
+  private final String entityId;
+
+  public Counter(EventSourcedEntityContext context) {
+    this.entityId = context.entityId();
+  }
+
+  @Override
+  public CounterDomain.CounterState emptyState() {
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty entity state");
+  }
+
+  @Override
+  public Effect<Empty> increase(CounterDomain.CounterState currentState, CounterApi.IncreaseValue increaseValue) {
+    return effects().error("The command handler for `Increase` is not implemented, yet");
+  }
+
+  @Override
+  public Effect<Empty> decrease(CounterDomain.CounterState currentState, CounterApi.DecreaseValue decreaseValue) {
+    return effects().error("The command handler for `Decrease` is not implemented, yet");
+  }
+
+  @Override
+  public CounterDomain.CounterState increased(CounterDomain.CounterState currentState, CounterDomain.Increased increased) {
+    throw new RuntimeException("The event handler for `Increased` is not implemented, yet");
+  }
+  @Override
+  public CounterDomain.CounterState decreased(CounterDomain.CounterState currentState, CounterDomain.Decreased decreased) {
+    throw new RuntimeException("The event handler for `Decreased` is not implemented, yet");
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/proto/counter_api.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/proto/counter_api.proto
@@ -1,0 +1,48 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the public API offered by your entity.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package org.example.eventsourcedentity;
+
+option java_outer_classname = "CounterApi";
+
+message IncreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message DecreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+
+service CounterService { 
+  option (akkaserverless.codegen) = {
+    event_sourced_entity: {
+      name: "Counter"
+      entity_type: "counter"
+      state: "CounterState"
+      events: ["Increased", "Decreased"]
+    }
+  };
+
+  rpc Increase (IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease (DecreaseValue) returns (google.protobuf.Empty);
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/proto/counter_domain.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/domain-in-service-package/proto/counter_domain.proto
@@ -1,0 +1,31 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.eventsourcedentity;
+
+option java_outer_classname = "CounterDomain";
+
+message CounterState {
+  int32 value = 1;
+}
+
+message Increased {
+  int32 value = 1;
+}
+
+message Decreased {
+  int32 value = 1;
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-integration-unmanaged/org/example/eventsourcedentity/CounterIntegrationTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-integration-unmanaged/org/example/eventsourcedentity/CounterIntegrationTest.java
@@ -1,0 +1,50 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.testkit.junit.AkkaServerlessTestKitResource;
+import com.google.protobuf.Empty;
+import org.example.Main;
+import org.example.eventsourcedentity.domain.CounterDomain;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+// Example of an integration test calling our service via the Akka Serverless proxy
+// Run all test classes ending with "IntegrationTest" using `mvn verify -Pit`
+public class CounterIntegrationTest {
+
+  /**
+   * The test kit starts both the service container and the Akka Serverless proxy.
+   */
+  @ClassRule
+  public static final AkkaServerlessTestKitResource testKit =
+    new AkkaServerlessTestKitResource(Main.createAkkaServerless());
+
+  /**
+   * Use the generated gRPC client to call the service through the Akka Serverless proxy.
+   */
+  private final CounterService client;
+
+  public CounterIntegrationTest() {
+    client = testKit.getGrpcClient(CounterService.class);
+  }
+
+  @Test
+  public void increaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.increase(CounterApi.IncreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+
+  @Test
+  public void decreaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.decrease(CounterApi.DecreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/AkkaServerlessFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/AkkaServerlessFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.domain.Counter;
+import org.example.eventsourcedentity.domain.CounterProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class AkkaServerlessFactory {
+
+  public static AkkaServerless withComponents(
+      Function<EventSourcedEntityContext, Counter> createCounter) {
+    AkkaServerless akkaServerless = new AkkaServerless();
+    return akkaServerless
+      .register(CounterProvider.of(createCounter));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/Components.java
@@ -1,0 +1,20 @@
+package org.example;
+
+import com.akkaserverless.javasdk.DeferredCall;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  CounterCalls counter();
+
+  interface CounterCalls {
+    DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue);
+
+    DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,55 @@
+package org.example;
+
+import com.akkaserverless.javasdk.Context;
+import com.akkaserverless.javasdk.DeferredCall;
+import com.akkaserverless.javasdk.impl.DeferredCallImpl;
+import com.akkaserverless.javasdk.impl.InternalContext;
+import com.akkaserverless.javasdk.impl.MetadataImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  @Override
+  public Components.CounterCalls counter() {
+    return new CounterCallsImpl();
+  }
+
+  private final class CounterCallsImpl implements Components.CounterCalls {
+     @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue) {
+      return new DeferredCallImpl<>(
+        increaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Increase",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).increase(increaseValue)
+      );
+    }
+    @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue) {
+      return new DeferredCallImpl<>(
+        decreaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Decrease",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).decrease(decreaseValue)
+      );
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
@@ -1,0 +1,32 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.google.protobuf.Empty;
+import org.example.Components;
+import org.example.ComponentsImpl;
+import org.example.eventsourcedentity.CounterApi;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/** An event sourced entity. */
+public abstract class AbstractCounter extends EventSourcedEntity<CounterDomain.CounterState> {
+
+  protected final Components components() {
+    return new ComponentsImpl(commandContext());
+  }
+
+  /** Command handler for "Increase". */
+  public abstract Effect<Empty> increase(CounterDomain.CounterState currentState, CounterApi.IncreaseValue increaseValue);
+
+  /** Command handler for "Decrease". */
+  public abstract Effect<Empty> decrease(CounterDomain.CounterState currentState, CounterApi.DecreaseValue decreaseValue);
+
+  /** Event handler for "Increased". */
+  public abstract CounterDomain.CounterState increased(CounterDomain.CounterState currentState, CounterDomain.Increased increased);
+
+  /** Event handler for "Decreased". */
+  public abstract CounterDomain.CounterState decreased(CounterDomain.CounterState currentState, CounterDomain.Decreased decreased);
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
@@ -1,0 +1,72 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityOptions;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityProvider;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Empty;
+import com.google.protobuf.EmptyProto;
+import org.example.eventsourcedentity.CounterApi;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity provider that defines how to register and create the entity for
+ * the Protobuf service <code>CounterService</code>.
+ *
+ * Should be used with the <code>register</code> method in {@link com.akkaserverless.javasdk.AkkaServerless}.
+ */
+public class CounterProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, Counter> {
+
+  private final Function<EventSourcedEntityContext, Counter> entityFactory;
+  private final EventSourcedEntityOptions options;
+
+  /** Factory method of CounterProvider */
+  public static CounterProvider of(Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return new CounterProvider(entityFactory, EventSourcedEntityOptions.defaults());
+  }
+
+  private CounterProvider(
+      Function<EventSourcedEntityContext, Counter> entityFactory,
+      EventSourcedEntityOptions options) {
+    this.entityFactory = entityFactory;
+    this.options = options;
+  }
+
+  @Override
+  public final EventSourcedEntityOptions options() {
+    return options;
+  }
+
+  public final CounterProvider withOptions(EventSourcedEntityOptions options) {
+    return new CounterProvider(entityFactory, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return CounterApi.getDescriptor().findServiceByName("CounterService");
+  }
+
+  @Override
+  public final String entityType() {
+    return "counter";
+  }
+
+  @Override
+  public final CounterRouter newRouter(EventSourcedEntityContext context) {
+    return new CounterRouter(entityFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {
+      CounterApi.getDescriptor(),
+      CounterDomain.getDescriptor(),
+      EmptyProto.getDescriptor()
+    };
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
@@ -1,0 +1,49 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.CommandContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityRouter;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.CounterApi;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
+ * and the command and event handler methods in the <code>Counter</code> class.
+ */
+public class CounterRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, Counter> {
+
+  public CounterRouter(Counter entity) {
+    super(entity);
+  }
+
+  @Override
+  public CounterDomain.CounterState handleEvent(CounterDomain.CounterState state, Object event) {
+    if (event instanceof CounterDomain.Increased) {
+      return entity().increased(state, (CounterDomain.Increased) event);
+    } else if (event instanceof CounterDomain.Decreased) {
+      return entity().decreased(state, (CounterDomain.Decreased) event);
+    } else {
+      throw new EventSourcedEntityRouter.EventHandlerNotFound(event.getClass());
+    }
+  }
+
+  @Override
+  public EventSourcedEntity.Effect<?> handleCommand(
+      String commandName, CounterDomain.CounterState state, Object command, CommandContext context) {
+    switch (commandName) {
+
+      case "Increase":
+        return entity().increase(state, (CounterApi.IncreaseValue) command);
+
+      case "Decrease":
+        return entity().decrease(state, (CounterApi.DecreaseValue) command);
+
+      default:
+        throw new EventSourcedEntityRouter.CommandHandlerNotFound(commandName);
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
@@ -1,0 +1,78 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl;
+import com.akkaserverless.javasdk.impl.effect.SecondaryEffectImpl;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedEntityEffectsRunner;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedResultImpl;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityCommandContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityEventContext;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.CounterApi;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * TestKit for unit testing Counter
+ */
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState> {
+
+  /**
+   * Create a testkit instance of Counter
+   * @param entityFactory A function that creates a Counter based on the given EventSourcedEntityContext,
+   *                      a default entity id is used.
+   */
+  public static CounterTestKit of(Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return of("testkit-entity-id", entityFactory);
+  }
+
+  /**
+   * Create a testkit instance of Counter with a specific entity id.
+   */
+  public static CounterTestKit of(String entityId, Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return new CounterTestKit(entityFactory.apply(new TestKitEventSourcedEntityContext(entityId)));
+  }
+
+  private Counter entity;
+
+  /** Construction is done through the static CounterTestKit.of-methods */
+  private CounterTestKit(Counter entity) {
+     super(entity);
+     this.entity = entity;
+  }
+
+  public CounterDomain.CounterState handleEvent(CounterDomain.CounterState state, Object event) {
+    try {
+      entity._internalSetEventContext(Optional.of(new TestKitEventSourcedEntityEventContext()));
+      if (event instanceof CounterDomain.Increased) {
+        return entity.increased(state, (CounterDomain.Increased) event);
+      } else if (event instanceof CounterDomain.Decreased) {
+        return entity.decreased(state, (CounterDomain.Decreased) event);
+      } else {
+        throw new NoSuchElementException("Unknown event type [" + event.getClass() + "]");
+      }
+    } finally {
+      entity._internalSetEventContext(Optional.empty());
+    }
+  }
+
+  public EventSourcedResult<Empty> increase(CounterApi.IncreaseValue command) {
+    return interpretEffects(() -> entity.increase(getState(), command));
+  }
+
+  public EventSourcedResult<Empty> decrease(CounterApi.DecreaseValue command) {
+    return interpretEffects(() -> entity.decrease(getState(), command));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
@@ -1,0 +1,48 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.CounterApi;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CounterTest {
+
+  @Test
+  public void exampleTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // use the testkit to execute a command
+    // of events emitted, or a final updated state:
+    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
+    // verify the emitted events
+    // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
+    // assertEquals(expectedEvent, actualEvent)
+    // verify the final state after applying the events
+    // assertEquals(expectedState, testKit.getState());
+    // verify the response
+    // SomeResponse actualResponse = result.getReply();
+    // assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  public void increaseTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+  }
+
+
+  @Test
+  public void decreaseTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import org.example.eventsourcedentity.domain.Counter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static AkkaServerless createAkkaServerless() {
+    // The AkkaServerlessFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new AkkaServerless()` instance.
+    return AkkaServerlessFactory.withComponents(
+      Counter::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Akka Serverless service");
+    createAkkaServerless().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-unmanaged/org/example/eventsourcedentity/domain/Counter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/generated-unmanaged/org/example/eventsourcedentity/domain/Counter.java
@@ -1,0 +1,48 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity.Effect;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.CounterApi;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+/** An event sourced entity. */
+public class Counter extends AbstractCounter {
+
+  @SuppressWarnings("unused")
+  private final String entityId;
+
+  public Counter(EventSourcedEntityContext context) {
+    this.entityId = context.entityId();
+  }
+
+  @Override
+  public CounterDomain.CounterState emptyState() {
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty entity state");
+  }
+
+  @Override
+  public Effect<Empty> increase(CounterDomain.CounterState currentState, CounterApi.IncreaseValue increaseValue) {
+    return effects().error("The command handler for `Increase` is not implemented, yet");
+  }
+
+  @Override
+  public Effect<Empty> decrease(CounterDomain.CounterState currentState, CounterApi.DecreaseValue decreaseValue) {
+    return effects().error("The command handler for `Decrease` is not implemented, yet");
+  }
+
+  @Override
+  public CounterDomain.CounterState increased(CounterDomain.CounterState currentState, CounterDomain.Increased increased) {
+    throw new RuntimeException("The event handler for `Increased` is not implemented, yet");
+  }
+  @Override
+  public CounterDomain.CounterState decreased(CounterDomain.CounterState currentState, CounterDomain.Decreased decreased) {
+    throw new RuntimeException("The event handler for `Decreased` is not implemented, yet");
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/proto/counter_api.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/proto/counter_api.proto
@@ -1,0 +1,48 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the public API offered by your entity.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package org.example.eventsourcedentity;
+
+option java_outer_classname = "CounterApi";
+
+message IncreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message DecreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+
+service CounterService { 
+  option (akkaserverless.codegen) = {
+    event_sourced_entity: {
+      name: ".domain.Counter"
+      entity_type: "counter"
+      state: ".domain.CounterState"
+      events: [".domain.Increased", ".domain.Decreased"]
+    }
+  };
+
+  rpc Increase (IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease (DecreaseValue) returns (google.protobuf.Empty);
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/proto/counter_domain.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/named-new-style/proto/counter_domain.proto
@@ -1,0 +1,31 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.eventsourcedentity.domain;
+
+option java_outer_classname = "CounterDomain";
+
+message CounterState {
+  int32 value = 1;
+}
+
+message Increased {
+  int32 value = 1;
+}
+
+message Decreased {
+  int32 value = 1;
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-integration-unmanaged/org/example/eventsourcedentity/CounterIntegrationTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-integration-unmanaged/org/example/eventsourcedentity/CounterIntegrationTest.java
@@ -1,0 +1,50 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.testkit.junit.AkkaServerlessTestKitResource;
+import com.google.protobuf.Empty;
+import org.example.Main;
+import org.example.eventsourcedentity.state.OuterCounterState;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+// Example of an integration test calling our service via the Akka Serverless proxy
+// Run all test classes ending with "IntegrationTest" using `mvn verify -Pit`
+public class CounterIntegrationTest {
+
+  /**
+   * The test kit starts both the service container and the Akka Serverless proxy.
+   */
+  @ClassRule
+  public static final AkkaServerlessTestKitResource testKit =
+    new AkkaServerlessTestKitResource(Main.createAkkaServerless());
+
+  /**
+   * Use the generated gRPC client to call the service through the Akka Serverless proxy.
+   */
+  private final CounterService client;
+
+  public CounterIntegrationTest() {
+    client = testKit.getGrpcClient(CounterService.class);
+  }
+
+  @Test
+  public void increaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.increase(CounterApi.IncreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+
+  @Test
+  public void decreaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.decrease(CounterApi.DecreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/AkkaServerlessFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/AkkaServerlessFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.domain.Counter;
+import org.example.eventsourcedentity.domain.CounterProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class AkkaServerlessFactory {
+
+  public static AkkaServerless withComponents(
+      Function<EventSourcedEntityContext, Counter> createCounter) {
+    AkkaServerless akkaServerless = new AkkaServerless();
+    return akkaServerless
+      .register(CounterProvider.of(createCounter));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/Components.java
@@ -1,0 +1,20 @@
+package org.example;
+
+import com.akkaserverless.javasdk.DeferredCall;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  CounterCalls counter();
+
+  interface CounterCalls {
+    DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue);
+
+    DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,55 @@
+package org.example;
+
+import com.akkaserverless.javasdk.Context;
+import com.akkaserverless.javasdk.DeferredCall;
+import com.akkaserverless.javasdk.impl.DeferredCallImpl;
+import com.akkaserverless.javasdk.impl.InternalContext;
+import com.akkaserverless.javasdk.impl.MetadataImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  @Override
+  public Components.CounterCalls counter() {
+    return new CounterCallsImpl();
+  }
+
+  private final class CounterCallsImpl implements Components.CounterCalls {
+     @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue) {
+      return new DeferredCallImpl<>(
+        increaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Increase",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).increase(increaseValue)
+      );
+    }
+    @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue) {
+      return new DeferredCallImpl<>(
+        decreaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Decrease",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).decrease(decreaseValue)
+      );
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/AbstractCounter.java
@@ -1,0 +1,34 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.google.protobuf.Empty;
+import org.example.Components;
+import org.example.ComponentsImpl;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.events.OuterCounterEvents;
+import org.example.eventsourcedentity.state.OuterCounterState;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/** An event sourced entity. */
+public abstract class AbstractCounter extends EventSourcedEntity<OuterCounterState.CounterState> {
+
+  protected final Components components() {
+    return new ComponentsImpl(commandContext());
+  }
+
+  /** Command handler for "Increase". */
+  public abstract Effect<Empty> increase(OuterCounterState.CounterState currentState, CounterApi.IncreaseValue increaseValue);
+
+  /** Command handler for "Decrease". */
+  public abstract Effect<Empty> decrease(OuterCounterState.CounterState currentState, CounterApi.DecreaseValue decreaseValue);
+
+  /** Event handler for "Increased". */
+  public abstract OuterCounterState.CounterState increased(OuterCounterState.CounterState currentState, OuterCounterEvents.Increased increased);
+
+  /** Event handler for "Decreased". */
+  public abstract OuterCounterState.CounterState decreased(OuterCounterState.CounterState currentState, OuterCounterEvents.Decreased decreased);
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/CounterProvider.java
@@ -1,0 +1,75 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityOptions;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityProvider;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Empty;
+import com.google.protobuf.EmptyProto;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.events.OuterCounterEvents;
+import org.example.eventsourcedentity.state.OuterCounterState;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity provider that defines how to register and create the entity for
+ * the Protobuf service <code>CounterService</code>.
+ *
+ * Should be used with the <code>register</code> method in {@link com.akkaserverless.javasdk.AkkaServerless}.
+ */
+public class CounterProvider implements EventSourcedEntityProvider<OuterCounterState.CounterState, Counter> {
+
+  private final Function<EventSourcedEntityContext, Counter> entityFactory;
+  private final EventSourcedEntityOptions options;
+
+  /** Factory method of CounterProvider */
+  public static CounterProvider of(Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return new CounterProvider(entityFactory, EventSourcedEntityOptions.defaults());
+  }
+
+  private CounterProvider(
+      Function<EventSourcedEntityContext, Counter> entityFactory,
+      EventSourcedEntityOptions options) {
+    this.entityFactory = entityFactory;
+    this.options = options;
+  }
+
+  @Override
+  public final EventSourcedEntityOptions options() {
+    return options;
+  }
+
+  public final CounterProvider withOptions(EventSourcedEntityOptions options) {
+    return new CounterProvider(entityFactory, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return CounterApi.getDescriptor().findServiceByName("CounterService");
+  }
+
+  @Override
+  public final String entityType() {
+    return "counter";
+  }
+
+  @Override
+  public final CounterRouter newRouter(EventSourcedEntityContext context) {
+    return new CounterRouter(entityFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {
+      CounterApi.getDescriptor(),
+      EmptyProto.getDescriptor(),
+      OuterCounterEvents.getDescriptor(),
+      OuterCounterState.getDescriptor()
+    };
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-managed/org/example/eventsourcedentity/domain/CounterRouter.java
@@ -1,0 +1,51 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.CommandContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityRouter;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.events.OuterCounterEvents;
+import org.example.eventsourcedentity.state.OuterCounterState;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
+ * and the command and event handler methods in the <code>Counter</code> class.
+ */
+public class CounterRouter extends EventSourcedEntityRouter<OuterCounterState.CounterState, Counter> {
+
+  public CounterRouter(Counter entity) {
+    super(entity);
+  }
+
+  @Override
+  public OuterCounterState.CounterState handleEvent(OuterCounterState.CounterState state, Object event) {
+    if (event instanceof OuterCounterEvents.Increased) {
+      return entity().increased(state, (OuterCounterEvents.Increased) event);
+    } else if (event instanceof OuterCounterEvents.Decreased) {
+      return entity().decreased(state, (OuterCounterEvents.Decreased) event);
+    } else {
+      throw new EventSourcedEntityRouter.EventHandlerNotFound(event.getClass());
+    }
+  }
+
+  @Override
+  public EventSourcedEntity.Effect<?> handleCommand(
+      String commandName, OuterCounterState.CounterState state, Object command, CommandContext context) {
+    switch (commandName) {
+
+      case "Increase":
+        return entity().increase(state, (CounterApi.IncreaseValue) command);
+
+      case "Decrease":
+        return entity().decrease(state, (CounterApi.DecreaseValue) command);
+
+      default:
+        throw new EventSourcedEntityRouter.CommandHandlerNotFound(commandName);
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-managed/org/example/eventsourcedentity/domain/CounterTestKit.java
@@ -1,0 +1,80 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl;
+import com.akkaserverless.javasdk.impl.effect.SecondaryEffectImpl;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedEntityEffectsRunner;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedResultImpl;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityCommandContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityEventContext;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.events.OuterCounterEvents;
+import org.example.eventsourcedentity.state.OuterCounterState;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * TestKit for unit testing Counter
+ */
+public final class CounterTestKit extends EventSourcedEntityEffectsRunner<OuterCounterState.CounterState> {
+
+  /**
+   * Create a testkit instance of Counter
+   * @param entityFactory A function that creates a Counter based on the given EventSourcedEntityContext,
+   *                      a default entity id is used.
+   */
+  public static CounterTestKit of(Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return of("testkit-entity-id", entityFactory);
+  }
+
+  /**
+   * Create a testkit instance of Counter with a specific entity id.
+   */
+  public static CounterTestKit of(String entityId, Function<EventSourcedEntityContext, Counter> entityFactory) {
+    return new CounterTestKit(entityFactory.apply(new TestKitEventSourcedEntityContext(entityId)));
+  }
+
+  private Counter entity;
+
+  /** Construction is done through the static CounterTestKit.of-methods */
+  private CounterTestKit(Counter entity) {
+     super(entity);
+     this.entity = entity;
+  }
+
+  public OuterCounterState.CounterState handleEvent(OuterCounterState.CounterState state, Object event) {
+    try {
+      entity._internalSetEventContext(Optional.of(new TestKitEventSourcedEntityEventContext()));
+      if (event instanceof OuterCounterEvents.Increased) {
+        return entity.increased(state, (OuterCounterEvents.Increased) event);
+      } else if (event instanceof OuterCounterEvents.Decreased) {
+        return entity.decreased(state, (OuterCounterEvents.Decreased) event);
+      } else {
+        throw new NoSuchElementException("Unknown event type [" + event.getClass() + "]");
+      }
+    } finally {
+      entity._internalSetEventContext(Optional.empty());
+    }
+  }
+
+  public EventSourcedResult<Empty> increase(CounterApi.IncreaseValue command) {
+    return interpretEffects(() -> entity.increase(getState(), command));
+  }
+
+  public EventSourcedResult<Empty> decrease(CounterApi.DecreaseValue command) {
+    return interpretEffects(() -> entity.decrease(getState(), command));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-test-unmanaged/org/example/eventsourcedentity/domain/CounterTest.java
@@ -1,0 +1,50 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.events.OuterCounterEvents;
+import org.example.eventsourcedentity.state.OuterCounterState;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CounterTest {
+
+  @Test
+  public void exampleTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // use the testkit to execute a command
+    // of events emitted, or a final updated state:
+    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
+    // verify the emitted events
+    // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
+    // assertEquals(expectedEvent, actualEvent)
+    // verify the final state after applying the events
+    // assertEquals(expectedState, testKit.getState());
+    // verify the response
+    // SomeResponse actualResponse = result.getReply();
+    // assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  public void increaseTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+  }
+
+
+  @Test
+  public void decreaseTest() {
+    CounterTestKit testKit = CounterTestKit.of(Counter::new);
+    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import org.example.eventsourcedentity.domain.Counter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static AkkaServerless createAkkaServerless() {
+    // The AkkaServerlessFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new AkkaServerless()` instance.
+    return AkkaServerlessFactory.withComponents(
+      Counter::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Akka Serverless service");
+    createAkkaServerless().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-unmanaged/org/example/eventsourcedentity/domain/Counter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/generated-unmanaged/org/example/eventsourcedentity/domain/Counter.java
@@ -1,0 +1,50 @@
+package org.example.eventsourcedentity.domain;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity.Effect;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.events.OuterCounterEvents;
+import org.example.eventsourcedentity.state.OuterCounterState;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+/** An event sourced entity. */
+public class Counter extends AbstractCounter {
+
+  @SuppressWarnings("unused")
+  private final String entityId;
+
+  public Counter(EventSourcedEntityContext context) {
+    this.entityId = context.entityId();
+  }
+
+  @Override
+  public OuterCounterState.CounterState emptyState() {
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty entity state");
+  }
+
+  @Override
+  public Effect<Empty> increase(OuterCounterState.CounterState currentState, CounterApi.IncreaseValue increaseValue) {
+    return effects().error("The command handler for `Increase` is not implemented, yet");
+  }
+
+  @Override
+  public Effect<Empty> decrease(OuterCounterState.CounterState currentState, CounterApi.DecreaseValue decreaseValue) {
+    return effects().error("The command handler for `Decrease` is not implemented, yet");
+  }
+
+  @Override
+  public OuterCounterState.CounterState increased(OuterCounterState.CounterState currentState, OuterCounterEvents.Increased increased) {
+    throw new RuntimeException("The event handler for `Increased` is not implemented, yet");
+  }
+  @Override
+  public OuterCounterState.CounterState decreased(OuterCounterState.CounterState currentState, OuterCounterEvents.Decreased decreased) {
+    throw new RuntimeException("The event handler for `Decreased` is not implemented, yet");
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/proto/counter_api.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/proto/counter_api.proto
@@ -1,0 +1,50 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the public API offered by your entity.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package org.example.eventsourcedentity;
+
+option java_outer_classname = "CounterApi";
+
+message IncreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message DecreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+
+service CounterService { 
+  option (akkaserverless.codegen) = {
+    event_sourced_entity: {
+      name: ".domain.Counter"
+      entity_type: "counter"
+      state: ".state.CounterState"
+      events: [
+        ".events.Increased",
+        ".events.Decreased"]
+    }
+  };
+
+  rpc Increase (IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease (DecreaseValue) returns (google.protobuf.Empty);
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/proto/counter_events.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/proto/counter_events.proto
@@ -1,0 +1,27 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.eventsourcedentity.events;
+
+option java_outer_classname = "OuterCounterEvents";
+
+message Increased {
+  int32 value = 1;
+}
+
+message Decreased {
+  int32 value = 1;
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/proto/counter_state.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/state-events-in-different-pacakge/proto/counter_state.proto
@@ -1,0 +1,23 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.eventsourcedentity.state;
+
+option java_outer_classname = "OuterCounterState";
+
+message CounterState {
+  int32 value = 1;
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-integration-unmanaged/org/example/eventsourcedentity/CounterServiceEntityIntegrationTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-integration-unmanaged/org/example/eventsourcedentity/CounterServiceEntityIntegrationTest.java
@@ -1,0 +1,50 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.testkit.junit.AkkaServerlessTestKitResource;
+import com.google.protobuf.Empty;
+import org.example.Main;
+import org.example.eventsourcedentity.domain.CounterDomain;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+// Example of an integration test calling our service via the Akka Serverless proxy
+// Run all test classes ending with "IntegrationTest" using `mvn verify -Pit`
+public class CounterServiceEntityIntegrationTest {
+
+  /**
+   * The test kit starts both the service container and the Akka Serverless proxy.
+   */
+  @ClassRule
+  public static final AkkaServerlessTestKitResource testKit =
+    new AkkaServerlessTestKitResource(Main.createAkkaServerless());
+
+  /**
+   * Use the generated gRPC client to call the service through the Akka Serverless proxy.
+   */
+  private final CounterService client;
+
+  public CounterServiceEntityIntegrationTest() {
+    client = testKit.getGrpcClient(CounterService.class);
+  }
+
+  @Test
+  public void increaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.increase(CounterApi.IncreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+
+  @Test
+  public void decreaseOnNonExistingEntity() throws Exception {
+    // TODO: set fields in command, and provide assertions to match replies
+    // client.decrease(CounterApi.DecreaseValue.newBuilder().build())
+    //         .toCompletableFuture().get(5, SECONDS);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/AkkaServerlessFactory.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/AkkaServerlessFactory.java
@@ -1,0 +1,23 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import org.example.eventsourcedentity.CounterApi;
+import org.example.eventsourcedentity.CounterServiceEntity;
+import org.example.eventsourcedentity.CounterServiceEntityProvider;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+public final class AkkaServerlessFactory {
+
+  public static AkkaServerless withComponents(
+      Function<EventSourcedEntityContext, CounterServiceEntity> createCounterServiceEntity) {
+    AkkaServerless akkaServerless = new AkkaServerless();
+    return akkaServerless
+      .register(CounterServiceEntityProvider.of(createCounterServiceEntity));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/Components.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/Components.java
@@ -1,0 +1,20 @@
+package org.example;
+
+import com.akkaserverless.javasdk.DeferredCall;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for user extension, provided through generated implementation
+ */
+public interface Components {
+  CounterServiceEntityCalls counterServiceEntity();
+
+  interface CounterServiceEntityCalls {
+    DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue);
+
+    DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue);
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/ComponentsImpl.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/ComponentsImpl.java
@@ -1,0 +1,55 @@
+package org.example;
+
+import com.akkaserverless.javasdk.Context;
+import com.akkaserverless.javasdk.DeferredCall;
+import com.akkaserverless.javasdk.impl.DeferredCallImpl;
+import com.akkaserverless.javasdk.impl.InternalContext;
+import com.akkaserverless.javasdk.impl.MetadataImpl;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * Not intended for direct instantiation, called by generated code, use Action.components() to access
+ */
+public final class ComponentsImpl implements Components {
+
+  private final InternalContext context;
+
+  public ComponentsImpl(Context context) {
+    this.context = (InternalContext) context;
+  }
+
+  private <T> T getGrpcClient(Class<T> serviceClass) {
+    return context.getComponentGrpcClient(serviceClass);
+  }
+
+  @Override
+  public Components.CounterServiceEntityCalls counterServiceEntity() {
+    return new CounterServiceEntityCallsImpl();
+  }
+
+  private final class CounterServiceEntityCallsImpl implements Components.CounterServiceEntityCalls {
+     @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.IncreaseValue, com.google.protobuf.Empty> increase(org.example.eventsourcedentity.CounterApi.IncreaseValue increaseValue) {
+      return new DeferredCallImpl<>(
+        increaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Increase",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).increase(increaseValue)
+      );
+    }
+    @Override
+    public DeferredCall<org.example.eventsourcedentity.CounterApi.DecreaseValue, com.google.protobuf.Empty> decrease(org.example.eventsourcedentity.CounterApi.DecreaseValue decreaseValue) {
+      return new DeferredCallImpl<>(
+        decreaseValue,
+        MetadataImpl.Empty(),
+        "org.example.eventsourcedentity.CounterService",
+        "Decrease",
+        () -> getGrpcClient(org.example.eventsourcedentity.CounterService.class).decrease(decreaseValue)
+      );
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/AbstractCounterServiceEntity.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/AbstractCounterServiceEntity.java
@@ -1,0 +1,32 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.google.protobuf.Empty;
+import org.example.Components;
+import org.example.ComponentsImpl;
+import org.example.eventsourcedentity.domain.CounterDomain;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/** An event sourced entity. */
+public abstract class AbstractCounterServiceEntity extends EventSourcedEntity<CounterDomain.CounterState> {
+
+  protected final Components components() {
+    return new ComponentsImpl(commandContext());
+  }
+
+  /** Command handler for "Increase". */
+  public abstract Effect<Empty> increase(CounterDomain.CounterState currentState, CounterApi.IncreaseValue increaseValue);
+
+  /** Command handler for "Decrease". */
+  public abstract Effect<Empty> decrease(CounterDomain.CounterState currentState, CounterApi.DecreaseValue decreaseValue);
+
+  /** Event handler for "Increased". */
+  public abstract CounterDomain.CounterState increased(CounterDomain.CounterState currentState, CounterDomain.Increased increased);
+
+  /** Event handler for "Decreased". */
+  public abstract CounterDomain.CounterState decreased(CounterDomain.CounterState currentState, CounterDomain.Decreased decreased);
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/CounterServiceEntityProvider.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/CounterServiceEntityProvider.java
@@ -1,0 +1,72 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityOptions;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityProvider;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Empty;
+import com.google.protobuf.EmptyProto;
+import org.example.eventsourcedentity.domain.CounterDomain;
+
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity provider that defines how to register and create the entity for
+ * the Protobuf service <code>CounterService</code>.
+ *
+ * Should be used with the <code>register</code> method in {@link com.akkaserverless.javasdk.AkkaServerless}.
+ */
+public class CounterServiceEntityProvider implements EventSourcedEntityProvider<CounterDomain.CounterState, CounterServiceEntity> {
+
+  private final Function<EventSourcedEntityContext, CounterServiceEntity> entityFactory;
+  private final EventSourcedEntityOptions options;
+
+  /** Factory method of CounterServiceEntityProvider */
+  public static CounterServiceEntityProvider of(Function<EventSourcedEntityContext, CounterServiceEntity> entityFactory) {
+    return new CounterServiceEntityProvider(entityFactory, EventSourcedEntityOptions.defaults());
+  }
+
+  private CounterServiceEntityProvider(
+      Function<EventSourcedEntityContext, CounterServiceEntity> entityFactory,
+      EventSourcedEntityOptions options) {
+    this.entityFactory = entityFactory;
+    this.options = options;
+  }
+
+  @Override
+  public final EventSourcedEntityOptions options() {
+    return options;
+  }
+
+  public final CounterServiceEntityProvider withOptions(EventSourcedEntityOptions options) {
+    return new CounterServiceEntityProvider(entityFactory, options);
+  }
+
+  @Override
+  public final Descriptors.ServiceDescriptor serviceDescriptor() {
+    return CounterApi.getDescriptor().findServiceByName("CounterService");
+  }
+
+  @Override
+  public final String entityType() {
+    return "counter";
+  }
+
+  @Override
+  public final CounterServiceEntityRouter newRouter(EventSourcedEntityContext context) {
+    return new CounterServiceEntityRouter(entityFactory.apply(context));
+  }
+
+  @Override
+  public final Descriptors.FileDescriptor[] additionalDescriptors() {
+    return new Descriptors.FileDescriptor[] {
+      CounterApi.getDescriptor(),
+      CounterDomain.getDescriptor(),
+      EmptyProto.getDescriptor()
+    };
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/CounterServiceEntityRouter.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-managed/org/example/eventsourcedentity/CounterServiceEntityRouter.java
@@ -1,0 +1,49 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.CommandContext;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityRouter;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.domain.CounterDomain;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * An event sourced entity handler that is the glue between the Protobuf service <code>CounterService</code>
+ * and the command and event handler methods in the <code>CounterServiceEntity</code> class.
+ */
+public class CounterServiceEntityRouter extends EventSourcedEntityRouter<CounterDomain.CounterState, CounterServiceEntity> {
+
+  public CounterServiceEntityRouter(CounterServiceEntity entity) {
+    super(entity);
+  }
+
+  @Override
+  public CounterDomain.CounterState handleEvent(CounterDomain.CounterState state, Object event) {
+    if (event instanceof CounterDomain.Increased) {
+      return entity().increased(state, (CounterDomain.Increased) event);
+    } else if (event instanceof CounterDomain.Decreased) {
+      return entity().decreased(state, (CounterDomain.Decreased) event);
+    } else {
+      throw new EventSourcedEntityRouter.EventHandlerNotFound(event.getClass());
+    }
+  }
+
+  @Override
+  public EventSourcedEntity.Effect<?> handleCommand(
+      String commandName, CounterDomain.CounterState state, Object command, CommandContext context) {
+    switch (commandName) {
+
+      case "Increase":
+        return entity().increase(state, (CounterApi.IncreaseValue) command);
+
+      case "Decrease":
+        return entity().decrease(state, (CounterApi.DecreaseValue) command);
+
+      default:
+        throw new EventSourcedEntityRouter.CommandHandlerNotFound(commandName);
+    }
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-managed/org/example/eventsourcedentity/CounterServiceEntityTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-managed/org/example/eventsourcedentity/CounterServiceEntityTestKit.java
@@ -1,0 +1,78 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl;
+import com.akkaserverless.javasdk.impl.effect.SecondaryEffectImpl;
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedEntityEffectsRunner;
+import com.akkaserverless.javasdk.testkit.impl.EventSourcedResultImpl;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityCommandContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.impl.TestKitEventSourcedEntityEventContext;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.domain.CounterDomain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+
+// This code is managed by Akka Serverless tooling.
+// It will be re-generated to reflect any changes to your protobuf definitions.
+// DO NOT EDIT
+
+/**
+ * TestKit for unit testing CounterServiceEntity
+ */
+public final class CounterServiceEntityTestKit extends EventSourcedEntityEffectsRunner<CounterDomain.CounterState> {
+
+  /**
+   * Create a testkit instance of CounterServiceEntity
+   * @param entityFactory A function that creates a CounterServiceEntity based on the given EventSourcedEntityContext,
+   *                      a default entity id is used.
+   */
+  public static CounterServiceEntityTestKit of(Function<EventSourcedEntityContext, CounterServiceEntity> entityFactory) {
+    return of("testkit-entity-id", entityFactory);
+  }
+
+  /**
+   * Create a testkit instance of CounterServiceEntity with a specific entity id.
+   */
+  public static CounterServiceEntityTestKit of(String entityId, Function<EventSourcedEntityContext, CounterServiceEntity> entityFactory) {
+    return new CounterServiceEntityTestKit(entityFactory.apply(new TestKitEventSourcedEntityContext(entityId)));
+  }
+
+  private CounterServiceEntity entity;
+
+  /** Construction is done through the static CounterServiceEntityTestKit.of-methods */
+  private CounterServiceEntityTestKit(CounterServiceEntity entity) {
+     super(entity);
+     this.entity = entity;
+  }
+
+  public CounterDomain.CounterState handleEvent(CounterDomain.CounterState state, Object event) {
+    try {
+      entity._internalSetEventContext(Optional.of(new TestKitEventSourcedEntityEventContext()));
+      if (event instanceof CounterDomain.Increased) {
+        return entity.increased(state, (CounterDomain.Increased) event);
+      } else if (event instanceof CounterDomain.Decreased) {
+        return entity.decreased(state, (CounterDomain.Decreased) event);
+      } else {
+        throw new NoSuchElementException("Unknown event type [" + event.getClass() + "]");
+      }
+    } finally {
+      entity._internalSetEventContext(Optional.empty());
+    }
+  }
+
+  public EventSourcedResult<Empty> increase(CounterApi.IncreaseValue command) {
+    return interpretEffects(() -> entity.increase(getState(), command));
+  }
+
+  public EventSourcedResult<Empty> decrease(CounterApi.DecreaseValue command) {
+    return interpretEffects(() -> entity.decrease(getState(), command));
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-unmanaged/org/example/eventsourcedentity/CounterServiceEntityTest.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-test-unmanaged/org/example/eventsourcedentity/CounterServiceEntityTest.java
@@ -1,0 +1,48 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.akkaserverless.javasdk.testkit.EventSourcedResult;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.domain.CounterDomain;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public class CounterServiceEntityTest {
+
+  @Test
+  public void exampleTest() {
+    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // use the testkit to execute a command
+    // of events emitted, or a final updated state:
+    // EventSourcedResult<SomeResponse> result = testKit.someOperation(SomeRequest);
+    // verify the emitted events
+    // ExpectedEvent actualEvent = result.getNextEventOfType(ExpectedEvent.class);
+    // assertEquals(expectedEvent, actualEvent)
+    // verify the final state after applying the events
+    // assertEquals(expectedState, testKit.getState());
+    // verify the response
+    // SomeResponse actualResponse = result.getReply();
+    // assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  public void increaseTest() {
+    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // EventSourcedResult<Empty> result = testKit.increase(IncreaseValue.newBuilder()...build());
+  }
+
+
+  @Test
+  public void decreaseTest() {
+    CounterServiceEntityTestKit testKit = CounterServiceEntityTestKit.of(CounterServiceEntity::new);
+    // EventSourcedResult<Empty> result = testKit.decrease(DecreaseValue.newBuilder()...build());
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-unmanaged/org/example/Main.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-unmanaged/org/example/Main.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import com.akkaserverless.javasdk.AkkaServerless;
+import org.example.eventsourcedentity.CounterServiceEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+public final class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  public static AkkaServerless createAkkaServerless() {
+    // The AkkaServerlessFactory automatically registers any generated Actions, Views or Entities,
+    // and is kept up-to-date with any changes in your protobuf definitions.
+    // If you prefer, you may remove this and manually register these components in a
+    // `new AkkaServerless()` instance.
+    return AkkaServerlessFactory.withComponents(
+      CounterServiceEntity::new);
+  }
+
+  public static void main(String[] args) throws Exception {
+    LOG.info("starting the Akka Serverless service");
+    createAkkaServerless().start();
+  }
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-unmanaged/org/example/eventsourcedentity/CounterServiceEntity.java
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/generated-unmanaged/org/example/eventsourcedentity/CounterServiceEntity.java
@@ -1,0 +1,48 @@
+package org.example.eventsourcedentity;
+
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntity.Effect;
+import com.akkaserverless.javasdk.eventsourcedentity.EventSourcedEntityContext;
+import com.google.protobuf.Empty;
+import org.example.eventsourcedentity.domain.CounterDomain;
+
+// This class was initially generated based on the .proto definition by Akka Serverless tooling.
+//
+// As long as this file exists it will not be overwritten: you can maintain it yourself,
+// or delete it so it is regenerated as needed.
+
+/** An event sourced entity. */
+public class CounterServiceEntity extends AbstractCounterServiceEntity {
+
+  @SuppressWarnings("unused")
+  private final String entityId;
+
+  public CounterServiceEntity(EventSourcedEntityContext context) {
+    this.entityId = context.entityId();
+  }
+
+  @Override
+  public CounterDomain.CounterState emptyState() {
+    throw new UnsupportedOperationException("Not implemented yet, replace with your empty entity state");
+  }
+
+  @Override
+  public Effect<Empty> increase(CounterDomain.CounterState currentState, CounterApi.IncreaseValue increaseValue) {
+    return effects().error("The command handler for `Increase` is not implemented, yet");
+  }
+
+  @Override
+  public Effect<Empty> decrease(CounterDomain.CounterState currentState, CounterApi.DecreaseValue decreaseValue) {
+    return effects().error("The command handler for `Decrease` is not implemented, yet");
+  }
+
+  @Override
+  public CounterDomain.CounterState increased(CounterDomain.CounterState currentState, CounterDomain.Increased increased) {
+    throw new RuntimeException("The event handler for `Increased` is not implemented, yet");
+  }
+  @Override
+  public CounterDomain.CounterState decreased(CounterDomain.CounterState currentState, CounterDomain.Decreased decreased) {
+    throw new RuntimeException("The event handler for `Decreased` is not implemented, yet");
+  }
+
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/proto/counter_api.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/proto/counter_api.proto
@@ -1,0 +1,47 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is the public API offered by your entity.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "akkaserverless/annotations.proto";
+
+package org.example.eventsourcedentity;
+
+option java_outer_classname = "CounterApi";
+
+message IncreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+message DecreaseValue {
+  string counter_id = 1 [(akkaserverless.field).entity_key = true];
+  int32 value = 2;
+}
+
+
+service CounterService { 
+  option (akkaserverless.codegen) = {
+    event_sourced_entity: {
+      entity_type: "counter"
+      state: ".domain.CounterState"
+      events: [".domain.Increased", ".domain.Decreased"]
+    }
+  };
+
+  rpc Increase (IncreaseValue) returns (google.protobuf.Empty);
+  rpc Decrease (DecreaseValue) returns (google.protobuf.Empty);
+}

--- a/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/proto/counter_domain.proto
+++ b/codegen/java-gen/src/test/resources/tests/event-sourced-entity/unnamed-new-style/proto/counter_domain.proto
@@ -1,0 +1,31 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package org.example.eventsourcedentity.domain;
+
+option java_outer_classname = "CounterDomain";
+
+message CounterState {
+  int32 value = 1;
+}
+
+message Increased {
+  int32 value = 1;
+}
+
+message Decreased {
+  int32 value = 1;
+}

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ExampleSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ExampleSuite.scala
@@ -60,9 +60,9 @@ class ExampleSuite extends munit.FunSuite {
 
     val files = SourceGenerator.generateFiles(model, "org.example.Main")
 
-    def t(testName: String, dir: String, fileSet: GeneratedFiles => Seq[codegen.File]): Unit =
+    def testFiles(testName: String, dir: String, fileSet: GeneratedFiles => Seq[codegen.File]): Unit =
       test(s"${testDirUnresolved.getPath.replace("/", " / ")} / $testName") {
-        checkFiles(testDir / dir, fileSet(files))
+        assertFiles(testDir / dir, fileSet(files))
       }
 
     if (regenerateAll || regenerate.exists) {
@@ -77,15 +77,15 @@ class ExampleSuite extends munit.FunSuite {
         regenerate.delete()
       }
     } else {
-      t("unmanaged", "generated-unmanaged", _.unmanagedFiles)
-      t("managed", "generated-managed", _.managedFiles)
-      t("unmanaged test", "generated-test-unmanaged", _.unmanagedTestFiles)
-      t("managed test", "generated-test-managed", _.managedTestFiles)
-      t("unmanaged integration tests", "generated-integration-managed", _.integrationTestFiles)
+      testFiles("unmanaged", "generated-unmanaged", _.unmanagedFiles)
+      testFiles("managed", "generated-managed", _.managedFiles)
+      testFiles("unmanaged test", "generated-test-unmanaged", _.unmanagedTestFiles)
+      testFiles("managed test", "generated-test-managed", _.managedTestFiles)
+      testFiles("unmanaged integration tests", "generated-integration-unmanaged", _.integrationTestFiles)
     }
   }
 
-  def checkFiles(expectedDir: File, actualGenerated: Seq[codegen.File]): Unit = {
+  def assertFiles(expectedDir: File, actualGenerated: Seq[codegen.File]): Unit = {
     val actual = actualGenerated.map(g => g.name -> g.content).toMap
     val expectedFiles = expectedDir.walkFiles().toVector
     val expectedNameSet = expectedFiles.map(_.getPath).toSet


### PR DESCRIPTION
LIke #774, but for event sourced entities. 

Also split in three commits to make it easy to review

The first commit fix a bug related to import of events. The previous code was expecting that the events were defined in the same proto as the State, but the new annotation allow us to split them. Actually, each event can technically be on a different file. I don't think this is will affect the Scala generator because there we use the code block interpolator. 

My fix here will also become obsolete once we start to use the interpolator for java, but this would be too much work to do now, so I opt for a quick fix. 

The second commit at the protos for events sourced tests services

The third commit can be ignored, it contains the generate code.