### PR TITLE
chore: upgrade Akka gRPC to 2.1.2

### DIFF
--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <akkaserverless-sdk.version>@project.version@</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <akkaserverless-sdk.version>@project.version@</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
   val scalapbCompilerPlugin = "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion
   val sbtProtoc = "com.thesamet" % "sbt-protoc" % "1.0.0"
 
-  val akkaGrpc = "com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.0"
+  val akkaGrpc = "com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.2"
 
   private val deps = libraryDependencies
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.1")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")

--- a/samples/java-customer-registry-quickstart/pom.xml
+++ b/samples/java-customer-registry-quickstart/pom.xml
@@ -18,7 +18,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-customer-registry-views-quickstart/pom.xml
@@ -18,7 +18,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-doc-snippets/pom.xml
+++ b/samples/java-doc-snippets/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-eventsourced-customer-registry/pom.xml
+++ b/samples/java-eventsourced-customer-registry/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-eventsourced-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-        <akka-grpc.version>2.1.0</akka-grpc.version>
+        <akka-grpc.version>2.1.2</akka-grpc.version>
     </properties>
 
     <build>

--- a/samples/java-fibonacci-action/pom.xml
+++ b/samples/java-fibonacci-action/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-first-service/pom.xml
+++ b/samples/java-first-service/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-replicatedentity-examples/pom.xml
+++ b/samples/java-replicatedentity-examples/pom.xml
@@ -20,7 +20,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-      <akka-grpc.version>2.1.0</akka-grpc.version>
+      <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-replicatedentity-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-      <akka-grpc.version>2.1.0</akka-grpc.version>
+      <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-shopping-cart-quickstart/pom.xml
+++ b/samples/java-shopping-cart-quickstart/pom.xml
@@ -18,7 +18,7 @@
     <jdk.target>11</jdk.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-valueentity-counter/pom.xml
+++ b/samples/java-valueentity-counter/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-valueentity-customer-registry/pom.xml
+++ b/samples/java-valueentity-customer-registry/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-    <akka-grpc.version>2.1.0</akka-grpc.version>
+    <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/samples/java-valueentity-shopping-cart/pom.xml
+++ b/samples/java-valueentity-shopping-cart/pom.xml
@@ -20,7 +20,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
       <akkaserverless-sdk.version>0.10.2</akkaserverless-sdk.version>
-      <akka-grpc.version>2.1.0</akka-grpc.version>
+      <akka-grpc.version>2.1.2</akka-grpc.version>
   </properties>
 
   <build>

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/compile-only/project/plugins.sbt
@@ -3,4 +3,4 @@ sys.props.get("plugin.version") match {
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.0") // FIXME should be included via sbt-akkaserverless
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.2") // FIXME should be included via sbt-akkaserverless

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/eventsourcedentity/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/eventsourcedentity/project/plugins.sbt
@@ -3,4 +3,4 @@ sys.props.get("plugin.version") match {
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.0") // FIXME should be included via sbt-akkaserverless
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.2") // FIXME should be included via sbt-akkaserverless

--- a/sbt-plugin/src/sbt-test/sbt-akkaserverless/no-common-pkg-root/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-akkaserverless/no-common-pkg-root/project/plugins.sbt
@@ -3,4 +3,4 @@ sys.props.get("plugin.version") match {
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.0") // FIXME should be included via sbt-akkaserverless
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.2") // FIXME should be included via sbt-akkaserverless


### PR DESCRIPTION
Should make building on Apple m1 work out of the box, even if packaging as docker image is not seamless yet.

References #78