### PR TITLE
feat: Support side effects and forward assertion in testkits 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,11 +110,7 @@ object Dependencies {
   // FIXME
   val sdkScala = deps ++= coreDeps ++ Seq(jacksonScala)
 
-  val sdkScalaTestKit = deps ++= Seq(
-    testContainers,
-    logback % "test;provided",
-    scalaTest % Test
-  )
+  val sdkScalaTestKit = deps ++= Seq(testContainers, logback % "test;provided", scalaTest % Test)
 
   val tck = deps ++= Seq(
     // FIXME: For now TCK protos have been copied and adapted into this project.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -104,12 +104,17 @@ object Dependencies {
     // https://github.com/testcontainers/testcontainers-java/issues/4308
     "org.apache.commons" % "commons-compress" % "1.21",
     junit4 % Provided,
-    junit5 % Provided)
+    junit5 % Provided,
+    scalaTest % Test)
 
   // FIXME
   val sdkScala = deps ++= coreDeps ++ Seq(jacksonScala)
 
-  val sdkScalaTestKit = deps ++= Seq(testContainers, logback % "test;provided")
+  val sdkScalaTestKit = deps ++= Seq(
+    testContainers,
+    logback % "test;provided",
+    scalaTest % Test
+  )
 
   val tck = deps ++= Seq(
     // FIXME: For now TCK protos have been copied and adapted into this project.

--- a/sdk/java-sdk-testkit/src/main/java/com/akkaserverless/javasdk/testkit/ValueEntityResult.java
+++ b/sdk/java-sdk-testkit/src/main/java/com/akkaserverless/javasdk/testkit/ValueEntityResult.java
@@ -16,6 +16,8 @@
 
 package com.akkaserverless.javasdk.testkit;
 
+import java.util.List;
+
 /**
  * Represents the result of an ValueEntity handling a command when run in through the testkit.
  *
@@ -60,4 +62,7 @@ public interface ValueEntityResult<R> {
 
   /** @return true if the call deleted the entity */
   boolean stateWasDeleted();
+
+  /** @return The list of side effects */
+  List<DeferredCallDetails<?, ?>> getSideEffects();
 }

--- a/sdk/java-sdk-testkit/src/test/scala/com/akkaserverless/javasdk/testkit/impl/ActionResultSpec.scala
+++ b/sdk/java-sdk-testkit/src/test/scala/com/akkaserverless/javasdk/testkit/impl/ActionResultSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akkaserverless.javasdk.testkit.impl
+
+import com.akkaserverless.javasdk.impl.DeferredCallImpl
+import com.akkaserverless.javasdk.impl.MetadataImpl
+import com.akkaserverless.javasdk.impl.action.ActionEffectImpl
+import com.akkaserverless.javasdk.impl.effect.SideEffectImpl
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ActionResultSpec extends AnyWordSpec with Matchers {
+
+  "Action Results" must {
+    "extract side effects" in {
+      val replyWithSideEffectResult = new ActionResultImpl[String](
+        ActionEffectImpl.Builder
+          .reply("reply")
+          .addSideEffect(SideEffectImpl(
+            DeferredCallImpl[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???),
+            synchronous = false)))
+
+      replyWithSideEffectResult.isReply() should ===(true)
+      replyWithSideEffectResult.getSideEffects().size() should ===(1)
+    }
+
+    "extract forward details" in {
+      val forwardResult = new ActionResultImpl[String](ActionEffectImpl.Builder.forward(
+        DeferredCallImpl[String, String]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???)))
+
+      forwardResult.isForward() should ===(true)
+      forwardResult.getForward().getMessage should ===("request")
+    }
+  }
+
+}

--- a/sdk/java-sdk-testkit/src/test/scala/com/akkaserverless/javasdk/testkit/impl/EventSourcedResultSpec.scala
+++ b/sdk/java-sdk-testkit/src/test/scala/com/akkaserverless/javasdk/testkit/impl/EventSourcedResultSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akkaserverless.javasdk.testkit.impl
+
+import com.akkaserverless.javasdk.impl.DeferredCallImpl
+import com.akkaserverless.javasdk.impl.MetadataImpl
+import com.akkaserverless.javasdk.impl.effect.ForwardReplyImpl
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl
+import com.akkaserverless.javasdk.impl.effect.SecondaryEffectImpl
+import com.akkaserverless.javasdk.impl.effect.SideEffectImpl
+import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl
+import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EventSourcedResultSpec extends AnyWordSpec with Matchers {
+
+  "Event Sourced Entity Results" must {
+    "extract side effects" in {
+      val replyWithSideEffectResult = new EventSourcedResultImpl[String, String](
+        new EventSourcedEntityEffectImpl().noReply[String](), // not actually used here
+        "state",
+        MessageReplyImpl(
+          "reply", // pretend it was evaluated, in practice done by the generated testkit
+          MetadataImpl.Empty,
+          Vector(SideEffectImpl(
+            DeferredCallImpl[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???),
+            synchronous = false))))
+
+      replyWithSideEffectResult.isReply() should ===(true)
+      replyWithSideEffectResult.getSideEffects().size() should ===(1)
+    }
+
+    "extract forward details" in {
+      val forwardResult = new EventSourcedResultImpl[String, String](
+        new EventSourcedEntityEffectImpl().noReply[String](), // not actually used here
+        "state",
+        ForwardReplyImpl(
+          deferredCall =
+            DeferredCallImpl[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???),
+          sideEffects = Vector.empty))
+
+      forwardResult.isForward() should ===(true)
+      forwardResult.getForward().getMessage should ===("request")
+    }
+  }
+
+}

--- a/sdk/java-sdk-testkit/src/test/scala/com/akkaserverless/javasdk/testkit/impl/ValueEntityResultSpec.scala
+++ b/sdk/java-sdk-testkit/src/test/scala/com/akkaserverless/javasdk/testkit/impl/ValueEntityResultSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akkaserverless.javasdk.testkit.impl
+
+import com.akkaserverless.javasdk.impl.DeferredCallImpl
+import com.akkaserverless.javasdk.impl.MetadataImpl
+import com.akkaserverless.javasdk.impl.action.ActionEffectImpl
+import com.akkaserverless.javasdk.impl.effect.SideEffectImpl
+import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ValueEntityResultSpec extends AnyWordSpec with Matchers {
+
+  "Value Entity Results" must {
+    "extract side effects" in {
+      val replyWithSideEffectResult = new ValueEntityResultImpl[String](
+        new ValueEntityEffectImpl()
+          .reply("reply")
+          .addSideEffects(SideEffectImpl(
+            DeferredCallImpl[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???),
+            synchronous = false)))
+
+      replyWithSideEffectResult.isReply() should ===(true)
+      replyWithSideEffectResult.getSideEffects().size() should ===(1)
+    }
+
+    "extract forward details" in {
+      val forwardResult = new ValueEntityResultImpl[String](new ValueEntityEffectImpl().forward(
+        DeferredCallImpl[String, String]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???)))
+
+      forwardResult.isForward() should ===(true)
+      forwardResult.getForward().getMessage should ===("request")
+    }
+  }
+
+}

--- a/sdk/java-sdk/src/main/scala/com/akkaserverless/javasdk/impl/action/ActionEffectImpl.scala
+++ b/sdk/java-sdk/src/main/scala/com/akkaserverless/javasdk/impl/action/ActionEffectImpl.scala
@@ -29,6 +29,7 @@ import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters.CompletionStageOps
 
+/** INTERNAL API */
 object ActionEffectImpl {
   sealed abstract class PrimaryEffect[T] extends Action.Effect[T] {
     override def addSideEffect(sideEffects: SideEffect*): Action.Effect[T] =
@@ -36,7 +37,7 @@ object ActionEffectImpl {
     override def addSideEffects(sideEffects: util.Collection[SideEffect]): Action.Effect[T] =
       withSideEffects(internalSideEffects() ++ sideEffects.asScala)
 
-    protected def internalSideEffects(): Seq[SideEffect]
+    def internalSideEffects(): Seq[SideEffect]
     protected def withSideEffects(sideEffects: Seq[SideEffect]): Action.Effect[T]
   }
   final case class ReplyEffect[T](msg: T, metadata: Option[Metadata], internalSideEffects: Seq[SideEffect])

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/EventSourcedResult.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/EventSourcedResult.scala
@@ -72,5 +72,5 @@ trait EventSourcedResult[R] {
   def nextEvent[E](implicit expectedClass: ClassTag[E]): E
 
   /** @return The list of side effects */
-  def sideEffects: Seq[DeferredCallDetails[_, _]];
+  def sideEffects: Seq[DeferredCallDetails[_, _]]
 }

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/ValueEntityResult.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/ValueEntityResult.scala
@@ -60,4 +60,7 @@ trait ValueEntityResult[R] {
 
   /** @return true if the call deleted the entity */
   def stateWasDeleted: Boolean
+
+  /** @return The list of side effects */
+  def sideEffects: Seq[DeferredCallDetails[_, _]]
 }

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/EffectUtils.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/EffectUtils.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akkaserverless.scalasdk.testkit.impl
+
+import com.akkaserverless.javasdk.{ SideEffect => JavaSideEffect }
+import com.akkaserverless.javasdk.impl.DeferredCallImpl
+import com.akkaserverless.javasdk.impl.effect.ErrorReplyImpl
+import com.akkaserverless.javasdk.impl.effect.ForwardReplyImpl
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl
+import com.akkaserverless.javasdk.impl.effect.NoReply
+import com.akkaserverless.javasdk.impl.effect.NoSecondaryEffectImpl
+import com.akkaserverless.javasdk.impl.effect.{ SecondaryEffectImpl => JavaSecondaryEffectImpl }
+import com.akkaserverless.scalasdk.testkit.DeferredCallDetails
+
+import scala.collection.immutable.Seq
+
+private[akkaserverless] object EffectUtils {
+  def toDeferredCallDetails(sideEffects: Seq[JavaSideEffect]): Seq[DeferredCallDetails[_, _]] = {
+    sideEffects.map { sideEffect =>
+      TestKitDeferredCall(sideEffect.call.asInstanceOf[DeferredCallImpl[_, _]])
+    }
+  }
+
+  def forwardDetailsFor[R](secondaryEffect: JavaSecondaryEffectImpl): DeferredCallDetails[_, R] =
+    secondaryEffect match {
+      case reply: ForwardReplyImpl[R @unchecked] =>
+        TestKitDeferredCall(reply.deferredCall.asInstanceOf[DeferredCallImpl[_, R]])
+      case _ => throw new IllegalArgumentException(s"Expected a forward effect but was [${nameFor(secondaryEffect)}]")
+    }
+
+  def nameFor(secondaryEffect: JavaSecondaryEffectImpl): String =
+    secondaryEffect match {
+      case _: MessageReplyImpl[_] => "reply"
+      case _: ForwardReplyImpl[_] => "forward"
+      case _: ErrorReplyImpl[_]   => "error"
+      case _: NoReply[_]          => "noReply"
+      case NoSecondaryEffectImpl  => "no effect"
+    }
+}

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/EventSourcedResultImpl.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/EventSourcedResultImpl.scala
@@ -33,7 +33,7 @@ import scala.reflect.ClassTag
  * INTERNAL API Used by the generated testkit
  */
 final class EventSourcedResultImpl[R, S](
-    effect: EventSourcedEntityEffectImpl[R, S],
+    primaryEffect: EventSourcedEntityEffectImpl[R, S],
     state: S,
     secondaryEffect: SecondaryEffectImpl)
     extends EventSourcedResult[R] {
@@ -44,53 +44,37 @@ final class EventSourcedResultImpl[R, S](
 
   private lazy val eventsIterator = events.iterator
 
-  override def events: Seq[Any] = eventsOf(effect)
+  override def events: Seq[Any] = eventsOf(primaryEffect)
 
   override def isReply: Boolean =
-    effect.javasdkEffect.secondaryEffect(state).isInstanceOf[MessageReplyImpl[_]]
+    secondaryEffect.isInstanceOf[MessageReplyImpl[_]]
 
   private def secondaryEffectName: String =
-    effect.javasdkEffect.secondaryEffect(state) match {
-      case _: MessageReplyImpl[_] => "reply"
-      case _: ForwardReplyImpl[_] => "forward"
-      case _: ErrorReplyImpl[_]   => "error"
-      case _: NoReply[_]          => "noReply"
-      case NoSecondaryEffectImpl  => "no effect" // this should never happen
-    }
+    EffectUtils.nameFor(secondaryEffect)
 
   override def reply: R =
-    effect.javasdkEffect.secondaryEffect(state) match {
+    secondaryEffect match {
       case reply: MessageReplyImpl[R @unchecked] => reply.message
       case _ => throw new IllegalStateException(s"The effect was not a reply but [$secondaryEffectName]")
     }
 
   override def isForward: Boolean =
-    effect.javasdkEffect.secondaryEffect(state).isInstanceOf[ForwardReplyImpl[_]]
+    secondaryEffect.isInstanceOf[ForwardReplyImpl[_]]
 
   override def forwardedTo: DeferredCallDetails[_, R] =
-    ??? // FIXME #587
-//    effect.javasdkEffect.secondaryEffect match {
-//    case reply: ForwardReplyImpl[R @unchecked] =>
-//      reply.serviceCall match {
-//        case t: TestKitServiceCallFactory.TestKitServiceCall[R @unchecked] =>
-//          t
-//        case surprise =>
-//          throw new IllegalStateException(s"Unexpected type of service call in testkit: ${surprise.getClass.getName}")
-//      }
-//    case _ => throw new IllegalStateException(s"The effect was not a forward but [$secondaryEffectName]")
-//  }
+    EffectUtils.forwardDetailsFor(secondaryEffect)
 
   override def isError: Boolean =
-    effect.javasdkEffect.secondaryEffect(state).isInstanceOf[ErrorReplyImpl[_]]
+    secondaryEffect.isInstanceOf[ErrorReplyImpl[_]]
 
   override def errorDescription: String =
-    effect.javasdkEffect.secondaryEffect(state) match {
+    secondaryEffect match {
       case error: ErrorReplyImpl[_] => error.description
       case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
     }
 
   override def isNoReply: Boolean =
-    effect.javasdkEffect.secondaryEffect(state).isInstanceOf[NoReply[_]]
+    secondaryEffect.isInstanceOf[NoReply[_]]
 
   override def updatedState: S = state
 
@@ -106,19 +90,8 @@ final class EventSourcedResultImpl[R, S](
           "expected event type [" + expectedClass.runtimeClass.getName + "] but found [" + next.getClass.getName + "]")
     }
 
-  private def extractServices(sideEffects: Vector[SideEffect]): Seq[DeferredCallDetails[_, _]] = {
-    sideEffects.map { sideEffect =>
-      TestKitDeferredCall(sideEffect.call.asInstanceOf[DeferredCallImpl[_, _]])
-    }
-  }
-
-  override def sideEffects(): Seq[DeferredCallDetails[_, _]] = secondaryEffect match {
-    case MessageReplyImpl(_, _, sideEffects) => extractServices(sideEffects)
-    case ForwardReplyImpl(_, sideEffects)    => extractServices(sideEffects)
-    case ErrorReplyImpl(_, sideEffects)      => extractServices(sideEffects)
-    case NoReply(sideEffects)                => extractServices(sideEffects)
-    case NoSecondaryEffectImpl               => Nil // this should never happen
-  }
+  override def sideEffects: Seq[DeferredCallDetails[_, _]] =
+    EffectUtils.toDeferredCallDetails(secondaryEffect.sideEffects)
 
 }
 
@@ -126,6 +99,7 @@ final class EventSourcedResultImpl[R, S](
  * INTERNAL API
  */
 object EventSourcedResultImpl {
+
   def eventsOf(effect: EventSourcedEntity.Effect[_]): Seq[Any] = {
     effect match {
       case ei: EventSourcedEntityEffectImpl[_, _] =>
@@ -138,7 +112,7 @@ object EventSourcedResultImpl {
 
   def secondaryEffectOf[S](effect: EventSourcedEntity.Effect[_], state: S): SecondaryEffectImpl = {
     effect match {
-      case ei: EventSourcedEntityEffectImpl[_, S] =>
+      case ei: EventSourcedEntityEffectImpl[_, S @unchecked] =>
         ei.javasdkEffect.secondaryEffect(state)
     }
   }

--- a/sdk/scala-sdk-testkit/src/test/scala/com/akkaserverless/scalasdk/testkit/impl/ActionResultSpec.scala
+++ b/sdk/scala-sdk-testkit/src/test/scala/com/akkaserverless/scalasdk/testkit/impl/ActionResultSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akkaserverless.scalasdk.testkit.impl
+
+import com.akkaserverless.javasdk.impl.DeferredCallImpl
+import com.akkaserverless.scalasdk.impl.ScalaDeferredCallAdapter
+import com.akkaserverless.javasdk.impl.MetadataImpl
+import com.akkaserverless.javasdk.impl.effect.{ SideEffectImpl => JavaSideEffectImpl }
+import com.akkaserverless.scalasdk.impl.ScalaSideEffectAdapter
+import com.akkaserverless.scalasdk.impl.action.ActionEffectImpl
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ActionResultSpec extends AnyWordSpec with Matchers {
+
+  "Action Results" must {
+    "extract side effects" in {
+      val replyWithSideEffectResult = new ActionResultImpl[String](
+        ActionEffectImpl.Builder
+          .reply("reply")
+          .addSideEffect(ScalaSideEffectAdapter(JavaSideEffectImpl(
+            DeferredCallImpl[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???),
+            synchronous = false))))
+
+      replyWithSideEffectResult.isReply should ===(true)
+      replyWithSideEffectResult.sideEffects should have size 1
+    }
+
+    "extract forward details" in {
+      val forwardResult = new ActionResultImpl[String](ActionEffectImpl.Builder.forward(ScalaDeferredCallAdapter(
+        DeferredCallImpl[String, String]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???))))
+
+      forwardResult.isForward should ===(true)
+      forwardResult.forwardedTo.message should ===("request")
+    }
+  }
+
+}

--- a/sdk/scala-sdk-testkit/src/test/scala/com/akkaserverless/scalasdk/testkit/impl/EventSourcedResultSpec.scala
+++ b/sdk/scala-sdk-testkit/src/test/scala/com/akkaserverless/scalasdk/testkit/impl/EventSourcedResultSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akkaserverless.scalasdk.testkit.impl
+
+import com.akkaserverless.javasdk.impl.DeferredCallImpl
+import com.akkaserverless.javasdk.impl.MetadataImpl
+import com.akkaserverless.javasdk.impl.effect.ForwardReplyImpl
+import com.akkaserverless.javasdk.impl.effect.MessageReplyImpl
+import com.akkaserverless.javasdk.impl.effect.SideEffectImpl
+import com.akkaserverless.scalasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EventSourcedResultSpec extends AnyWordSpec with Matchers {
+
+  "Event Sourced Entity Results" must {
+
+    "extract side effects" in {
+      val replyWithSideEffectResult = new EventSourcedResultImpl[String, String](
+        EventSourcedEntityEffectImpl().noReply[String], // not actually used here
+        "state",
+        MessageReplyImpl(
+          "reply", // pretend it was evaluated, in practice done by the generated testkit
+          MetadataImpl.Empty,
+          Vector(SideEffectImpl(
+            DeferredCallImpl[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???),
+            synchronous = false))))
+
+      replyWithSideEffectResult.isReply should ===(true)
+      replyWithSideEffectResult.sideEffects should have size 1
+    }
+
+    "extract forward details" in {
+      val forwardResult = new EventSourcedResultImpl[String, String](
+        EventSourcedEntityEffectImpl().noReply[String], // not actually used here
+        "state",
+        ForwardReplyImpl(
+          deferredCall =
+            DeferredCallImpl[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???),
+          sideEffects = Vector.empty))
+
+      forwardResult.isForward should ===(true)
+      forwardResult.forwardedTo.message should ===("request")
+    }
+
+  }
+
+}

--- a/sdk/scala-sdk-testkit/src/test/scala/com/akkaserverless/scalasdk/testkit/impl/ValueEntityResultSpec.scala
+++ b/sdk/scala-sdk-testkit/src/test/scala/com/akkaserverless/scalasdk/testkit/impl/ValueEntityResultSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akkaserverless.scalasdk.testkit.impl
+
+import com.akkaserverless.javasdk.impl.DeferredCallImpl
+import com.akkaserverless.javasdk.impl.effect.SideEffectImpl
+import com.akkaserverless.javasdk.impl.MetadataImpl
+import com.akkaserverless.scalasdk.impl.ScalaDeferredCallAdapter
+import com.akkaserverless.scalasdk.impl.ScalaSideEffectAdapter
+import com.akkaserverless.scalasdk.impl.valueentity.ValueEntityEffectImpl
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ValueEntityResultSpec extends AnyWordSpec with Matchers {
+
+  "Value Entity Results" must {
+    "extract side effects" in {
+      val replyWithSideEffectResult = new ValueEntityResultImpl[String](
+        ValueEntityEffectImpl()
+          .reply("reply")
+          .addSideEffects(ScalaSideEffectAdapter(SideEffectImpl(
+            DeferredCallImpl[String, Any]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???),
+            synchronous = false)) :: Nil))
+
+      replyWithSideEffectResult.isReply should ===(true)
+      replyWithSideEffectResult.sideEffects should have size 1
+    }
+
+    "extract forward details" in {
+      val forwardResult = new ValueEntityResultImpl[String](ValueEntityEffectImpl().forward(ScalaDeferredCallAdapter(
+        DeferredCallImpl[String, String]("request", MetadataImpl.Empty, "full.service.Name", "MethodName", () => ???))))
+
+      forwardResult.isForward should ===(true)
+      forwardResult.forwardedTo.message should ===("request")
+    }
+
+  }
+
+}


### PR DESCRIPTION
References #322 and #587

With some additional cleanup and deduplication of code in the testkit result classes