### PR TITLE
Adding Metadata and eventSubject to ActionTestKit

### DIFF
--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionTestKitGenerator.scala
@@ -44,6 +44,7 @@ object ActionTestKitGenerator {
         "java.util.function.Function",
         "java.util.Optional",
         s"$packageName.$className",
+        "com.akkaserverless.javasdk.Metadata",
         "com.akkaserverless.javasdk.action.Action.Effect",
         "com.akkaserverless.javasdk.action.ActionCreationContext",
         "com.akkaserverless.javasdk.testkit.ActionResult",
@@ -64,11 +65,11 @@ object ActionTestKitGenerator {
         |
         |  private Function<ActionCreationContext, $className> actionFactory;
         |
-        |  private $className createAction() {
-        |    $className action = actionFactory.apply(new TestKitActionContext());
-        |    action._internalSetActionContext(Optional.of(new TestKitActionContext()));
+        |  private $className createAction(TestKitActionContext context) {
+        |    $className action = actionFactory.apply(context);
+        |    action._internalSetActionContext(Optional.of(context));
         |    return action;
-        |  };
+        |  }
         |
         |  public static $testKitClassName of(Function<ActionCreationContext, $className> actionFactory) {
         |    return new $testKitClassName(actionFactory);
@@ -83,6 +84,10 @@ object ActionTestKitGenerator {
         |  }
         |
         |  ${Format.indent(generateServices(service), 2)}
+        |
+        |  ${Format.indent(generateServicesMetadata(service), 2)}
+        |
+        |  ${Format.indent(generateServicesDefault(service), 2)}
         |
         |}
         |""".stripMargin
@@ -135,10 +140,45 @@ object ActionTestKitGenerator {
     service.commands
       .map { command =>
         s"""|public ${selectOutputResult(command)} ${lowerFirst(command.name)}(${selectInputType(command)} ${lowerFirst(
-          command.inputType.protoName)}) {
-          |  ${selectOutputEffect(command)} effect = createAction().${lowerFirst(command.name)}(${lowerFirst(
+          command.inputType.protoName)}, Metadata metadata, Optional<String> eventSubject) {
+          |  TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+          |  ${selectOutputEffect(command)} effect = createAction(context).${lowerFirst(command.name)}(${lowerFirst(
           command.inputType.protoName)});
           |  return ${selectOutputReturn(command)}
+          |}
+          |""".stripMargin + "\n"
+      }
+      .mkString("")
+  }
+
+  /**
+   * Leveraging `generateServices` by passing Metadata and setting default eventSubject
+   */
+  def generateServicesMetadata(service: ModelBuilder.ActionService): String = {
+    require(!service.commands.isEmpty, "empty `commands` not allowed")
+
+    service.commands
+      .map { command =>
+        s"""|public ${selectOutputResult(command)} ${lowerFirst(command.name)}(${selectInputType(command)} ${lowerFirst(
+          command.inputType.protoName)}, Metadata metadata) {
+          |  return ${lowerFirst(command.name)}(${lowerFirst(command.inputType.protoName)}, metadata, Optional.of("test-subject-id"));
+          |}
+          |""".stripMargin + "\n"
+      }
+      .mkString("")
+  }
+
+  /**
+   * Leveraging `generateServices` by setting default Metadata and default eventSubject
+   */
+  def generateServicesDefault(service: ModelBuilder.ActionService): String = {
+    require(!service.commands.isEmpty, "empty `commands` not allowed")
+
+    service.commands
+      .map { command =>
+        s"""|public ${selectOutputResult(command)} ${lowerFirst(command.name)}(${selectInputType(command)} ${lowerFirst(
+          command.inputType.protoName)}) {
+          |  return ${lowerFirst(command.name)}(${lowerFirst(command.inputType.protoName)}, Metadata.EMPTY, Optional.of("test-subject-id"));
           |}
           |""".stripMargin + "\n"
       }

--- a/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionTestKitGenerator.scala
+++ b/codegen/java-gen/src/main/scala/com/lightbend/akkasls/codegen/java/ActionTestKitGenerator.scala
@@ -85,8 +85,6 @@ object ActionTestKitGenerator {
         |
         |  ${Format.indent(generateServices(service), 2)}
         |
-        |  ${Format.indent(generateServicesMetadata(service), 2)}
-        |
         |  ${Format.indent(generateServicesDefault(service), 2)}
         |
         |}
@@ -140,8 +138,8 @@ object ActionTestKitGenerator {
     service.commands
       .map { command =>
         s"""|public ${selectOutputResult(command)} ${lowerFirst(command.name)}(${selectInputType(command)} ${lowerFirst(
-          command.inputType.protoName)}, Metadata metadata, Optional<String> eventSubject) {
-          |  TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+          command.inputType.protoName)}, Metadata metadata) {
+          |  TestKitActionContext context = new TestKitActionContext(metadata);
           |  ${selectOutputEffect(command)} effect = createAction(context).${lowerFirst(command.name)}(${lowerFirst(
           command.inputType.protoName)});
           |  return ${selectOutputReturn(command)}
@@ -152,24 +150,7 @@ object ActionTestKitGenerator {
   }
 
   /**
-   * Leveraging `generateServices` by passing Metadata and setting default eventSubject
-   */
-  def generateServicesMetadata(service: ModelBuilder.ActionService): String = {
-    require(!service.commands.isEmpty, "empty `commands` not allowed")
-
-    service.commands
-      .map { command =>
-        s"""|public ${selectOutputResult(command)} ${lowerFirst(command.name)}(${selectInputType(command)} ${lowerFirst(
-          command.inputType.protoName)}, Metadata metadata) {
-          |  return ${lowerFirst(command.name)}(${lowerFirst(command.inputType.protoName)}, metadata, Optional.of("test-subject-id"));
-          |}
-          |""".stripMargin + "\n"
-      }
-      .mkString("")
-  }
-
-  /**
-   * Leveraging `generateServices` by setting default Metadata and default eventSubject
+   * Leveraging `generateServices` by setting default Metadata as Metadata.EMPTY
    */
   def generateServicesDefault(service: ModelBuilder.ActionService): String = {
     require(!service.commands.isEmpty, "empty `commands` not allowed")
@@ -178,7 +159,7 @@ object ActionTestKitGenerator {
       .map { command =>
         s"""|public ${selectOutputResult(command)} ${lowerFirst(command.name)}(${selectInputType(command)} ${lowerFirst(
           command.inputType.protoName)}) {
-          |  return ${lowerFirst(command.name)}(${lowerFirst(command.inputType.protoName)}, Metadata.EMPTY, Optional.of("test-subject-id"));
+          |  return ${lowerFirst(command.name)}(${lowerFirst(command.inputType.protoName)}, Metadata.EMPTY);
           |}
           |""".stripMargin + "\n"
       }

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.java
@@ -44,60 +44,44 @@ public final class MyServiceNamedActionTestKit {
     return new ActionResultImpl(effect);
   }
 
-  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Effect<Empty> effect = createAction(context).simpleMethod(myRequest);
     return interpretEffects(effect);
   }
 
-  public Source<ActionResult<Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public Source<ActionResult<Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Source<Effect<Empty>, akka.NotUsed> effect = createAction(context).streamedOutputMethod(myRequest);
     return effect.map(e -> interpretEffects(e));
   }
 
-  public ActionResult<Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public ActionResult<Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Effect<Empty> effect = createAction(context).streamedInputMethod(myRequest);
     return interpretEffects(effect);
   }
 
-  public Source<ActionResult<Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public Source<ActionResult<Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Source<Effect<Empty>, akka.NotUsed> effect = createAction(context).fullStreamedMethod(myRequest);
     return effect.map(e -> interpretEffects(e));
   }
 
-  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
-    return simpleMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public Source<ActionResult<Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
-    return streamedOutputMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public ActionResult<Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
-    return streamedInputMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public Source<ActionResult<Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
-    return fullStreamedMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
   public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
-    return simpleMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return simpleMethod(myRequest, Metadata.EMPTY);
   }
 
   public Source<ActionResult<Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest) {
-    return streamedOutputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return streamedOutputMethod(myRequest, Metadata.EMPTY);
   }
 
   public ActionResult<Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    return streamedInputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return streamedInputMethod(myRequest, Metadata.EMPTY);
   }
 
   public Source<ActionResult<Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    return fullStreamedMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return fullStreamedMethod(myRequest, Metadata.EMPTY);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.java
@@ -2,6 +2,7 @@ package org.example.service;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
+import com.akkaserverless.javasdk.Metadata;
 import com.akkaserverless.javasdk.action.Action.Effect;
 import com.akkaserverless.javasdk.action.ActionCreationContext;
 import com.akkaserverless.javasdk.impl.action.ActionEffectImpl;
@@ -25,11 +26,11 @@ public final class MyServiceNamedActionTestKit {
 
   private Function<ActionCreationContext, MyServiceNamedAction> actionFactory;
 
-  private MyServiceNamedAction createAction() {
-    MyServiceNamedAction action = actionFactory.apply(new TestKitActionContext());
-    action._internalSetActionContext(Optional.of(new TestKitActionContext()));
+  private MyServiceNamedAction createAction(TestKitActionContext context) {
+    MyServiceNamedAction action = actionFactory.apply(context);
+    action._internalSetActionContext(Optional.of(context));
     return action;
-  };
+  }
 
   public static MyServiceNamedActionTestKit of(Function<ActionCreationContext, MyServiceNamedAction> actionFactory) {
     return new MyServiceNamedActionTestKit(actionFactory);
@@ -43,24 +44,60 @@ public final class MyServiceNamedActionTestKit {
     return new ActionResultImpl(effect);
   }
 
-  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
-    Effect<Empty> effect = createAction().simpleMethod(myRequest);
+  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Effect<Empty> effect = createAction(context).simpleMethod(myRequest);
     return interpretEffects(effect);
+  }
+
+  public Source<ActionResult<Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Source<Effect<Empty>, akka.NotUsed> effect = createAction(context).streamedOutputMethod(myRequest);
+    return effect.map(e -> interpretEffects(e));
+  }
+
+  public ActionResult<Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Effect<Empty> effect = createAction(context).streamedInputMethod(myRequest);
+    return interpretEffects(effect);
+  }
+
+  public Source<ActionResult<Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Source<Effect<Empty>, akka.NotUsed> effect = createAction(context).fullStreamedMethod(myRequest);
+    return effect.map(e -> interpretEffects(e));
+  }
+
+  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    return simpleMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public Source<ActionResult<Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    return streamedOutputMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public ActionResult<Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    return streamedInputMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public Source<ActionResult<Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    return fullStreamedMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
+    return simpleMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public Source<ActionResult<Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest) {
-    Source<Effect<Empty>, akka.NotUsed> effect = createAction().streamedOutputMethod(myRequest);
-    return effect.map(e -> interpretEffects(e));
+    return streamedOutputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public ActionResult<Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    Effect<Empty> effect = createAction().streamedInputMethod(myRequest);
-    return interpretEffects(effect);
+    return streamedInputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public Source<ActionResult<Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    Source<Effect<Empty>, akka.NotUsed> effect = createAction().fullStreamedMethod(myRequest);
-    return effect.map(e -> interpretEffects(e));
+    return fullStreamedMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
@@ -2,6 +2,7 @@ package org.example.service;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
+import com.akkaserverless.javasdk.Metadata;
 import com.akkaserverless.javasdk.action.Action.Effect;
 import com.akkaserverless.javasdk.action.ActionCreationContext;
 import com.akkaserverless.javasdk.impl.action.ActionEffectImpl;
@@ -25,11 +26,11 @@ public final class MyServiceActionTestKit {
 
   private Function<ActionCreationContext, MyServiceAction> actionFactory;
 
-  private MyServiceAction createAction() {
-    MyServiceAction action = actionFactory.apply(new TestKitActionContext());
-    action._internalSetActionContext(Optional.of(new TestKitActionContext()));
+  private MyServiceAction createAction(TestKitActionContext context) {
+    MyServiceAction action = actionFactory.apply(context);
+    action._internalSetActionContext(Optional.of(context));
     return action;
-  };
+  }
 
   public static MyServiceActionTestKit of(Function<ActionCreationContext, MyServiceAction> actionFactory) {
     return new MyServiceActionTestKit(actionFactory);
@@ -43,24 +44,60 @@ public final class MyServiceActionTestKit {
     return new ActionResultImpl(effect);
   }
 
-  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
-    Effect<ExternalDomain.Empty> effect = createAction().simpleMethod(myRequest);
+  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Effect<ExternalDomain.Empty> effect = createAction(context).simpleMethod(myRequest);
     return interpretEffects(effect);
+  }
+
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction(context).streamedOutputMethod(myRequest);
+    return effect.map(e -> interpretEffects(e));
+  }
+
+  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Effect<ExternalDomain.Empty> effect = createAction(context).streamedInputMethod(myRequest);
+    return interpretEffects(effect);
+  }
+
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction(context).fullStreamedMethod(myRequest);
+    return effect.map(e -> interpretEffects(e));
+  }
+
+  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    return simpleMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    return streamedOutputMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    return streamedInputMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    return fullStreamedMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
+    return simpleMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest) {
-    Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction().streamedOutputMethod(myRequest);
-    return effect.map(e -> interpretEffects(e));
+    return streamedOutputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    Effect<ExternalDomain.Empty> effect = createAction().streamedInputMethod(myRequest);
-    return interpretEffects(effect);
+    return streamedInputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction().fullStreamedMethod(myRequest);
-    return effect.map(e -> interpretEffects(e));
+    return fullStreamedMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
@@ -44,60 +44,44 @@ public final class MyServiceActionTestKit {
     return new ActionResultImpl(effect);
   }
 
-  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Effect<ExternalDomain.Empty> effect = createAction(context).simpleMethod(myRequest);
     return interpretEffects(effect);
   }
 
-  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction(context).streamedOutputMethod(myRequest);
     return effect.map(e -> interpretEffects(e));
   }
 
-  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Effect<ExternalDomain.Empty> effect = createAction(context).streamedInputMethod(myRequest);
     return interpretEffects(effect);
   }
 
-  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction(context).fullStreamedMethod(myRequest);
     return effect.map(e -> interpretEffects(e));
   }
 
-  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
-    return simpleMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
-    return streamedOutputMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
-    return streamedInputMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
-    return fullStreamedMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
   public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
-    return simpleMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return simpleMethod(myRequest, Metadata.EMPTY);
   }
 
   public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest) {
-    return streamedOutputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return streamedOutputMethod(myRequest, Metadata.EMPTY);
   }
 
   public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    return streamedInputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return streamedInputMethod(myRequest, Metadata.EMPTY);
   }
 
   public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    return fullStreamedMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return fullStreamedMethod(myRequest, Metadata.EMPTY);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
@@ -2,6 +2,7 @@ package org.example.service;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
+import com.akkaserverless.javasdk.Metadata;
 import com.akkaserverless.javasdk.action.Action.Effect;
 import com.akkaserverless.javasdk.action.ActionCreationContext;
 import com.akkaserverless.javasdk.impl.action.ActionEffectImpl;
@@ -25,11 +26,11 @@ public final class MyServiceActionTestKit {
 
   private Function<ActionCreationContext, MyServiceAction> actionFactory;
 
-  private MyServiceAction createAction() {
-    MyServiceAction action = actionFactory.apply(new TestKitActionContext());
-    action._internalSetActionContext(Optional.of(new TestKitActionContext()));
+  private MyServiceAction createAction(TestKitActionContext context) {
+    MyServiceAction action = actionFactory.apply(context);
+    action._internalSetActionContext(Optional.of(context));
     return action;
-  };
+  }
 
   public static MyServiceActionTestKit of(Function<ActionCreationContext, MyServiceAction> actionFactory) {
     return new MyServiceActionTestKit(actionFactory);
@@ -43,24 +44,60 @@ public final class MyServiceActionTestKit {
     return new ActionResultImpl(effect);
   }
 
-  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
-    Effect<ExternalDomain.Empty> effect = createAction().simpleMethod(myRequest);
+  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Effect<ExternalDomain.Empty> effect = createAction(context).simpleMethod(myRequest);
     return interpretEffects(effect);
+  }
+
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction(context).streamedOutputMethod(myRequest);
+    return effect.map(e -> interpretEffects(e));
+  }
+
+  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Effect<ExternalDomain.Empty> effect = createAction(context).streamedInputMethod(myRequest);
+    return interpretEffects(effect);
+  }
+
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction(context).fullStreamedMethod(myRequest);
+    return effect.map(e -> interpretEffects(e));
+  }
+
+  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    return simpleMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    return streamedOutputMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    return streamedInputMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    return fullStreamedMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
+    return simpleMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest) {
-    Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction().streamedOutputMethod(myRequest);
-    return effect.map(e -> interpretEffects(e));
+    return streamedOutputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    Effect<ExternalDomain.Empty> effect = createAction().streamedInputMethod(myRequest);
-    return interpretEffects(effect);
+    return streamedInputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
   public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction().fullStreamedMethod(myRequest);
-    return effect.map(e -> interpretEffects(e));
+    return fullStreamedMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.java
@@ -44,60 +44,44 @@ public final class MyServiceActionTestKit {
     return new ActionResultImpl(effect);
   }
 
-  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Effect<ExternalDomain.Empty> effect = createAction(context).simpleMethod(myRequest);
     return interpretEffects(effect);
   }
 
-  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction(context).streamedOutputMethod(myRequest);
     return effect.map(e -> interpretEffects(e));
   }
 
-  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Effect<ExternalDomain.Empty> effect = createAction(context).streamedInputMethod(myRequest);
     return interpretEffects(effect);
   }
 
-  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Source<Effect<ExternalDomain.Empty>, akka.NotUsed> effect = createAction(context).fullStreamedMethod(myRequest);
     return effect.map(e -> interpretEffects(e));
   }
 
-  public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
-    return simpleMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
-    return streamedOutputMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
-    return streamedInputMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
-  public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest, Metadata metadata) {
-    return fullStreamedMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
   public ActionResult<ExternalDomain.Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
-    return simpleMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return simpleMethod(myRequest, Metadata.EMPTY);
   }
 
   public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> streamedOutputMethod(ServiceOuterClass.MyRequest myRequest) {
-    return streamedOutputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return streamedOutputMethod(myRequest, Metadata.EMPTY);
   }
 
   public ActionResult<ExternalDomain.Empty> streamedInputMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    return streamedInputMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return streamedInputMethod(myRequest, Metadata.EMPTY);
   }
 
   public Source<ActionResult<ExternalDomain.Empty>, akka.NotUsed> fullStreamedMethod(Source<ServiceOuterClass.MyRequest, akka.NotUsed> myRequest) {
-    return fullStreamedMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return fullStreamedMethod(myRequest, Metadata.EMPTY);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.java
@@ -42,18 +42,14 @@ public final class MyServiceActionImplTestKit {
     return new ActionResultImpl(effect);
   }
 
-  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
-    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    TestKitActionContext context = new TestKitActionContext(metadata);
     Effect<Empty> effect = createAction(context).simpleMethod(myRequest);
     return interpretEffects(effect);
   }
 
-  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
-    return simpleMethod(myRequest, metadata, Optional.of("test-subject-id"));
-  }
-
   public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
-    return simpleMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
+    return simpleMethod(myRequest, Metadata.EMPTY);
   }
 
 }

--- a/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.java
+++ b/codegen/java-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.java
@@ -1,5 +1,6 @@
 package org.example.service;
 
+import com.akkaserverless.javasdk.Metadata;
 import com.akkaserverless.javasdk.action.Action.Effect;
 import com.akkaserverless.javasdk.action.ActionCreationContext;
 import com.akkaserverless.javasdk.impl.action.ActionEffectImpl;
@@ -23,11 +24,11 @@ public final class MyServiceActionImplTestKit {
 
   private Function<ActionCreationContext, MyServiceActionImpl> actionFactory;
 
-  private MyServiceActionImpl createAction() {
-    MyServiceActionImpl action = actionFactory.apply(new TestKitActionContext());
-    action._internalSetActionContext(Optional.of(new TestKitActionContext()));
+  private MyServiceActionImpl createAction(TestKitActionContext context) {
+    MyServiceActionImpl action = actionFactory.apply(context);
+    action._internalSetActionContext(Optional.of(context));
     return action;
-  };
+  }
 
   public static MyServiceActionImplTestKit of(Function<ActionCreationContext, MyServiceActionImpl> actionFactory) {
     return new MyServiceActionImplTestKit(actionFactory);
@@ -41,9 +42,18 @@ public final class MyServiceActionImplTestKit {
     return new ActionResultImpl(effect);
   }
 
-  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
-    Effect<Empty> effect = createAction().simpleMethod(myRequest);
+  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata, Optional<String> eventSubject) {
+    TestKitActionContext context = new TestKitActionContext(metadata, eventSubject);
+    Effect<Empty> effect = createAction(context).simpleMethod(myRequest);
     return interpretEffects(effect);
+  }
+
+  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest, Metadata metadata) {
+    return simpleMethod(myRequest, metadata, Optional.of("test-subject-id"));
+  }
+
+  public ActionResult<Empty> simpleMethod(ServiceOuterClass.MyRequest myRequest) {
+    return simpleMethod(myRequest, Metadata.EMPTY, Optional.of("test-subject-id"));
   }
 
 }

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ActionTestKitGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ActionTestKitGenerator.scala
@@ -49,9 +49,8 @@ object ActionTestKitGenerator {
 
     val methods = service.commands.map { cmd =>
       s"""def ${lowerFirst(cmd.name)}(command: ${selectInput(
-        cmd)}, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ${selectOutputResult(
-        cmd)} = {\n""" +
-      "  val context = new TestKitActionContext(metadata, eventSubject)\n" +
+        cmd)}, metadata: Metadata = Metadata.empty): ${selectOutputResult(cmd)} = {\n""" +
+      "  val context = new TestKitActionContext(metadata)\n" +
       (if (cmd.isUnary || cmd.isStreamIn) {
          s"""  new ActionResultImpl(newActionInstance(context).${lowerFirst(cmd.name)}(command))"""
        } else {

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ActionTestKitGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ActionTestKitGenerator.scala
@@ -50,15 +50,15 @@ object ActionTestKitGenerator {
     val methods = service.commands.map { cmd =>
       s"""def ${lowerFirst(cmd.name)}(command: ${selectInput(
         cmd)}, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ${selectOutputResult(
-        cmd)} = { \n""" +
-      "val context = new TestKitActionContext(metadata, eventSubject) \n" +
+        cmd)} = {\n""" +
+      "  val context = new TestKitActionContext(metadata, eventSubject)\n" +
       (if (cmd.isUnary || cmd.isStreamIn) {
          s"""  new ActionResultImpl(newActionInstance(context).${lowerFirst(cmd.name)}(command))"""
        } else {
          s"""  newActionInstance(context).${lowerFirst(
            cmd.name)}(command).map(effect => new ActionResultImpl(effect))"""
        }) + "\n" +
-      "} \n"
+      "}\n"
     }
 
     File.scala(

--- a/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ActionTestKitGenerator.scala
+++ b/codegen/scala-gen/src/main/scala/com/akkaserverless/codegen/scalasdk/impl/ActionTestKitGenerator.scala
@@ -39,6 +39,7 @@ object ActionTestKitGenerator {
         service.commands.map(_.outputType),
         service.messageType.parent.scalaPackage,
         otherImports = Seq(
+          "com.akkaserverless.scalasdk.Metadata",
           "com.akkaserverless.scalasdk.testkit.ActionResult",
           "com.akkaserverless.scalasdk.testkit.impl.ActionResultImpl",
           "com.akkaserverless.scalasdk.action.ActionCreationContext",
@@ -47,12 +48,17 @@ object ActionTestKitGenerator {
     val actionClassName = service.className
 
     val methods = service.commands.map { cmd =>
-      s"""def ${lowerFirst(cmd.name)}(command: ${selectInput(cmd)}): ${selectOutputResult(cmd)} =\n""" +
+      s"""def ${lowerFirst(cmd.name)}(command: ${selectInput(
+        cmd)}, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ${selectOutputResult(
+        cmd)} = { \n""" +
+      "val context = new TestKitActionContext(metadata, eventSubject) \n" +
       (if (cmd.isUnary || cmd.isStreamIn) {
-         s"""  new ActionResultImpl(newActionInstance().${lowerFirst(cmd.name)}(command))"""
+         s"""  new ActionResultImpl(newActionInstance(context).${lowerFirst(cmd.name)}(command))"""
        } else {
-         s"""  newActionInstance().${lowerFirst(cmd.name)}(command).map(effect => new ActionResultImpl(effect))"""
-       }) + "\n"
+         s"""  newActionInstance(context).${lowerFirst(
+           cmd.name)}(command).map(effect => new ActionResultImpl(effect))"""
+       }) + "\n" +
+      "} \n"
     }
 
     File.scala(
@@ -82,8 +88,7 @@ object ActionTestKitGenerator {
           | */
           |final class ${actionClassName}TestKit private(actionFactory: ActionCreationContext => $actionClassName) {
           |
-          |  private def newActionInstance() = {
-          |    val context = new TestKitActionContext
+          |  private def newActionInstance(context: TestKitActionContext) = {
           |    val action = actionFactory(context)
           |    action._internalSetActionContext(Some(context))
           |    action

--- a/codegen/scala-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.scala
@@ -2,6 +2,7 @@ package org.example.service
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import com.akkaserverless.scalasdk.Metadata
 import com.akkaserverless.scalasdk.action.ActionCreationContext
 import com.akkaserverless.scalasdk.testkit.ActionResult
 import com.akkaserverless.scalasdk.testkit.impl.ActionResultImpl
@@ -30,7 +31,7 @@ object MyServiceNamedActionTestKit {
  */
 final class MyServiceNamedActionTestKit private(actionFactory: ActionCreationContext => MyServiceNamedAction) {
 
-  private def newActionInstance() = {
+  private def newActionInstance(context: TestKitActionContext) = {
     val action = actionFactory(context)
     action._internalSetActionContext(Some(context))
     action
@@ -41,17 +42,17 @@ final class MyServiceNamedActionTestKit private(actionFactory: ActionCreationCon
     new ActionResultImpl(newActionInstance(context).simpleMethod(command))
   }
 
-  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] =
+  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
     val context = new TestKitActionContext(metadata, eventSubject)
     newActionInstance(context).streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
   }
 
-  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] =
+  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
     val context = new TestKitActionContext(metadata, eventSubject)
     new ActionResultImpl(newActionInstance(context).streamedInputMethod(command))
   }
 
-  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed] metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] =
+  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
     val context = new TestKitActionContext(metadata, eventSubject)
     newActionInstance(context).fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
   }

--- a/codegen/scala-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.scala
@@ -37,23 +37,23 @@ final class MyServiceNamedActionTestKit private(actionFactory: ActionCreationCon
     action
   }
 
-  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata)
     new ActionResultImpl(newActionInstance(context).simpleMethod(command))
   }
 
-  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata)
     newActionInstance(context).streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
   }
 
-  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata)
     new ActionResultImpl(newActionInstance(context).streamedInputMethod(command))
   }
 
-  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata)
     newActionInstance(context).fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
   }
 }

--- a/codegen/scala-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/named-new-style/generated-test-managed/org/example/service/MyServiceNamedActionTestKit.scala
@@ -31,21 +31,28 @@ object MyServiceNamedActionTestKit {
 final class MyServiceNamedActionTestKit private(actionFactory: ActionCreationContext => MyServiceNamedAction) {
 
   private def newActionInstance() = {
-    val context = new TestKitActionContext
     val action = actionFactory(context)
     action._internalSetActionContext(Some(context))
     action
   }
 
-  def simpleMethod(command: MyRequest): ActionResult[Empty] =
-    new ActionResultImpl(newActionInstance().simpleMethod(command))
+  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    new ActionResultImpl(newActionInstance(context).simpleMethod(command))
+  }
 
-  def streamedOutputMethod(command: MyRequest): Source[ActionResult[Empty], akka.NotUsed] =
-    newActionInstance().streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
+  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] =
+    val context = new TestKitActionContext(metadata, eventSubject)
+    newActionInstance(context).streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
+  }
 
-  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed]): ActionResult[Empty] =
-    new ActionResultImpl(newActionInstance().streamedInputMethod(command))
+  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] =
+    val context = new TestKitActionContext(metadata, eventSubject)
+    new ActionResultImpl(newActionInstance(context).streamedInputMethod(command))
+  }
 
-  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed]): Source[ActionResult[Empty], akka.NotUsed] =
-    newActionInstance().fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
+  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed] metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] =
+    val context = new TestKitActionContext(metadata, eventSubject)
+    newActionInstance(context).fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
+  }
 }

--- a/codegen/scala-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.scala
@@ -2,6 +2,7 @@ package org.example.service
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import com.akkaserverless.scalasdk.Metadata
 import com.akkaserverless.scalasdk.action.ActionCreationContext
 import com.akkaserverless.scalasdk.testkit.ActionResult
 import com.akkaserverless.scalasdk.testkit.impl.ActionResultImpl
@@ -30,22 +31,29 @@ object MyServiceActionTestKit {
  */
 final class MyServiceActionTestKit private(actionFactory: ActionCreationContext => MyServiceAction) {
 
-  private def newActionInstance() = {
-    val context = new TestKitActionContext
+  private def newActionInstance(context: TestKitActionContext) = {
     val action = actionFactory(context)
     action._internalSetActionContext(Some(context))
     action
   }
 
-  def simpleMethod(command: MyRequest): ActionResult[Empty] =
-    new ActionResultImpl(newActionInstance().simpleMethod(command))
+  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    new ActionResultImpl(newActionInstance(context).simpleMethod(command))
+  }
 
-  def streamedOutputMethod(command: MyRequest): Source[ActionResult[Empty], akka.NotUsed] =
-    newActionInstance().streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
+  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    newActionInstance(context).streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
+  }
 
-  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed]): ActionResult[Empty] =
-    new ActionResultImpl(newActionInstance().streamedInputMethod(command))
+  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    new ActionResultImpl(newActionInstance(context).streamedInputMethod(command))
+  }
 
-  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed]): Source[ActionResult[Empty], akka.NotUsed] =
-    newActionInstance().fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
+  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    newActionInstance(context).fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
+  }
 }

--- a/codegen/scala-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/simple-new-style/generated-test-managed/org/example/service/MyServiceActionTestKit.scala
@@ -37,23 +37,23 @@ final class MyServiceActionTestKit private(actionFactory: ActionCreationContext 
     action
   }
 
-  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata)
     new ActionResultImpl(newActionInstance(context).simpleMethod(command))
   }
 
-  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata)
     newActionInstance(context).streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
   }
 
-  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata)
     new ActionResultImpl(newActionInstance(context).streamedInputMethod(command))
   }
 
-  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata)
     newActionInstance(context).fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
   }
 }

--- a/codegen/scala-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.scala
@@ -2,6 +2,7 @@ package org.example.service
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import com.akkaserverless.scalasdk.Metadata
 import com.akkaserverless.scalasdk.action.ActionCreationContext
 import com.akkaserverless.scalasdk.testkit.ActionResult
 import com.akkaserverless.scalasdk.testkit.impl.ActionResultImpl
@@ -30,22 +31,29 @@ object MyServiceActionTestKit {
  */
 final class MyServiceActionTestKit private(actionFactory: ActionCreationContext => MyServiceAction) {
 
-  private def newActionInstance() = {
-    val context = new TestKitActionContext
+  private def newActionInstance(context: TestKitActionContext) = {
     val action = actionFactory(context)
     action._internalSetActionContext(Some(context))
     action
   }
 
-  def simpleMethod(command: MyRequest): ActionResult[Empty] =
-    new ActionResultImpl(newActionInstance().simpleMethod(command))
+  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    new ActionResultImpl(newActionInstance(context).simpleMethod(command))
+  }
 
-  def streamedOutputMethod(command: MyRequest): Source[ActionResult[Empty], akka.NotUsed] =
-    newActionInstance().streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
+  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    newActionInstance(context).streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
+  }
 
-  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed]): ActionResult[Empty] =
-    new ActionResultImpl(newActionInstance().streamedInputMethod(command))
+  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    new ActionResultImpl(newActionInstance(context).streamedInputMethod(command))
+  }
 
-  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed]): Source[ActionResult[Empty], akka.NotUsed] =
-    newActionInstance().fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
+  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    newActionInstance(context).fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
+  }
 }

--- a/codegen/scala-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/simple-old-style/generated-test-managed/org/example/service/MyServiceActionTestKit.scala
@@ -37,23 +37,23 @@ final class MyServiceActionTestKit private(actionFactory: ActionCreationContext 
     action
   }
 
-  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata)
     new ActionResultImpl(newActionInstance(context).simpleMethod(command))
   }
 
-  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def streamedOutputMethod(command: MyRequest, metadata: Metadata = Metadata.empty): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata)
     newActionInstance(context).streamedOutputMethod(command).map(effect => new ActionResultImpl(effect))
   }
 
-  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def streamedInputMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata)
     new ActionResultImpl(newActionInstance(context).streamedInputMethod(command))
   }
 
-  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): Source[ActionResult[Empty], akka.NotUsed] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def fullStreamedMethod(command: Source[MyRequest, akka.NotUsed], metadata: Metadata = Metadata.empty): Source[ActionResult[Empty], akka.NotUsed] = {
+    val context = new TestKitActionContext(metadata)
     newActionInstance(context).fullStreamedMethod(command).map(effect => new ActionResultImpl(effect))
   }
 }

--- a/codegen/scala-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.scala
@@ -1,5 +1,6 @@
 package org.example.service
 
+import com.akkaserverless.scalasdk.Metadata
 import com.akkaserverless.scalasdk.action.ActionCreationContext
 import com.akkaserverless.scalasdk.testkit.ActionResult
 import com.akkaserverless.scalasdk.testkit.impl.ActionResultImpl
@@ -28,13 +29,14 @@ object MyServiceActionImplTestKit {
  */
 final class MyServiceActionImplTestKit private(actionFactory: ActionCreationContext => MyServiceActionImpl) {
 
-  private def newActionInstance() = {
-    val context = new TestKitActionContext
+  private def newActionInstance(context: TestKitActionContext) = {
     val action = actionFactory(context)
     action._internalSetActionContext(Some(context))
     action
   }
 
-  def simpleMethod(command: MyRequest): ActionResult[Empty] =
-    new ActionResultImpl(newActionInstance().simpleMethod(command))
+  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata, eventSubject)
+    new ActionResultImpl(newActionInstance(context).simpleMethod(command))
+  }
 }

--- a/codegen/scala-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.scala
+++ b/codegen/scala-gen/src/test/resources/tests/action-service/with-action-in-name/generated-test-managed/org/example/service/MyServiceActionImplTestKit.scala
@@ -35,8 +35,8 @@ final class MyServiceActionImplTestKit private(actionFactory: ActionCreationCont
     action
   }
 
-  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty, eventSubject: Option[String] = Some("test-subject-id")): ActionResult[Empty] = {
-    val context = new TestKitActionContext(metadata, eventSubject)
+  def simpleMethod(command: MyRequest, metadata: Metadata = Metadata.empty): ActionResult[Empty] = {
+    val context = new TestKitActionContext(metadata)
     new ActionResultImpl(newActionInstance(context).simpleMethod(command))
   }
 }

--- a/samples/java-eventsourced-counter/src/main/java/com/example/actions/CounterJournalToTopicAction.java
+++ b/samples/java-eventsourced-counter/src/main/java/com/example/actions/CounterJournalToTopicAction.java
@@ -42,6 +42,25 @@ public class CounterJournalToTopicAction extends AbstractCounterJournalToTopicAc
   // end::counter-topic[]
 
   @Override
+  public Effect<CounterTopicApi.Increased> increaseConditional(CounterDomain.ValueIncreased valueIncreased) {
+    Optional<String> counterId = actionContext().eventSubject();
+
+    CounterTopicApi.Increased increased;
+    if(actionContext().metadata().get("myKey").equals(Optional.of("myValue"))){
+      increased = 
+      CounterTopicApi.Increased.newBuilder() 
+        .setValue(valueIncreased.getValue() * 2)
+        .build();
+    } else {
+      increased = 
+      CounterTopicApi.Increased.newBuilder() 
+        .setValue(valueIncreased.getValue())
+        .build();
+    }
+    return effects().reply(increased); 
+  } 
+
+  @Override
   public Effect<CounterTopicApi.Decreased> decrease(CounterDomain.ValueDecreased valueDecreased) {
     CounterTopicApi.Decreased decreased =
         CounterTopicApi.Decreased.newBuilder()

--- a/samples/java-eventsourced-counter/src/main/java/com/example/actions/CounterJournalToTopicAction.java
+++ b/samples/java-eventsourced-counter/src/main/java/com/example/actions/CounterJournalToTopicAction.java
@@ -46,7 +46,8 @@ public class CounterJournalToTopicAction extends AbstractCounterJournalToTopicAc
     Optional<String> counterId = actionContext().eventSubject();
 
     CounterTopicApi.Increased increased;
-    if(actionContext().metadata().get("myKey").equals(Optional.of("myValue"))){
+    if(actionContext().metadata().get("myKey").equals(Optional.of("myValue")) 
+      && actionContext().eventSubject().equals(Optional.of("mySubject"))){
       increased = 
       CounterTopicApi.Increased.newBuilder() 
         .setValue(valueIncreased.getValue() * 2)

--- a/samples/java-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
+++ b/samples/java-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
@@ -46,6 +46,15 @@ service CounterJournalToTopic {
       topic:  "counter-events"
     };
   } 
+
+  rpc IncreaseConditional (com.example.domain.ValueIncreased) returns (Increased) { 
+    option (akkaserverless.method).eventing.in = { 
+      event_sourced_entity: "counter" 
+    };
+    option (akkaserverless.method).eventing.out = {
+      topic:  "counter-events"
+    };
+  } 
   
   rpc Decrease (com.example.domain.ValueDecreased) returns (Decreased) { 
     option (akkaserverless.method).eventing.in = { 

--- a/samples/java-eventsourced-counter/src/test/java/com/example/actions/CounterJournalToTopicActionTest.java
+++ b/samples/java-eventsourced-counter/src/test/java/com/example/actions/CounterJournalToTopicActionTest.java
@@ -30,7 +30,7 @@ public class CounterJournalToTopicActionTest {
     CounterJournalToTopicActionTestKit testKit = CounterJournalToTopicActionTestKit.of(CounterJournalToTopicAction::new);
     ActionResult<CounterTopicApi.Increased> result = testKit.increaseConditional(
       CounterDomain.ValueIncreased.newBuilder().setValue(1).build(),
-      Metadata.EMPTY.set("myKey","myValue")
+      Metadata.EMPTY.set("myKey","myValue").set("ce-subject","mySubject")
       );
     assertEquals(2, result.getReply().getValue());
   }

--- a/samples/java-eventsourced-counter/src/test/java/com/example/actions/CounterJournalToTopicActionTest.java
+++ b/samples/java-eventsourced-counter/src/test/java/com/example/actions/CounterJournalToTopicActionTest.java
@@ -4,6 +4,7 @@
  */
 package com.example.actions;
 
+import com.akkaserverless.javasdk.Metadata;
 import com.akkaserverless.javasdk.testkit.ActionResult;
 import com.example.actions.CounterJournalToTopicAction;
 import com.example.actions.CounterJournalToTopicActionTestKit;
@@ -22,6 +23,16 @@ public class CounterJournalToTopicActionTest {
     CounterJournalToTopicActionTestKit testKit = CounterJournalToTopicActionTestKit.of(CounterJournalToTopicAction::new);
     ActionResult<CounterTopicApi.Increased> result = testKit.increase(CounterDomain.ValueIncreased.newBuilder().setValue(1).build());
     assertEquals(1, result.getReply().getValue());
+  }
+
+   @Test
+  public void increaseTestConditional() {
+    CounterJournalToTopicActionTestKit testKit = CounterJournalToTopicActionTestKit.of(CounterJournalToTopicAction::new);
+    ActionResult<CounterTopicApi.Increased> result = testKit.increaseConditional(
+      CounterDomain.ValueIncreased.newBuilder().setValue(1).build(),
+      Metadata.EMPTY.set("myKey","myValue")
+      );
+    assertEquals(2, result.getReply().getValue());
   }
 
   @Test

--- a/samples/scala-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
+++ b/samples/scala-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
@@ -44,6 +44,15 @@ service CounterJournalToTopic {
       topic:  "counter-events"
     };
   } 
+
+   rpc IncreaseConditional (com.example.domain.ValueIncreased) returns (Increased) { // <3>
+    option (akkaserverless.method).eventing.in = { // <4>
+      event_sourced_entity: "counter" 
+    };
+    option (akkaserverless.method).eventing.out = { // <5>
+      topic:  "counter-events"
+    };
+  } 
   
   rpc Decrease (com.example.domain.ValueDecreased) returns (Decreased) { 
     option (akkaserverless.method).eventing.in = { 

--- a/samples/scala-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
+++ b/samples/scala-eventsourced-counter/src/main/proto/com/example/actions/counter_topic.proto
@@ -45,11 +45,11 @@ service CounterJournalToTopic {
     };
   } 
 
-   rpc IncreaseConditional (com.example.domain.ValueIncreased) returns (Increased) { // <3>
-    option (akkaserverless.method).eventing.in = { // <4>
+  rpc IncreaseConditional (com.example.domain.ValueIncreased) returns (Increased) { 
+    option (akkaserverless.method).eventing.in = { 
       event_sourced_entity: "counter" 
     };
-    option (akkaserverless.method).eventing.out = { // <5>
+    option (akkaserverless.method).eventing.out = {
       topic:  "counter-events"
     };
   } 

--- a/samples/scala-eventsourced-counter/src/main/scala/com/example/actions/CounterJournalToTopicAction.scala
+++ b/samples/scala-eventsourced-counter/src/main/scala/com/example/actions/CounterJournalToTopicAction.scala
@@ -30,8 +30,8 @@ class CounterJournalToTopicAction(creationContext: ActionCreationContext) extend
   // end::counter-topic[]
 
   override def increaseConditional(valueIncreased: ValueIncreased): Action.Effect[Increased] = {
-    val counterId = actionContext.eventSubject 
-    if (actionContext.metadata.get("myKey") == Some("myValue")){
+    println(actionContext.metadata.get("ce-subject") == Some("mySubject"))
+    if (actionContext.metadata.get("myKey") == Some("myValue") && actionContext.eventSubject == Some("mySubject")){
       effects.reply(Increased(valueIncreased.value * 2))
     } else {
       effects.reply(Increased(valueIncreased.value))

--- a/samples/scala-eventsourced-counter/src/main/scala/com/example/actions/CounterJournalToTopicAction.scala
+++ b/samples/scala-eventsourced-counter/src/main/scala/com/example/actions/CounterJournalToTopicAction.scala
@@ -29,6 +29,16 @@ class CounterJournalToTopicAction(creationContext: ActionCreationContext) extend
   // end::counter-topic-event-subject[]
   // end::counter-topic[]
 
+  override def increaseConditional(valueIncreased: ValueIncreased): Action.Effect[Increased] = {
+    val counterId = actionContext.eventSubject 
+    if (actionContext.metadata.get("myKey") == Some("myValue")){
+      effects.reply(Increased(valueIncreased.value * 2))
+    } else {
+      effects.reply(Increased(valueIncreased.value))
+    }
+
+  }
+
   override def decrease(valueDecreased: ValueDecreased): Action.Effect[Decreased] = {
     effects.reply(Decreased(valueDecreased.value))
   }

--- a/samples/scala-eventsourced-counter/src/test/scala/com/example/actions/CounterJournalToTopicActionSpec.scala
+++ b/samples/scala-eventsourced-counter/src/test/scala/com/example/actions/CounterJournalToTopicActionSpec.scala
@@ -18,7 +18,7 @@ class CounterJournalToTopicActionSpec extends AnyWordSpec with Matchers {
 
     "handle command Increase with Metadata" in {
       val testKit = CounterJournalToTopicActionTestKit(new CounterJournalToTopicAction(_))
-      val result = testKit.increaseConditional(ValueIncreased(1),Metadata.empty.set("myKey","myValue"))
+      val result = testKit.increaseConditional(ValueIncreased(1),Metadata.empty.set("myKey","myValue").set("ce-subject","mySubject"))
       result.reply shouldBe Increased(2)
     }
 

--- a/samples/scala-eventsourced-counter/src/test/scala/com/example/actions/CounterJournalToTopicActionSpec.scala
+++ b/samples/scala-eventsourced-counter/src/test/scala/com/example/actions/CounterJournalToTopicActionSpec.scala
@@ -4,6 +4,7 @@ import com.example.domain.ValueDecreased
 import com.example.domain.ValueIncreased
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import com.akkaserverless.scalasdk.Metadata
 
 class CounterJournalToTopicActionSpec extends AnyWordSpec with Matchers {
 
@@ -13,6 +14,12 @@ class CounterJournalToTopicActionSpec extends AnyWordSpec with Matchers {
       val testKit = CounterJournalToTopicActionTestKit(new CounterJournalToTopicAction(_))
       val result = testKit.increase(ValueIncreased(1))
       result.reply shouldBe Increased(1)
+    }
+
+    "handle command Increase with Metadata" in {
+      val testKit = CounterJournalToTopicActionTestKit(new CounterJournalToTopicAction(_))
+      val result = testKit.increaseConditional(ValueIncreased(1),Metadata.empty.set("myKey","myValue"))
+      result.reply shouldBe Increased(2)
     }
 
     "handle command Decrease" in {

--- a/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/TestKitActionContext.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/TestKitActionContext.scala
@@ -29,19 +29,19 @@ import scala.collection.convert.ImplicitConversions._
 /**
  * INTERNAL API Used by the generated testkit
  */
-final class TestKitActionContext(metadata: Metadata, eventSubject: java.util.Optional[String])
+final class TestKitActionContext(metadata: Metadata)
     extends AbstractTestKitContext
     with ActionContext
     with ActionCreationContext
     with InternalContext {
 
   def this() {
-    this(Metadata.EMPTY, Optional.of("test-subject-id"))
+    this(Metadata.EMPTY)
   }
 
   override def metadata() = metadata
 
-  override def eventSubject() = eventSubject
+  override def eventSubject() = metadata.get("ce-subject")
 
   override def getGrpcClient[T](clientClass: Class[T], service: String): T =
     throw new UnsupportedOperationException("Testing logic using a gRPC client is not possible with the testkit")

--- a/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/TestKitActionContext.scala
+++ b/sdk/java-sdk-testkit/src/main/scala/com/akkaserverless/javasdk/testkit/impl/TestKitActionContext.scala
@@ -18,23 +18,30 @@ package com.akkaserverless.javasdk.testkit.impl;
 
 import com.akkaserverless.javasdk.action.ActionContext
 
-import java.util.Optional
+import java.util.{ HashMap, Optional }
+import java.nio.ByteBuffer
 import com.akkaserverless.javasdk.action.ActionCreationContext
 import akka.stream.Materializer
 import com.akkaserverless.javasdk.impl.InternalContext
+import com.akkaserverless.javasdk.Metadata
+import scala.collection.convert.ImplicitConversions._
 
 /**
  * INTERNAL API Used by the generated testkit
  */
-final class TestKitActionContext
+final class TestKitActionContext(metadata: Metadata, eventSubject: java.util.Optional[String])
     extends AbstractTestKitContext
     with ActionContext
     with ActionCreationContext
     with InternalContext {
 
-  override def metadata() = throw new UnsupportedOperationException("Accessing metadata from testkit not supported yet")
+  def this() {
+    this(Metadata.EMPTY, Optional.of("test-subject-id"))
+  }
 
-  override def eventSubject() = Optional.of("test-subject-id")
+  override def metadata() = metadata
+
+  override def eventSubject() = eventSubject
 
   override def getGrpcClient[T](clientClass: Class[T], service: String): T =
     throw new UnsupportedOperationException("Testing logic using a gRPC client is not possible with the testkit")

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/TestKitActionContext.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/TestKitActionContext.scala
@@ -24,10 +24,12 @@ import com.akkaserverless.scalasdk.action.ActionCreationContext
 /**
  * INTERNAL API Used by the generated testkit
  */
-final class TestKitActionContext extends AbstractTestKitContext with ActionContext with ActionCreationContext {
-  override def metadata: Metadata = throw new UnsupportedOperationException(
-    "Accessing metadata from testkit not supported yet")
-  override def eventSubject: Option[String] = Some("test-subject-id")
+final class TestKitActionContext(
+    override val metadata: Metadata = Metadata.empty,
+    override val eventSubject: Option[String] = Some("test-subject-id"))
+    extends AbstractTestKitContext
+    with ActionContext
+    with ActionCreationContext {
   override def getGrpcClient[T](clientClass: Class[T], service: String): T =
     throw new UnsupportedOperationException("Testing logic using a gRPC client is not possible with the testkit")
 

--- a/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/TestKitActionContext.scala
+++ b/sdk/scala-sdk-testkit/src/main/scala/com/akkaserverless/scalasdk/testkit/impl/TestKitActionContext.scala
@@ -24,12 +24,12 @@ import com.akkaserverless.scalasdk.action.ActionCreationContext
 /**
  * INTERNAL API Used by the generated testkit
  */
-final class TestKitActionContext(
-    override val metadata: Metadata = Metadata.empty,
-    override val eventSubject: Option[String] = Some("test-subject-id"))
+final class TestKitActionContext(override val metadata: Metadata = Metadata.empty)
     extends AbstractTestKitContext
     with ActionContext
     with ActionCreationContext {
+
+  override def eventSubject = metadata.get("ce-subject")
   override def getGrpcClient[T](clientClass: Class[T], service: String): T =
     throw new UnsupportedOperationException("Testing logic using a gRPC client is not possible with the testkit")
 


### PR DESCRIPTION
Aproach passing Metadata to the RPC call methods themselves. One test passing using the TestKit generated by the ActionTestKitGenerator.

References #501