### PR TITLE
chore: remove go_package

### DIFF
--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/action/action.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/action/action.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.action;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/action;action";
 option java_package = "kalix.tck.model.action";
 
 import "google/api/annotations.proto";

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventing/local_persistence_eventing.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventing/local_persistence_eventing.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.eventing;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/eventing;eventing";
 option java_package = "kalix.tck.model.eventing";
 
 import "kalix/annotations.proto";

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventsourcedentity/event_sourced_configured.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventsourcedentity/event_sourced_configured.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.eventsourcedentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/eventsourcedentity;eventsourcedentity";
 option java_package = "kalix.tck.model.eventsourcedentity";
 option java_multiple_files = true;
 

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventsourcedentity/event_sourced_entity_api.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventsourcedentity/event_sourced_entity_api.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.eventsourcedentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/eventsourcedentity;eventsourcedentity";
 option java_package = "kalix.tck.model.eventsourcedentity";
 
 import "kalix/annotations.proto";

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventsourcedentity/event_sourced_tck_model.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventsourcedentity/event_sourced_tck_model.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.eventsourcedentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/eventsourcedentity;eventsourcedentity";
 option java_package = "kalix.tck.model.eventsourcedentity";
 option java_multiple_files = true;
 

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventsourcedentity/event_sourced_two.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/eventsourcedentity/event_sourced_two.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.eventsourcedentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/eventsourcedentity;eventsourcedentity";
 option java_package = "kalix.tck.model.eventsourcedentity";
 option java_multiple_files = true;
 

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/replicatedentity/replicated_entity.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/replicatedentity/replicated_entity.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.replicatedentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/replicatedentity;replicatedentity";
 option java_package = "kalix.tck.model";
 
 import "kalix/annotations.proto";

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/valueentity/value_entity_api.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/valueentity/value_entity_api.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.valueentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/valueentity;valueentity";
 option java_package = "kalix.tck.model.valueentity";
 
 import "kalix/annotations.proto";

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/valueentity/value_entity_configured.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/valueentity/value_entity_configured.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.valueentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/valueentity;valueentity";
 option java_package = "kalix.tck.model.valueentity";
 option java_multiple_files = true;
 

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/valueentity/value_entity_tck_model.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/valueentity/value_entity_tck_model.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.valueentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/valueentity;valueentity";
 option java_package = "kalix.tck.model.valueentity";
 option java_multiple_files = true;
 

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/valueentity/value_entity_two.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/valueentity/value_entity_two.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.valueentity;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/valueentity;valueentity";
 option java_package = "kalix.tck.model.valueentity";
 option java_multiple_files = true;
 

--- a/tck/java-tck/src/main/proto/akkaserverless/tck/model/view/view.proto
+++ b/tck/java-tck/src/main/proto/akkaserverless/tck/model/view/view.proto
@@ -20,7 +20,6 @@ syntax = "proto3";
 
 package kalix.tck.model.view;
 
-option go_package = "github.com/lightbend/akkaserverless-go-sdk/tck/view;view";
 option java_package = "kalix.tck.model.view";
 //option java_multiple_files = true;
 //option java_outer_classname = "ViewModel";


### PR DESCRIPTION
Unrelated to renaming, but sending to kalix-main anyway. 

I don't think we need it in the tck files. Probably dates from the time where this and the proxy were one single project? 