### PR TITLE
chore: fix link to quickstart page

### DIFF
--- a/docs/src/modules/java/pages/index.adoc
+++ b/docs/src/modules/java/pages/index.adoc
@@ -78,7 +78,7 @@ addSbtPlugin("com.akkaserverless" % "sbt-akkaserverless" % "{akkaserverless-java
 Akka Serverless supports JSON formatted logging to provide multi-line messages formatted in JSON syntax. Always use JSON formatted logging for your Akka Serverless projects to efficiently analyze and easily leverage logging information.
 
 [TIP]
-https://developer.lightbend.com/docs/akka-serverless/quickstart/cr-value-entity-java.html[Build and deploy the Quickstart example] to see JSON formatted logging in action.
+xref:java:quickstart/cr-value-entity-java.adoc[Build and deploy the Quickstart example] to see JSON formatted logging in action.
 
 JSON formatted logging is enabled by default in the projects created by the xref:quickstart-template.adoc[Akka Serverless project template]. It includes a transitive dependency on `logback-json-classic` and a `logback.xml` file as shown here:
 
@@ -129,4 +129,3 @@ This section provides details on how to accomplish common tasks:
 * xref:java:side-effects.adoc[Running Side Effects]
 * xref:serialization.adoc[Serialization]
 * xref:api.adoc[API docs]
-


### PR DESCRIPTION
This got broken after we changed the page in the main docs.