### PR TITLE
feat: placeholder configuration for JWT dev secrets

### DIFF
--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -10,7 +10,11 @@ services:
     environment:
 #[[      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
-      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator ]]#
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
+      # Uncomment to disable the JWT dev secret
+      # JWT_DEV_SECRET: "false"
+      # Uncomment to set the JWT dev secret issuer
+      # JWT_DEV_SECRET_ISSUER: "my-issuer" ]]#
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -10,7 +10,11 @@ services:
     environment:
 #[[      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
       USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
-      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator ]]#
+      PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
+      # Uncomment to disable the JWT dev secret
+      # JWT_DEV_SECRET: "false"
+      # Uncomment to set the JWT dev secret issuer
+      # JWT_DEV_SECRET_ISSUER: "my-issuer" ]]#
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085


### PR DESCRIPTION
This adds commented out placeholders for configuring JWT dev secrets as implemented in https://github.com/lightbend/akkaserverless-framework/pull/1055.