### PR TITLE
chore: cycle circle CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
     description: "Save dependency cache"
     steps:
       - save_cache:
-          key: deps-cache-01
+          key: deps-cache-02
           paths:
             - "~/.ivy2/cache"
             - "~/.sbt"
@@ -61,7 +61,7 @@ commands:
     description: "Restore dependency cache"
     steps:
       - restore_cache:
-          key: deps-cache-01
+          key: deps-cache-02
 
   set-sdk-version:
     description: "Set global option, grab current SDK version"


### PR DESCRIPTION
It seems the cache is severely out of date and the maven plugin publish step
is taking many minutes to build just because of downloading dependencies.

CircleCI isn't able to cache by contents so, we need to cycle keys to refresh
the cache.