### PR TITLE
chore: move closing ']]#'

### DIFF
--- a/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/akkaserverless-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -9,12 +9,12 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
 #[[      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
-      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080} ]]#
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
       # Uncomment to disable the JWT dev secret
       # JWT_DEV_SECRET: "false"
       # Uncomment to set the JWT dev secret issuer
-      # JWT_DEV_SECRET_ISSUER: "my-issuer" ]]#
+      # JWT_DEV_SECRET_ISSUER: "my-issuer"
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085

--- a/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
+++ b/maven-java/akkaserverless-maven-archetype-value-entity/src/main/resources/archetype-resources/docker-compose.yml
@@ -9,12 +9,12 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
 #[[      USER_FUNCTION_HOST: ${USER_FUNCTION_HOST:-host.docker.internal}
-      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080}
+      USER_FUNCTION_PORT: ${USER_FUNCTION_PORT:-8080} ]]#
       PUBSUB_EMULATOR_HOST: gcloud-pubsub-emulator
       # Uncomment to disable the JWT dev secret
       # JWT_DEV_SECRET: "false"
       # Uncomment to set the JWT dev secret issuer
-      # JWT_DEV_SECRET_ISSUER: "my-issuer" ]]#
+      # JWT_DEV_SECRET_ISSUER: "my-issuer"
   gcloud-pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:341.0.0
     command: gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085


### PR DESCRIPTION
I'm not sure about this `]]#`, but it seems that it's used to escape the `$`. I couldn't find docs about it. 

In any case, I think we should only enclose the lines that seems to need it. Having it in a comment line make it less visible for us when maintaining this code.