### PR TITLE
feat(java): Support for building Kalix images on Mac m1 #78

### DIFF
--- a/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-event-sourced-entity/src/main/resources/archetype-resources/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -122,6 +122,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${D}{jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${D}{dockerTag}</tag>

--- a/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
+++ b/maven-java/kalix-maven-archetype-value-entity/src/main/resources/archetype-resources/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -122,6 +122,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${D}{jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${D}{dockerTag}</tag>

--- a/samples/java-customer-registry-kafka-quickstart/pom.xml
+++ b/samples/java-customer-registry-kafka-quickstart/pom.xml
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -120,6 +120,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-customer-registry-quickstart/pom.xml
+++ b/samples/java-customer-registry-quickstart/pom.xml
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -120,6 +120,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-customer-registry-views-quickstart/pom.xml
+++ b/samples/java-customer-registry-views-quickstart/pom.xml
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -120,6 +120,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-doc-snippets/pom.xml
+++ b/samples/java-doc-snippets/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -122,6 +122,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-eventsourced-counter/pom.xml
+++ b/samples/java-eventsourced-counter/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -122,6 +122,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-eventsourced-customer-registry/pom.xml
+++ b/samples/java-eventsourced-customer-registry/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -122,6 +122,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-eventsourced-shopping-cart/pom.xml
+++ b/samples/java-eventsourced-shopping-cart/pom.xml
@@ -117,7 +117,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.26.1</version>
+                <version>0.39.1</version>
                 <configuration>
                     <images>
                         <image>
@@ -125,6 +125,9 @@
                             <build>
                                 <!-- Base Docker image which contains jre-->
                                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                                <createImageOptions>
+                                    <platform>linux/amd64</platform>
+                                </createImageOptions>
                                 <tags>
                                     <!-- tag for generated image -->
                                     <tag>${dockerTag}</tag>

--- a/samples/java-fibonacci-action/pom.xml
+++ b/samples/java-fibonacci-action/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -122,6 +122,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-first-service/pom.xml
+++ b/samples/java-first-service/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -122,6 +122,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-replicatedentity-examples/pom.xml
+++ b/samples/java-replicatedentity-examples/pom.xml
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.26.1</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -120,6 +120,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-replicatedentity-shopping-cart/pom.xml
+++ b/samples/java-replicatedentity-shopping-cart/pom.xml
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.26.1</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -120,6 +120,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-shopping-cart-quickstart/pom.xml
+++ b/samples/java-shopping-cart-quickstart/pom.xml
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -121,6 +121,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-valueentity-counter/pom.xml
+++ b/samples/java-valueentity-counter/pom.xml
@@ -125,7 +125,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -133,6 +133,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+	            <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-valueentity-customer-registry/pom.xml
+++ b/samples/java-valueentity-customer-registry/pom.xml
@@ -114,7 +114,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -122,6 +122,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>

--- a/samples/java-valueentity-shopping-cart/pom.xml
+++ b/samples/java-valueentity-shopping-cart/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.36.0</version>
+        <version>0.39.1</version>
         <configuration>
           <images>
             <image>
@@ -123,6 +123,9 @@
               <build>
                 <!-- Base Docker image which contains jre-->
                 <from>docker.io/library/adoptopenjdk:${jdk.target}-jre-hotspot</from>
+                <createImageOptions>
+                  <platform>linux/amd64</platform>
+                </createImageOptions>
                 <tags>
                   <!-- tag for generated image -->
                   <tag>${dockerTag}</tag>


### PR DESCRIPTION
References #78 

M1 needs to cross build images for x86_64, this maven plugin setting should do that out of the box.

Manually verified to also work building an image on Linux/x86_64 (I don't think our tests cover building images)