### PR TITLE
[WIP] fancy way of doing compilation tests for all defined ExampleSuite examples

### DIFF
--- a/codegen/java-gen/src/test/resources/tests/build.sbt
+++ b/codegen/java-gen/src/test/resources/tests/build.sbt
@@ -1,0 +1,28 @@
+val sdk = ProjectRef(file("../../../../../.."), "sdkJava")
+
+val modules: CompositeProject = new CompositeProject {
+  val inner = findProjects(file(".")).map(f =>
+    Project("test" + f.getPath.replaceAll("[./]+", "-"), f)
+      .dependsOn(sdk % "compile")
+      .settings(
+        Compile / unmanagedSourceDirectories ++= Seq("generated-managed", "generated-unmanaged").map(baseDirectory.value / _),
+        Compile / PB.protoSources += baseDirectory.value / "proto",
+        akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
+      )
+      .enablePlugins(ProtocPlugin, AkkaGrpcPlugin)
+  )
+  val core = project
+    .in(file("."))
+    .aggregate(inner.map(p => p: ProjectReference): _*)
+
+  def componentProjects: Seq[Project] = inner :+ core
+
+  import java.io.File
+  def findProjects(base: File): Seq[File] =
+    if (base.listFiles().exists(d => d.isDirectory && d.getName == "proto")) Seq(base)
+    else {
+      base.listFiles()
+        .filter(f => f.isDirectory && f.getName != "." && f.getName != "..")
+        .flatMap(findProjects)
+    }
+}

--- a/codegen/java-gen/src/test/resources/tests/build.sbt
+++ b/codegen/java-gen/src/test/resources/tests/build.sbt
@@ -1,21 +1,23 @@
 val sdk = ProjectRef(file("../../../../../.."), "sdkJava")
+val testkit = ProjectRef(file("../../../../../.."), "sdkJavaTestKit")
 
 val modules: CompositeProject = new CompositeProject {
   val inner = findProjects(file(".")).map(f =>
     Project("test" + f.getPath.replaceAll("[./]+", "-"), f)
-      .dependsOn(sdk % "compile")
+      .dependsOn(sdk % "compile", testkit % "test")
       .settings(
         Compile / unmanagedSourceDirectories ++= Seq("generated-managed", "generated-unmanaged").map(baseDirectory.value / _),
+        Test / unmanagedSourceDirectories ++= Seq("generated-test-managed", "generated-test-unmanaged").map(baseDirectory.value / _),
         Compile / PB.protoSources += baseDirectory.value / "proto",
         akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
       )
       .enablePlugins(ProtocPlugin, AkkaGrpcPlugin)
   )
-  val core = project
+  val root = project
     .in(file("."))
     .aggregate(inner.map(p => p: ProjectReference): _*)
 
-  def componentProjects: Seq[Project] = inner :+ core
+  def componentProjects: Seq[Project] = inner :+ root
 
   import java.io.File
   def findProjects(base: File): Seq[File] =

--- a/codegen/java-gen/src/test/resources/tests/project/build.properties
+++ b/codegen/java-gen/src/test/resources/tests/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.8

--- a/codegen/java-gen/src/test/resources/tests/project/plugins.sbt
+++ b/codegen/java-gen/src/test/resources/tests/project/plugins.sbt
@@ -1,0 +1,3 @@
+// FIXME: those versions need to be kept in sync with sbt-akkaserverless dependencies
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.2")


### PR DESCRIPTION
Here's a fancy way of doing compilation testing for the generated test code of the example suite test files.

I created a new sbt build to avoid that the main build is overloaded with all those test builds. We would compile those files only from CI.

@octonato this could be an alternative to the script you mentioned before.