### PR TITLE
chore: Update archetype READMEs to CLI centered and fix links

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/README.md
@@ -10,7 +10,7 @@ While designing your service it is useful to read [designing services](https://d
 ]]#
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
 extend it it may be useful to read up on [developing services](https://docs.kalix.io/developing/index.html)
-and in particular the [Java section](https://docs.kalix.io/java-services/index.html)
+and in particular the [Java section](https://docs.kalix.io/java/index.html)
 
 #[[
 ## Building
@@ -39,7 +39,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/${package}.MyServiceEntity/GetValue -d '{"entityId": "foo"}'
@@ -69,8 +69,8 @@ You will need to update the `dockerImage` property in the `pom.xml` and refer to
 [Configuring registries](https://docs.kalix.io/projects/container-registries.html)
 for more information on how to make your docker image available to Kalix.
 
-Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a project and then deploy your service into the project either by using `mvn deploy` which
-will also conveniently package and publish your docker image prior to deployment, or by first packaging and
-publishing the docker image through `mvn clean package docker:push -DskipTests` and then deploying the image
-through the `kalix` CLI or via the web interface.
+Finally, you use the `kalix` CLI to create a project as described in [Create a new Project](https://docs.kalix.io/projects/create-project.html). Once you have a project you can deploy your service into the project either
+by using `mvn deploy` which will also conveniently package and publish your docker image prior to deployment,
+or by first packaging and publishing the docker image through `mvn clean package docker:push -DskipTests` and
+then [deploying the image through the `kalix` CLI](https://docs.kalix.io/services/deploy-service.html#_deploy).
+

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/README.md
@@ -10,7 +10,7 @@ While designing your service it is useful to read [designing services](https://d
 ]]#
 This project has a bare-bones skeleton service ready to go, but in order to adapt and
 extend it it may be useful to read up on [developing services](https://docs.kalix.io/developing/index.html)
-and in particular the [Java section](https://docs.kalix.io/java-services/index.html)
+and in particular the [Java section](https://docs.kalix.io/java/index.html)
 
 #[[
 ## Building
@@ -39,7 +39,7 @@ To start the application locally, the `exec-maven-plugin` is used. Use the follo
 mvn compile exec:exec
 ```
 
-With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/proto.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
+With both the proxy and your application running, any defined endpoints should be available at `http://localhost:9000`. In addition to the defined gRPC interface, each method has a corresponding HTTP endpoint. Unless configured otherwise (see [Transcoding HTTP](https://docs.kalix.io/java/writing-grpc-descriptors-protobuf.html#_transcoding_http)), this endpoint accepts POST requests at the path `/[package].[entity name]/[method]`. For example, using `curl`:
 
 ```
 > curl -XPOST -H "Content-Type: application/json" localhost:9000/${package}.CounterService/GetCurrentCounter -d '{"counterId": "foo"}'
@@ -69,8 +69,7 @@ You will need to update the `dockerImage` property in the `pom.xml` and refer to
 [Configuring registries](https://docs.kalix.io/projects/container-registries.html)
 for more information on how to make your docker image available to Kalix.
 
-Finally, you can use the [Kalix Console](https://console.kalix.io)
-to create a project and then deploy your service into the project either by using `mvn deploy` which
-will also conveniently package and publish your docker image prior to deployment, or by first packaging and
-publishing the docker image through `mvn clean package docker:push -DskipTests` and then deploying the image
-through the `kalix` CLI or via the web interface.
+Finally, you use the `kalix` CLI to create a project as described in [Create a new Project](https://docs.kalix.io/projects/create-project.html). Once you have a project you can deploy your service into the project either 
+by using `mvn deploy` which will also conveniently package and publish your docker image prior to deployment, 
+or by first packaging and publishing the docker image through `mvn clean package docker:push -DskipTests` and 
+then [deploying the image through the `kalix` CLI](https://docs.kalix.io/services/deploy-service.html#_deploy).


### PR DESCRIPTION
References https://github.com/lightbend/kalix-docs/issues/1189