### PR TITLE
fix: workflow effect.error should not throw MatchError exception

### DIFF
--- a/publishLocally.sh
+++ b/publishLocally.sh
@@ -1,6 +1,7 @@
 # This script will publish the current snapshot of all artifacts. 
 # Including the maven plugin and archetypes.
 
+set -e
 export SDK_VERSION=$(sbt "print coreSdk/version" | tail -1)
 
 echo

--- a/samples/scala-protobuf-transfer-workflow/src/test/scala/com/example/transfer/api/TransferWorkflowIntegrationSpec.scala
+++ b/samples/scala-protobuf-transfer-workflow/src/test/scala/com/example/transfer/api/TransferWorkflowIntegrationSpec.scala
@@ -52,6 +52,12 @@ class TransferWorkflowIntegrationSpec
       }
     }
 
+    "not start transfer with negative amount" in {
+      val ex = transferClient.start(Transfer("1", "a", "b", -10)).failed.futureValue
+
+      ex.getMessage should include("transfer amount should be greater than zero")
+    }
+
   }
 
   override def afterAll(): Unit = {

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/workflow/WorkflowAdapters.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/workflow/WorkflowAdapters.scala
@@ -5,9 +5,12 @@
 package kalix.scalasdk.impl.workflow
 
 import java.util.Optional
+
 import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters.ScalaDurationOps
 import scala.jdk.FutureConverters.FutureOps
 import scala.jdk.OptionConverters._
+
 import akka.stream.Materializer
 import com.google.protobuf.Descriptors
 import kalix.javasdk
@@ -26,8 +29,6 @@ import kalix.scalasdk.workflow.CommandContext
 import kalix.scalasdk.workflow.WorkflowContext
 import kalix.scalasdk.workflow.WorkflowOptions
 import kalix.scalasdk.workflow.WorkflowProvider
-
-import scala.jdk.DurationConverters.ScalaDurationOps
 
 private[scalasdk] final class JavaWorkflowAdapter[S >: Null](scalaSdkWorkflow: AbstractWorkflow[S])
     extends javasdk.workflow.Workflow[S] {
@@ -174,7 +175,8 @@ private[scalasdk] final class JavaWorkflowRouterAdapter[S >: Null](
       command: Any,
       context: javasdk.workflow.CommandContext): javasdk.workflow.AbstractWorkflow.Effect[_] = {
     scalaSdkRouter.handleCommand(commandName, state, command, new ScalaCommandContextAdapter(context)) match {
-      case WorkflowEffectImpl(javaSdkEffectImpl) => javaSdkEffectImpl
+      case WorkflowEffectImpl(javaSdkEffectImpl)   => javaSdkEffectImpl
+      case ErrorEffectImpl(javaSdkErrorEffectImpl) => javaSdkErrorEffectImpl
     }
   }
 }

--- a/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/workflow/WorkflowEffectImpl.scala
+++ b/sdk/scala-sdk-protobuf/src/main/scala/kalix/scalasdk/impl/workflow/WorkflowEffectImpl.scala
@@ -85,7 +85,7 @@ private[scalasdk] final case class WorkflowEffectImpl[S, T](
     override def delete: TransitionalEffect[Void] =
       TransitionalEffectImpl(javasdkEffect.delete())
   }
-
-  case class ErrorEffectImpl[R](javasdkEffect: workflow.AbstractWorkflow.Effect.ErrorEffect[T]) extends ErrorEffect[R]
-
 }
+
+private[scalasdk] final case class ErrorEffectImpl[R](javasdkEffect: workflow.AbstractWorkflow.Effect.ErrorEffect[R])
+    extends ErrorEffect[R]


### PR DESCRIPTION
References: https://github.com/lightbend/akka-runtime/issues/4471
