### PR TITLE
feat: Allow error codes for non error effects in Scala SDK

### DIFF
--- a/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
+++ b/sdk/java-sdk-protobuf/src/main/scala/kalix/javasdk/impl/MetadataImpl.scala
@@ -190,13 +190,16 @@ private[kalix] class MetadataImpl private (val entries: Seq[MetadataEntry]) exte
   override def clearTime(): MetadataImpl = remove(MetadataImpl.CeTime)
 
   override def withStatusCode(code: StatusCode.Redirect): MetadataImpl =
-    set("_kalix-http-code", code.value.toString)
+    withHttpStatusCode(code.value)
 
   override def withStatusCode(code: StatusCode.Success): MetadataImpl =
-    set("_kalix-http-code", code.value.toString)
+    withHttpStatusCode(code.value)
 
   override def withStatusCode(code: StatusCode.ErrorCode): MetadataImpl =
-    set("_kalix-http-code", code.value.toString)
+    withHttpStatusCode(code.value)
+
+  private def withHttpStatusCode(code: Int): MetadataImpl =
+    set("_kalix-http-code", code.toString)
 
   override def asMetadata(): Metadata = this
 

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/Metadata.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/Metadata.scala
@@ -276,6 +276,17 @@ trait Metadata extends Iterable[MetadataEntry] {
   def withStatusCode(httpStatusCode: StatusCode.Redirect): Metadata
 
   /**
+   * Add an HTTP response code to this metadata. This will only take effect when HTTP transcoding is in use. It will be
+   * ignored for gRPC requests.
+   *
+   * @param httpStatusCode
+   *   The error status code to add.
+   * @return
+   *   a copy of this metadata with the HTTP response code set.
+   */
+  def withStatusCode(httpStatusCode: StatusCode.Error): Metadata
+
+  /**
    * Get the trace context associated with this request metadata.
    * @return
    *   The trace context.

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/StatusCode.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/StatusCode.scala
@@ -52,4 +52,25 @@ object StatusCode {
   case object TemporaryRedirect extends Redirect(307)
 
   case object PermanentRedirect extends Redirect(308)
+
+  sealed abstract class Error(val value: Int) extends StatusCode
+
+  case object BadRequest extends Error(400)
+
+  case object Unauthorized extends Error(401)
+
+  case object Forbidden extends Error(403)
+
+  case object NotFound extends Error(404)
+
+  case object Conflict extends Error(409)
+
+  case object TooManyRequests extends Error(429)
+
+  case object InternalServerError extends Error(500)
+
+  case object ServiceUnavailable extends Error(503)
+
+  case object GatewayTimeout extends Error(504)
+
 }

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/MetadataImpl.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/MetadataImpl.scala
@@ -87,10 +87,16 @@ private[kalix] class MetadataImpl(val impl: kalix.javasdk.impl.MetadataImpl) ext
     override def apply: Seq[Principal] = impl.principals.get.asScala.map(Principal.toScala).toSeq
   }
   override def withStatusCode(code: StatusCode.Success): Metadata =
-    set("_kalix-http-code", code.value.toString)
+    withHttpStatusCode(code.value)
 
   override def withStatusCode(code: StatusCode.Redirect): Metadata =
-    set("_kalix-http-code", code.value.toString)
+    withHttpStatusCode(code.value)
+
+  override def withStatusCode(code: StatusCode.Error): Metadata =
+    withHttpStatusCode(code.value)
+
+  private def withHttpStatusCode(code: Int): Metadata =
+    set("_kalix-http-code", code.toString)
 
   override lazy val traceContext: TraceContext = new TraceContext {
     override def asOpenTelemetryContext = W3CTraceContextPropagator


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->
References
- https://github.com/lightbend/akka-runtime/issues/4211

Example usage:
```scala
effects.reply(message, Metadata.empty.withStatusCode(StatusCode.BadRequest))
```