### PR TITLE
feat: custom failure status code support

### DIFF
--- a/sdk/java-sdk-testkit/src/main/java/com/akkaserverless/javasdk/testkit/ActionResult.java
+++ b/sdk/java-sdk-testkit/src/main/java/com/akkaserverless/javasdk/testkit/ActionResult.java
@@ -16,6 +16,8 @@
 
 package com.akkaserverless.javasdk.testkit;
 
+import io.grpc.Status;
+
 import java.util.concurrent.CompletionStage;
 import java.util.List;
 
@@ -63,6 +65,11 @@ public interface ActionResult<T> {
    *     an error
    */
   String getError();
+
+  /**
+   * @return The error status code or throws if the effect returned by the action was not an error.
+   */
+  Status.Code getErrorStatusCode();
 
   /** @return true if the call had a noReply effect, false if not */
   boolean isNoReply();

--- a/sdk/java-sdk-testkit/src/main/java/com/akkaserverless/javasdk/testkit/EventSourcedResult.java
+++ b/sdk/java-sdk-testkit/src/main/java/com/akkaserverless/javasdk/testkit/EventSourcedResult.java
@@ -16,6 +16,8 @@
 
 package com.akkaserverless.javasdk.testkit;
 
+import io.grpc.Status;
+
 import java.util.List;
 
 /**
@@ -51,6 +53,11 @@ public interface EventSourcedResult<R> {
 
   /** The error description. If the result was not an error an exception is thrown */
   String getError();
+
+  /**
+   * @return The error status code or throws if the effect returned by the action was not an error.
+   */
+  Status.Code getErrorStatusCode();
 
   /** @return true if the call had a noReply effect, false if not */
   boolean isNoReply();

--- a/sdk/java-sdk-testkit/src/main/java/com/akkaserverless/javasdk/testkit/ValueEntityResult.java
+++ b/sdk/java-sdk-testkit/src/main/java/com/akkaserverless/javasdk/testkit/ValueEntityResult.java
@@ -16,6 +16,8 @@
 
 package com.akkaserverless.javasdk.testkit;
 
+import io.grpc.Status;
+
 import java.util.List;
 
 /**
@@ -50,6 +52,11 @@ public interface ValueEntityResult<R> {
 
   /** The error description. If the result was not an error an exception is thrown */
   String getError();
+
+  /**
+   * @return The error status code or throws if the effect returned by the action was not an error.
+   */
+  Status.Code getErrorStatusCode();
 
   /** @return true if the call had a noReply effect, false if not */
   boolean isNoReply();

--- a/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/ActionResultImpl.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/ActionResultImpl.scala
@@ -22,9 +22,11 @@ import com.akkaserverless.javasdk.impl.DeferredCallImpl
 import com.akkaserverless.javasdk.impl.action.ActionEffectImpl
 import com.akkaserverless.javasdk.testkit.ActionResult
 import com.akkaserverless.javasdk.testkit.DeferredCallDetails
-
 import java.util.concurrent.CompletionStage
 import java.util.{ List => JList }
+
+import io.grpc.Status
+
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
@@ -87,6 +89,11 @@ final class ActionResultImpl[T](effect: ActionEffectImpl.PrimaryEffect[T]) exten
   def getError(): String = {
     val error = getEffectOfType(classOf[ActionEffectImpl.ErrorEffect[T]])
     error.description
+  }
+
+  def getErrorStatusCode(): Status.Code = {
+    val error = getEffectOfType(classOf[ActionEffectImpl.ErrorEffect[T]])
+    error.statusCode.getOrElse(Status.Code.UNKNOWN)
   }
 
   /** @return true if the call had a noReply effect, false if not */

--- a/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/EventSourcedResultImpl.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/EventSourcedResultImpl.scala
@@ -31,9 +31,11 @@ import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffe
 import com.akkaserverless.javasdk.testkit.DeferredCallDetails
 import com.akkaserverless.javasdk.testkit.EventSourcedResult
 import com.akkaserverless.javasdk.testkit.impl.EventSourcedResultImpl.eventsOf
-
 import java.util.Collections
 import java.util.{ List => JList }
+
+import io.grpc.Status
+
 import scala.jdk.CollectionConverters._
 
 /**
@@ -113,7 +115,12 @@ private[akkaserverless] final class EventSourcedResultImpl[R, S](
   override def isError: Boolean = secondaryEffect.isInstanceOf[ErrorReplyImpl[_]]
 
   override def getError: String = secondaryEffect match {
-    case ErrorReplyImpl(description, _) => description
+    case ErrorReplyImpl(description, _, _) => description
+    case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
+  }
+
+  override def getErrorStatusCode: Status.Code = secondaryEffect match {
+    case ErrorReplyImpl(_, status, _) => status.getOrElse(Status.Code.UNKNOWN)
     case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
   }
 

--- a/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/ValueEntityResultImpl.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/ValueEntityResultImpl.scala
@@ -27,8 +27,10 @@ import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl
 import com.akkaserverless.javasdk.testkit.DeferredCallDetails
 import com.akkaserverless.javasdk.testkit.ValueEntityResult
 import com.akkaserverless.javasdk.valueentity.ValueEntity
-
 import java.util.{ List => JList }
+
+import io.grpc.Status
+
 import scala.jdk.CollectionConverters._
 
 /**
@@ -73,6 +75,11 @@ private[akkaserverless] final class ValueEntityResultImpl[R](effect: ValueEntity
 
   override def getError(): String = effect.secondaryEffect match {
     case error: ErrorReplyImpl[_] => error.description
+    case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
+  }
+
+  override def getErrorStatusCode: Status.Code = effect.secondaryEffect match {
+    case ErrorReplyImpl(_, status, _) => status.getOrElse(Status.Code.UNKNOWN)
     case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
   }
 

--- a/sdk/java-sdk/src/main/java/com/akkaserverless/javasdk/action/Action.java
+++ b/sdk/java-sdk/src/main/java/com/akkaserverless/javasdk/action/Action.java
@@ -20,6 +20,7 @@ import com.akkaserverless.javasdk.DeferredCall;
 import com.akkaserverless.javasdk.Metadata;
 import com.akkaserverless.javasdk.SideEffect;
 import com.akkaserverless.javasdk.impl.action.ActionEffectImpl;
+import io.grpc.Status;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -105,6 +106,16 @@ public abstract class Action {
        * @param <S> The type of the message that must be returned by this call.
        */
       <S> Effect<S> error(String description);
+
+      /**
+       * Create an error reply.
+       *
+       * @param description The description of the error.
+       * @param statusCode A custom gRPC status code.
+       * @return An error reply.
+       * @param <T> The type of the message that must be returned by this call.
+       */
+      <T> Effect<T> error(String description, Status.Code statusCode);
 
       /**
        * Create a message reply from an async operation result.

--- a/sdk/java-sdk/src/main/java/com/akkaserverless/javasdk/eventsourcedentity/EventSourcedEntity.java
+++ b/sdk/java-sdk/src/main/java/com/akkaserverless/javasdk/eventsourcedentity/EventSourcedEntity.java
@@ -20,6 +20,7 @@ import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffe
 import com.akkaserverless.javasdk.Metadata;
 import com.akkaserverless.javasdk.DeferredCall;
 import com.akkaserverless.javasdk.SideEffect;
+import io.grpc.Status;
 
 import java.util.Collection;
 import java.util.List;
@@ -132,6 +133,16 @@ public abstract class EventSourcedEntity<S> {
        * @param <T> The type of the message that must be returned by this call.
        */
       <T> Effect<T> error(String description);
+
+      /**
+       * Create an error reply.
+       *
+       * @param description The description of the error.
+       * @param statusCode A custom gRPC status code.
+       * @return An error reply.
+       * @param <T> The type of the message that must be returned by this call.
+       */
+      <T> Effect<T> error(String description, Status.Code statusCode);
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.

--- a/sdk/java-sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedEntity.java
+++ b/sdk/java-sdk/src/main/java/com/akkaserverless/javasdk/replicatedentity/ReplicatedEntity.java
@@ -21,6 +21,8 @@ import com.akkaserverless.javasdk.DeferredCall;
 import com.akkaserverless.javasdk.SideEffect;
 import com.akkaserverless.javasdk.impl.replicatedentity.ReplicatedEntityEffectImpl;
 import com.akkaserverless.replicatedentity.ReplicatedData;
+import io.grpc.Status;
+
 import java.util.Collection;
 import java.util.Optional;
 
@@ -126,6 +128,16 @@ public abstract class ReplicatedEntity<D extends ReplicatedData> {
        * @param <T> The type of the message that must be returned by this call.
        */
       <T> Effect<T> error(String description);
+
+      /**
+       * Create an error reply.
+       *
+       * @param description The description of the error.
+       * @param statusCode A custom gRPC status code.
+       * @return An error reply.
+       * @param <T> The type of the message that must be returned by this call.
+       */
+      <T> Effect<T> error(String description, Status.Code statusCode);
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.

--- a/sdk/java-sdk/src/main/java/com/akkaserverless/javasdk/valueentity/ValueEntity.java
+++ b/sdk/java-sdk/src/main/java/com/akkaserverless/javasdk/valueentity/ValueEntity.java
@@ -20,6 +20,7 @@ import com.akkaserverless.javasdk.DeferredCall;
 import com.akkaserverless.javasdk.Metadata;
 import com.akkaserverless.javasdk.SideEffect;
 import com.akkaserverless.javasdk.impl.valueentity.ValueEntityEffectImpl;
+import io.grpc.Status;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -114,6 +115,16 @@ public abstract class ValueEntity<S> {
        * @param <T> The type of the message that must be returned by this call.
        */
       <T> Effect<T> error(String description);
+
+      /**
+       * Create an error reply.
+       *
+       * @param description The description of the error.
+       * @param statusCode A custom gRPC status code.
+       * @return An error reply.
+       * @param <T> The type of the message that must be returned by this call.
+       */
+      <T> Effect<T> error(String description, Status.Code statusCode);
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.

--- a/sdk/java-sdk/src/main/scala/com/akkaserverless/javasdk/impl/action/ActionsImpl.scala
+++ b/sdk/java-sdk/src/main/scala/com/akkaserverless/javasdk/impl/action/ActionsImpl.scala
@@ -134,10 +134,11 @@ private[javasdk] final class ActionsImpl(
           .recover { case NonFatal(ex) =>
             handleUnexpectedException(service, command, ex)
           }
-      case ErrorEffect(description, sideEffects) =>
+      case ErrorEffect(description, status, sideEffects) =>
         Future.successful(
           ActionResponse(
-            ActionResponse.Response.Failure(Failure(description = description)),
+            ActionResponse.Response.Failure(
+              Failure(description = description, grpcStatusCode = status.map(_.value()).getOrElse(0))),
             toProtocol(anySupport, sideEffects)))
       case NoReply(sideEffects) =>
         Future.successful(ActionResponse(ActionResponse.Response.Empty, toProtocol(anySupport, sideEffects)))

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/ActionResult.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/ActionResult.scala
@@ -16,6 +16,8 @@
 
 package com.akkaserverless.scalasdk.testkit
 
+import io.grpc.Status
+
 import scala.concurrent.Future
 
 /**
@@ -63,6 +65,12 @@ trait ActionResult[T] {
    *   The error description returned or throws if the effect returned by the action was not an error
    */
   def errorDescription: String
+
+  /**
+   * @return
+   *   The error status code returned or throws if the effect returned by the action was not an error
+   */
+  def errorStatusCode: Status.Code
 
   /** @return true if the call had a noReply effect, false if not */
   def isNoReply: Boolean

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/EventSourcedResult.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/EventSourcedResult.scala
@@ -16,6 +16,8 @@
 
 package com.akkaserverless.scalasdk.testkit
 
+import io.grpc.Status
+
 import scala.reflect.ClassTag
 
 /**
@@ -50,6 +52,9 @@ trait EventSourcedResult[R] {
 
   /** The error description. If the result was not an error an exception is thrown */
   def errorDescription: String
+
+  /** The error status code. If the result was not an error an exception is thrown. */
+  def errorStatusCode: Status.Code
 
   /** @return true if the call had a noReply effect, false if not */
   def isNoReply: Boolean

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/ValueEntityResult.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/ValueEntityResult.scala
@@ -16,6 +16,8 @@
 
 package com.akkaserverless.scalasdk.testkit
 
+import io.grpc.Status
+
 /**
  * Represents the result of an ValueEntity handling a command when run in through the testkit.
  *
@@ -48,6 +50,9 @@ trait ValueEntityResult[R] {
 
   /** The error description. If the result was not an error an exception is thrown */
   def errorDescription: String
+
+  /** The error status code. If the result was not an error an exception is thrown. */
+  def errorStatusCode: Status.Code
 
   /** @return true if the call had a noReply effect, false if not */
   def isNoReply: Boolean

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/ActionResultImpl.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/ActionResultImpl.scala
@@ -24,6 +24,8 @@ import com.akkaserverless.scalasdk.impl.action.ActionEffectImpl
 import com.akkaserverless.scalasdk.testkit.ActionResult
 import com.akkaserverless.scalasdk.testkit.DeferredCallDetails
 import com.akkaserverless.javasdk.impl.action.ActionEffectImpl.{ PrimaryEffect => JavaPrimaryEffect }
+import io.grpc.Status
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -72,6 +74,11 @@ final class ActionResultImpl[T](val effect: ActionEffectImpl.PrimaryEffect[T]) e
 
   override def errorDescription: String = effect match {
     case e: ActionEffectImpl.ErrorEffect[_] => e.description
+    case _ => throw new IllegalStateException(s"The effect was not error but [$effectName]")
+  }
+
+  override def errorStatusCode: Status.Code = effect match {
+    case e: ActionEffectImpl.ErrorEffect[_] => e.statusCode.getOrElse(Status.Code.UNKNOWN)
     case _ => throw new IllegalStateException(s"The effect was not error but [$effectName]")
   }
 

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/EventSourcedResultImpl.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/EventSourcedResultImpl.scala
@@ -22,10 +22,7 @@ import com.akkaserverless.javasdk.impl.eventsourcedentity.EventSourcedEntityEffe
 import com.akkaserverless.scalasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl
 import com.akkaserverless.scalasdk.testkit.{ DeferredCallDetails, EventSourcedResult }
 import com.akkaserverless.scalasdk.eventsourcedentity.EventSourcedEntity
-import com.akkaserverless.javasdk.SideEffect
-import com.akkaserverless.scalasdk.DeferredCall
-
-import com.akkaserverless.javasdk.impl.DeferredCallImpl
+import io.grpc.Status
 
 import scala.reflect.ClassTag
 
@@ -70,6 +67,12 @@ final class EventSourcedResultImpl[R, S](
   override def errorDescription: String =
     secondaryEffect match {
       case error: ErrorReplyImpl[_] => error.description
+      case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
+    }
+
+  override def errorStatusCode: Status.Code =
+    secondaryEffect match {
+      case error: ErrorReplyImpl[_] => error.status.getOrElse(Status.Code.UNKNOWN)
       case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
     }
 

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/ValueEntityResultImpl.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/ValueEntityResultImpl.scala
@@ -26,6 +26,7 @@ import com.akkaserverless.javasdk.impl.valueentity.{ ValueEntityEffectImpl => JV
 import com.akkaserverless.scalasdk.testkit.DeferredCallDetails
 import com.akkaserverless.scalasdk.testkit.ValueEntityResult
 import com.akkaserverless.scalasdk.valueentity.ValueEntity
+import io.grpc.Status
 
 /**
  * INTERNAL API Used by the generated testkit
@@ -62,6 +63,12 @@ final class ValueEntityResultImpl[R](effect: ValueEntityEffectImpl[R]) extends V
   override def errorDescription: String =
     secondaryEffect match {
       case error: ErrorReplyImpl[_] => error.description
+      case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
+    }
+
+  override def errorStatusCode: Status.Code =
+    secondaryEffect match {
+      case error: ErrorReplyImpl[_] => error.status.getOrElse(Status.Code.UNKNOWN)
       case _ => throw new IllegalStateException(s"The effect was not an error but [$secondaryEffectName]")
     }
 

--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/action/Action.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/action/Action.scala
@@ -18,11 +18,9 @@ package com.akkaserverless.scalasdk.action
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
-
-import com.akkaserverless.scalasdk.Metadata
-import com.akkaserverless.scalasdk.DeferredCall
-import com.akkaserverless.scalasdk.SideEffect
+import com.akkaserverless.scalasdk.{ DeferredCall, Metadata, SideEffect }
 import com.akkaserverless.scalasdk.impl.action.ActionEffectImpl
+import io.grpc.Status
 
 object Action {
 
@@ -107,12 +105,14 @@ object Action {
        *
        * @param description
        *   The description of the error.
+       * @param statusCode
+       *   An optional gRPC status code.
        * @return
        *   An error reply.
        * @tparam S
        *   The type of the message that must be returned by this call.
        */
-      def error[S](description: String): Action.Effect[S]
+      def error[S](description: String, statusCode: Option[Status.Code] = None): Action.Effect[S]
 
       /**
        * Create a message reply from an async operation result.

--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/eventsourcedentity/EventSourcedEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/eventsourcedentity/EventSourcedEntity.scala
@@ -16,11 +16,9 @@
 
 package com.akkaserverless.scalasdk.eventsourcedentity
 
-import com.akkaserverless.scalasdk.Metadata
-import com.akkaserverless.scalasdk.DeferredCall
-import com.akkaserverless.scalasdk.Context
-import com.akkaserverless.scalasdk.SideEffect
+import com.akkaserverless.scalasdk.{ Context, DeferredCall, Metadata, SideEffect }
 import com.akkaserverless.scalasdk.impl.eventsourcedentity.EventSourcedEntityEffectImpl
+import io.grpc.Status
 
 object EventSourcedEntity {
 
@@ -101,12 +99,14 @@ object EventSourcedEntity {
        *
        * @param description
        *   The description of the error.
+       * @param statusCode
+       *   An optional gRPC status code.
        * @return
        *   An error reply.
        * @tparam T
        *   The type of the message that must be returned by this call.
        */
-      def error[T](description: String): Effect[T]
+      def error[T](description: String, statusCode: Option[Status.Code] = None): Effect[T]
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.

--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/replicatedentity/ReplicatedEntityEffectImpl.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/replicatedentity/ReplicatedEntityEffectImpl.scala
@@ -15,18 +15,18 @@
  */
 
 package com.akkaserverless.scalasdk.impl.replicatedentity
+import com.akkaserverless.javasdk
 import com.akkaserverless.javasdk.impl.replicatedentity.{
   ReplicatedEntityEffectImpl => JavaSdkReplicatedEntityEffectImpl
 }
 import com.akkaserverless.replicatedentity.ReplicatedData
-import com.akkaserverless.scalasdk.DeferredCall
-import com.akkaserverless.scalasdk.Metadata
-import com.akkaserverless.scalasdk.SideEffect
+import com.akkaserverless.scalasdk.{ DeferredCall, Metadata, SideEffect }
 import com.akkaserverless.scalasdk.impl.MetadataConverters
 import com.akkaserverless.scalasdk.impl.ScalaDeferredCallAdapter
 import com.akkaserverless.scalasdk.impl.ScalaSideEffectAdapter
 import com.akkaserverless.scalasdk.replicatedentity.ReplicatedEntity
 import com.akkaserverless.scalasdk.replicatedentity.ReplicatedEntity.Effect
+import io.grpc.Status
 
 import scala.jdk.CollectionConverters.IterableHasAsJava
 
@@ -58,8 +58,11 @@ private[scalasdk] final case class ReplicatedEntityEffectImpl[D <: ReplicatedDat
         ReplicatedEntityEffectImpl(javaSdkEffect.forward(javaSdkDeferredCall))
     }
 
-  override def error[T](description: String): ReplicatedEntity.Effect[T] =
-    ReplicatedEntityEffectImpl(javaSdkEffect.error(description))
+  def error[T](description: String, statusCode: Option[Status.Code]): ReplicatedEntity.Effect[T] =
+    ReplicatedEntityEffectImpl(statusCode match {
+      case Some(code) => javaSdkEffect.error(description, code)
+      case None       => javaSdkEffect.error(description)
+    })
 
   override def noReply[T]: ReplicatedEntity.Effect[T] =
     ReplicatedEntityEffectImpl(javaSdkEffect.noReply())

--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/valueentity/ValueEntityEffectImpl.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/impl/valueentity/ValueEntityEffectImpl.scala
@@ -22,6 +22,7 @@ import com.akkaserverless.scalasdk.SideEffect
 import com.akkaserverless.scalasdk.impl.ScalaDeferredCallAdapter
 import com.akkaserverless.scalasdk.impl.ScalaSideEffectAdapter
 import com.akkaserverless.scalasdk.valueentity.ValueEntity
+import io.grpc.Status
 
 private[scalasdk] object ValueEntityEffectImpl {
   def apply[S](): ValueEntityEffectImpl[S] = ValueEntityEffectImpl(
@@ -38,6 +39,12 @@ private[scalasdk] final case class ValueEntityEffectImpl[S](
 
   def error[T](description: String): ValueEntity.Effect[T] = new ValueEntityEffectImpl(
     javasdkEffect.error[T](description))
+
+  def error[T](description: String, statusCode: Option[Status.Code]): ValueEntity.Effect[T] =
+    ValueEntityEffectImpl(statusCode match {
+      case Some(code) => javasdkEffect.error(description, code)
+      case None       => javasdkEffect.error(description)
+    })
 
   def forward[T](deferredCall: com.akkaserverless.scalasdk.DeferredCall[_, T]): ValueEntity.Effect[T] = {
     deferredCall match {

--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/replicatedentity/ReplicatedEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/replicatedentity/ReplicatedEntity.scala
@@ -17,10 +17,9 @@
 package com.akkaserverless.scalasdk.replicatedentity
 
 import com.akkaserverless.replicatedentity.ReplicatedData
-import com.akkaserverless.scalasdk.Metadata
-import com.akkaserverless.scalasdk.DeferredCall
-import com.akkaserverless.scalasdk.SideEffect
+import com.akkaserverless.scalasdk.{ DeferredCall, Metadata, SideEffect }
 import com.akkaserverless.scalasdk.impl.replicatedentity.ReplicatedEntityEffectImpl
+import io.grpc.Status
 
 object ReplicatedEntity {
   object Effect {
@@ -90,12 +89,14 @@ object ReplicatedEntity {
        *
        * @param description
        *   The description of the error.
+       * @param statusCode
+       *   An optional gRPC status code.
        * @return
        *   An error reply.
        * @tparam T
        *   The type of the message that must be returned by this call.
        */
-      def error[T](description: String): ReplicatedEntity.Effect[T]
+      def error[T](description: String, statusCode: Option[Status.Code] = None): ReplicatedEntity.Effect[T]
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.

--- a/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/valueentity/ValueEntity.scala
+++ b/sdk/scala-sdk/src/main/scala/com/akkaserverless/scalasdk/valueentity/ValueEntity.scala
@@ -16,10 +16,9 @@
 
 package com.akkaserverless.scalasdk.valueentity
 
-import com.akkaserverless.scalasdk.Metadata
-import com.akkaserverless.scalasdk.DeferredCall
-import com.akkaserverless.scalasdk.SideEffect
+import com.akkaserverless.scalasdk.{ DeferredCall, Metadata, SideEffect }
 import com.akkaserverless.scalasdk.impl.valueentity.ValueEntityEffectImpl
+import io.grpc.Status
 
 object ValueEntity {
   object Effect {
@@ -80,12 +79,14 @@ object ValueEntity {
        *
        * @param description
        *   The description of the error.
+       * @param statusCode
+       *   An optional gRPC status code.
        * @return
        *   An error reply.
        * @tparam T
        *   The type of the message that must be returned by this call.
        */
-      def error[T](description: String): Effect[T]
+      def error[T](description: String, statusCode: Option[Status.Code] = None): Effect[T]
 
       /**
        * Create a reply that contains neither a message nor a forward nor an error.


### PR DESCRIPTION
Added support for custom status codes to both Java and Scala SDKs.

This is to match feature parity with https://github.com/lightbend/akkaserverless-javascript-sdk/pull/253.