### PR TITLE
build: improve release process with script and artifact checks

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,10 @@
 # Releasing Kalix Java SDK
 
-Create a release issue (using the [GitHub CLI](https://cli.github.com/))
+Create a release issue (using the [GitHub CLI](https://cli.github.com/)):
 
 ```shell
-gh issue create --title 'Release Kalix Java/Scala SDKs' --label kalix-runtime --body-file docs/release-issue-template.md -w
-````
+sh ./scripts/create-release-issue.sh 1.x.y
+```
 
 and follow the instructions.
 

--- a/docs/release-issue-template.md
+++ b/docs/release-issue-template.md
@@ -17,6 +17,8 @@ You can see the Kalix Runtime version on prod [on grafana](https://grafana.sre.k
 
 ### Check availability
 
+- [ ] Wait for the [Publish action](https://github.com/lightbend/kalix-jvm-sdk/actions/workflows/publish.yml) to complete for the release tag
+
 - [ ] Manually update [`docs/kalix-current`](https://github.com/lightbend/kalix-jvm-sdk/commits/docs/kalix-current) (There is a workflow but that has been failing, possibly for expired secrets)
   - To update that branch, run this locally
     ```shell
@@ -26,8 +28,8 @@ You can see the Kalix Runtime version on prod [on grafana](https://grafana.sre.k
     ```
 
 - [ ] Check the released artifacts
-    - [ ] Check the parent pom version is available at maven central https://repo1.maven.org/maven2/io/kalix/kalix-java-sdk-protobuf-parent/
-    - [ ] Check the version is listed in our own https://repo.akka.io/maven/io/kalix/kalix-jvm-core-sdk/.
+    - [ ] Check the parent pom is available at Maven Central: `mvn dependency:get -Dartifact=io.kalix:kalix-java-sdk-protobuf-parent:$VERSION$:pom`
+    - [ ] Check the core SDK is available in our own repo: `mvn dependency:get -Dartifact=io.kalix:kalix-jvm-core-sdk:$VERSION$ -Dmaven.repo.remote=https://repo.akka.io/maven`
 
 ### Fix and publish docs
 

--- a/docs/release-issue-template.md
+++ b/docs/release-issue-template.md
@@ -11,7 +11,7 @@ You can see the Kalix Runtime version on prod [on grafana](https://grafana.sre.k
 ### Cutting the release 
 
 - [ ] Update the "Change date" on [the license](../blob/main/LICENSE#L9) to release date plus three years and the version of the SDK in "Licensed Work".
-- [ ] Use the "Generate release notes" button to create [a new release](https://github.com/lightbend/kalix-jvm-sdk/releases/new) with the appropriate tag.
+- [ ] Use the "Generate release notes" button to create [a new release](https://github.com/lightbend/kalix-jvm-sdk/releases/new?tag=v$VERSION$) with the appropriate tag.
     - Review the generated notes and "Publish release"
     - CI will automatically publish to the repository based on the tag
 

--- a/scripts/create-release-issue.sh
+++ b/scripts/create-release-issue.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+VERSION=$1
+if [ -z $VERSION ]
+then
+  echo "Specify the version to be released, e.g. 1.5.24"
+else
+  sed -e 's/\$VERSION\$/'$VERSION'/g' docs/release-issue-template.md > /tmp/release-$VERSION.md
+  echo Created $(gh issue create --title "Release Kalix Java/Scala SDKs $VERSION" --label kalix-runtime --body-file /tmp/release-$VERSION.md --web)
+fi


### PR DESCRIPTION
Improves the release process:

- Add `scripts/create-release-issue.sh` to create release issues (modelled after akka-core), substituting `$VERSION$` in the template
- Update `RELEASING.md` to use the new script instead of the raw `gh issue create` command
- Update `docs/release-issue-template.md`:
  - Add step to wait for the Publish action to complete before checking artifacts
  - Replace broken Maven Central and repo.akka.io browse links with `mvn dependency:get` commands using `$VERSION$` substitution