### PR TITLE
chore: trigger ExampleSuite regeneration via -D property

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -217,6 +217,7 @@ lazy val codegenJava =
     .dependsOn(codegenCore % "compile->compile;test->test")
     .enablePlugins(PublishSonatype)
     .settings(
+      Test / fork := false, // needed to pass -D properties to ExampleSuite
       // to provide access to protoc to tests
       Test / buildInfoPackage := "com.lightbend.akkasls.codegen.java",
       Test / buildInfoKeys := Seq(
@@ -299,6 +300,7 @@ lazy val codegenScala =
     .settings(
       name := "akkaserverless-codegen-scala",
       scalaVersion := Dependencies.ScalaVersionForSbtPlugin,
+      Test / fork := false, // needed to pass -D properties to ExampleSuite
       buildInfoKeys := Seq[BuildInfoKey](
         name,
         organization,

--- a/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/File.scala
+++ b/codegen/core/src/main/scala/com/lightbend/akkasls/codegen/File.scala
@@ -27,6 +27,7 @@ case class GeneratedFiles(
     managedTestFiles: Seq[File],
     unmanagedTestFiles: Seq[File],
     integrationTestFiles: Seq[File]) {
+
   def write(
       managedSourceDirectory: Path,
       unmanagedSourceDirectory: Path,
@@ -38,6 +39,18 @@ case class GeneratedFiles(
     managedTestFiles.map(_.writeToDirectory(managedTestSourceDirectory, onlyIfMissing = false)) ++
     unmanagedTestFiles.map(_.writeToDirectory(unmanagedTestSourceDirectory, onlyIfMissing = true)) ++
     integrationTestFiles.map(_.writeToDirectory(unmanagedIntegrationTestSourceDirectory, onlyIfMissing = true))
+
+  def overwrite(
+      managedSourceDirectory: Path,
+      unmanagedSourceDirectory: Path,
+      managedTestSourceDirectory: Path,
+      unmanagedTestSourceDirectory: Path,
+      unmanagedIntegrationTestSourceDirectory: Path): Iterable[Path] =
+    managedFiles.map(_.writeToDirectory(managedSourceDirectory, onlyIfMissing = false)) ++
+    unmanagedFiles.map(_.writeToDirectory(unmanagedSourceDirectory, onlyIfMissing = false)) ++
+    managedTestFiles.map(_.writeToDirectory(managedTestSourceDirectory, onlyIfMissing = false)) ++
+    unmanagedTestFiles.map(_.writeToDirectory(unmanagedTestSourceDirectory, onlyIfMissing = false)) ++
+    integrationTestFiles.map(_.writeToDirectory(unmanagedIntegrationTestSourceDirectory, onlyIfMissing = false))
 
   def addManaged(file: File): GeneratedFiles =
     copy(managedFiles = managedFiles :+ file)

--- a/codegen/java-gen/src/test/resources/tests/README.md
+++ b/codegen/java-gen/src/test/resources/tests/README.md
@@ -6,9 +6,87 @@ Each directory contains one test case. Directories can be nested, a test directo
 directory inside.
 
 The `proto` below each test directory contains the input protobuf files and the `generated-` directories contain the
-expected output files. You can create a file named `regenerate` into the test folder to have the test succeed and
-create the test files for the given protobuf definitions. The `regenerate` file will be automatically deleted afterwards.
+expected output files. 
 
-You can also change the flag `regenerateAll` in `ExampleSuite` to have the full set of example files regenerated after
-a change. In that case, the test will always succeed and you are required to validate the diff to the previous version
-of files.
+To generate the files for the first time, you must pass a -D property indicating the newly added test dir, eg:
+
+```shell 
+sbt -Dexample.suite.java.regenerate=my-new-test-suite
+```
+
+When changing the codegen itself, you can use the ExampleSuite to force the regeneration of files. 
+After regenerating the files you can inspect their contents and decide if the output is as expected. 
+
+To regenerate the files for a specific group of tests, you can pass the name of a parent folder, eg:
+
+```shell 
+sbt -Dexample.suite.java.regenerate=action-service
+```
+
+This will regenerate the files for all suites under `action-service`.
+
+Finally, you can regenerate all files for all suites by passing.
+
+```shell 
+sbt -Dexample.suite.java.regenerate=all
+```
+
+# Compiling
+
+The ExampleSuite only generates files, but doesn't compile them.
+To compile the files, you should start sbt with:
+
+```shell
+sbt -Dexample.suite.java.enabled 
+```
+
+When the example suites are enabled at sbt level, you will get a few more sbt projects.
+
+```shell
+[info]   * akkaserverless-java-sdk
+...
+# extra project 
+[info]     codegenJavaCompilationExampleSuite
+... 
+# each directory under codegen/java-gen/src/test/resources/tests containing proto files will show up here as an sbt project
+[info]     test-java-action-service-named-new-style
+[info]     test-java-action-service-simple-new-style
+[info]     test-java-action-service-simple-old-style
+[info]     test-java-action-service-with-action-in-name
+[info]     test-java-event-sourced-entity-absolute-packages
+[info]     test-java-event-sourced-entity-domain-in-service-package
+[info]     test-java-event-sourced-entity-named-new-style
+[info]     test-java-event-sourced-entity-named-new-style-with-java-package
+[info]     test-java-event-sourced-entity-state-events-in-different-pacakge
+[info]     test-java-event-sourced-entity-unnamed-new-style
+[info]     test-java-replicated-entity-multimap-absolute-packages
+[info]     test-java-replicated-entity-multimap-domain-in-service-package
+[info]     test-java-replicated-entity-multimap-key-value-in-different-pacakge
+[info]     test-java-replicated-entity-multimap-named-new-style
+[info]     test-java-replicated-entity-multimap-scalar-named-new-style
+[info]     test-java-replicated-entity-multimap-unnamed-new-style
+[info]     test-java-value-entity-absolute-packages
+[info]     test-java-value-entity-domain-in-service-package
+[info]     test-java-value-entity-named-new-style
+[info]     test-java-value-entity-state-events-in-different-pacakge
+[info]     test-java-value-entity-unnamed-new-style
+[info]     test-java-view-service-named-new-style
+[info]     test-java-view-service-unnamed-new-style
+[info]     test-java-view-service-view-in-name-new-style
+
+```
+
+You can compile then by calling: `codegenJavaCompilationExampleSuite/compile` or individually `test-java-action-service-named-new-style/compile`
+
+# Generate and compile cycle
+
+When working on a specific part of the codegen, a possible workflow could be:
+
+
+```shell
+# when working on action codegen, for example
+sbt -Dexample.suite.java.regenerate=action-service -Dexample.suite.java.enabled 
+
+# code, regenerate and compile suites
+codegenJava/testOnly *ExampleSuite;test-java-action-service-named-new-style/compile
+```

--- a/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ExampleSuite.scala
+++ b/codegen/java-gen/src/test/scala/com/lightbend/akkasls/codegen/java/ExampleSuite.scala
@@ -20,12 +20,18 @@ import com.google.protobuf.Descriptors
 import com.lightbend.akkasls.codegen.{ ExampleSuiteBase, GeneratedFiles, ModelBuilder }
 
 class ExampleSuite extends ExampleSuiteBase {
+
   def regenerateAll: Boolean = false
+
   lazy val BuildInfo = com.lightbend.akkasls.codegen.java.BuildInfo
+
+  override def propertyPath: String = "example.suite.java.regenerate"
+
   override def createFQNExtractor(
       fileDescriptors: Seq[Descriptors.FileDescriptor]): ModelBuilder.FullyQualifiedNameExtractor =
     FullyQualifiedNameExtractor
 
   override def generateFiles(model: ModelBuilder.Model): GeneratedFiles =
     SourceGenerator.generateFiles(model, "org.example.Main")
+
 }

--- a/codegen/scala-gen/src/test/resources/tests/README.md
+++ b/codegen/scala-gen/src/test/resources/tests/README.md
@@ -5,10 +5,87 @@ These are the test files for the `ExampleSuite`.
 Each directory contains one test case. Directories can be nested, a test directory is recognized by finding a `proto`
 directory inside.
 
-The `proto` below each test directory contains the input protobuf files and the `generated-` directories contain the
-expected output files. You can create a file named `regenerate` into the test folder to have the test succeed and
-create the test files for the given protobuf definitions. The `regenerate` file will be automatically deleted afterwards.
 
-You can also change the flag `regenerateAll` in `ExampleSuite` to have the full set of example files regenerated after
-a change. In that case, the test will always succeed and you are required to validate the diff to the previous version
-of files.
+The `proto` below each test directory contains the input protobuf files and the `generated-` directories contain the
+expected output files.
+
+To generate the files for the first time, you must pass a -D property indicating the newly added test dir, eg:
+
+```shell 
+sbt -Dexample.suite.scala.regenerate=my-new-test-suite
+```
+
+When changing the codegen itself, you can use the ExampleSuite to force the regeneration of files.
+After regenerating the files you can inspect their contents and decide if the output is as expected.
+
+To regenerate the files for a specific group of tests, you can pass the name of a parent folder, eg:
+
+```shell 
+sbt -Dexample.suite.scala.regenerate=action-service
+```
+
+This will regenerate the files for all suites under `action-service`.
+
+Finally, you can regenerate all files for all suites by passing.
+
+```shell 
+sbt -Dexample.suite.scala.regenerate=all
+```
+
+# Compiling
+
+The ExampleSuite only generates files, but doesn't compile them.
+To compile the files, you should start sbt with:
+
+```shell
+sbt -Dexample.suite.scala.enabled 
+```
+
+When the example suites are enabled at sbt level, you will get a few more sbt projects.
+
+```shell
+[info]   * akkaserverless-java-sdk
+...
+# extra project 
+[info]     codegenScalaCompilationExampleSuite
+... 
+# each directory under codegen/scala-gen/src/test/resources/tests containing proto files will show up here as an sbt project
+[info]     test-scala-action-service-named-new-style
+[info]     test-scala-action-service-simple-new-style
+[info]     test-scala-action-service-simple-old-style
+[info]     test-scala-action-service-with-action-in-name
+[info]     test-scala-event-sourced-entity-absolute-packages
+[info]     test-scala-event-sourced-entity-domain-in-service-package
+[info]     test-scala-event-sourced-entity-named-new-style
+[info]     test-scala-event-sourced-entity-state-events-in-different-pacakge
+[info]     test-scala-event-sourced-entity-unnamed-new-style
+[info]     test-scala-replicated-entity-multimap-absolute-packages
+[info]     test-scala-replicated-entity-multimap-domain-in-service-package
+[info]     test-scala-replicated-entity-multimap-key-value-in-different-pacakge
+[info]     test-scala-replicated-entity-multimap-named-new-style
+[info]     test-scala-replicated-entity-multimap-scalar-named-new-style
+[info]     test-scala-replicated-entity-multimap-unnamed-new-style
+[info]     test-scala-value-entity-absolute-packages
+[info]     test-scala-value-entity-domain-in-service-package
+[info]     test-scala-value-entity-named-new-style
+[info]     test-scala-value-entity-state-events-in-different-pacakge
+[info]     test-scala-value-entity-unnamed-new-style
+[info]     test-scala-view-service-named-new-style
+[info]     test-scala-view-service-unnamed-new-style
+[info]     test-scala-view-service-view-in-name-new-style
+```
+
+You can compile then by calling: `codegenScalaCompilationExampleSuite/compile` or individually `test-scala-action-service-named-new-style/compile`
+
+# Generate and compile cycle
+
+When working on a specific part of the codegen, a possible workflow could be:
+
+
+```shell
+# when working on action codegen, for example
+sbt -Dexample.suite.scala.regenerate=action-service -Dexample.suite.scala.enabled 
+
+# code, regenerate and compile suites
+codegenScala/testOnly *ExampleSuite;test-scala-action-service-named-new-style/compile
+```

--- a/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ExampleSuite.scala
+++ b/codegen/scala-gen/src/test/scala/com/akkaserverless/codegen/scalasdk/ExampleSuite.scala
@@ -22,8 +22,12 @@ import com.lightbend.akkasls.codegen.{ ExampleSuiteBase, GeneratedFiles, ModelBu
 import scalapb.compiler.{ DescriptorImplicits, GeneratorParams }
 
 class ExampleSuite extends ExampleSuiteBase {
+
   def regenerateAll: Boolean = false
+
   lazy val BuildInfo = com.akkaserverless.codegen.scalasdk.BuildInfo
+
+  override def propertyPath: String = "example.suite.scala.regenerate"
 
   override def createFQNExtractor(
       fileDescriptors: Seq[Descriptors.FileDescriptor]): ModelBuilder.FullyQualifiedNameExtractor =
@@ -31,4 +35,5 @@ class ExampleSuite extends ExampleSuiteBase {
 
   override def generateFiles(model: ModelBuilder.Model): GeneratedFiles =
     SourceGenerator.generateFiles(model, Some("org.example"))
+
 }


### PR DESCRIPTION
References #781 

With this PR we may be able to delete the codegen String comparison tests. 
It makes it a little easier to use the ExampleSuite + compilation as the base of our test strategy. 
By passing some flags to sbt we can force the regeneration of some files and then compile them. 

There is a little bit more of gymnastic is required when changing the codegen though. 

The updated README files contain some explanation on how we can use it to have a better dev roundtrip.