### PR TITLE
build: use correct mvn publish creds from env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Setup global resolver
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PUBLISH_USER: ${{ secrets.PUBLISH_USER }}
-          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.KALIX_IO_SONATYPE_USER }}
+          SONATYPE_PASSWORD: ${{ secrets.KALIX_IO_SONATYPE_PASSWORD }}
         run: |
           chmod +x ./scripts/setup_global_resolver.sh
           ./scripts/setup_global_resolver.sh


### PR DESCRIPTION
I do not see `PUBLISH_USER` and `PUBLISH_PASSWORD` being used in the script: https://github.com/akka/github-actions-scripts/blob/main/setup_global_resolver.sh

But I see that `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` are used, and the [recent failure indicated](https://github.com/lightbend/kalix-jvm-sdk/actions/runs/18586846455/job/52992596478#step:10:542) that they were expected if we want the publish creds be present in the `settings.xml`:

> ⚠️ Publishing credentials (SONATYPE_USERNAME, SONATYPE_PASSWORD, PGP_PASSPHRASE) not set. Skipping publishing configuration.


🤞 