### PR TITLE
feat: Allow error codes for non error effects in Java SDK

### DIFF
--- a/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Metadata.java
+++ b/sdk/java-sdk-protobuf/src/main/java/kalix/javasdk/Metadata.java
@@ -251,6 +251,15 @@ public interface Metadata extends Iterable<Metadata.MetadataEntry> {
    */
   Metadata withStatusCode(StatusCode.Redirect httpStatusCode);
 
+  /**
+   * Add an HTTP response code to this metadata.
+   * This will only take effect when HTTP transcoding is in use. It will be ignored for gRPC requests.
+   *
+   * @param httpStatusCode The success status code to add.
+   * @return a copy of this metadata with the HTTP response code set.
+   */
+  Metadata withStatusCode(StatusCode.ErrorCode httpStatusCode);
+
   /** A metadata entry. */
   interface MetadataEntry {
     /**

--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
@@ -195,6 +195,9 @@ private[kalix] class MetadataImpl private (val entries: Seq[MetadataEntry]) exte
   override def withStatusCode(code: StatusCode.Success): MetadataImpl =
     set("_kalix-http-code", code.value.toString)
 
+  override def withStatusCode(code: StatusCode.ErrorCode): MetadataImpl =
+    set("_kalix-http-code", code.value.toString)
+
   override def asMetadata(): Metadata = this
 
   // The reason we don't just implement JwtClaims ourselves is that some of the methods clash with CloudEvent


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->
References
- https://github.com/lightbend/akka-runtime/issues/4211

Sample usage:

```java
effects().reply(
  responsePayload, 
  Metadata.EMPTY.withStatusCode(StatusCode.ErrorCode.BAD_REQUEST))
```