### PR TITLE
build: Fix release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Build and publish artifacts and plugins
         id: build_sdk
         run: |-
-          sbt -Ddisable.apidocs=true publishM2 +publishLocal
+          sbt -Dkalix.release=true -Ddisable.apidocs=true publishM2 +publishLocal
           # the SDK_VERSION is later used to run the maven tests (see below)
           .github/determine-sdk-version.sh
           SDK_VERSION="$(cat ~/kalix-sdk-version.txt)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,10 +57,10 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           PUBLISH_USER: ${{ secrets.PUBLISH_USER }}
           PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
-        run: sbt +publishSigned
+        run: sbt -Dkalix.release=true +publishSigned
 
       - name: sbt publishM2
-        run: sbt +publishM2
+        run: sbt -Dkalix.release=true +publishM2
 
       - name: mvn deploy
         run: |-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,16 +35,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: akka/github-actions-scripts
-          path: scripts
+          path: github-actions-scripts
 
       - name: Setup global resolver
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           SONATYPE_USERNAME: ${{ secrets.KALIX_IO_SONATYPE_USER }}
           SONATYPE_PASSWORD: ${{ secrets.KALIX_IO_SONATYPE_PASSWORD }}
-        run: |
-          chmod +x ./scripts/setup_global_resolver.sh
-          ./scripts/setup_global_resolver.sh
+        run: ./github-actions-scripts/setup_global_resolver.sh
 
       - name: Determine SDK version
         id: determine_sdk_version
@@ -120,12 +118,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: akka/github-actions-scripts
-          path: scripts
+          path: github-actions-scripts
 
       - name: Setup global resolver
-        run: |
-          chmod +x ./scripts/setup_global_resolver.sh
-          ./scripts/setup_global_resolver.sh
+        run: ./github-actions-scripts/setup_global_resolver.sh
 
       - name: Determine SDK version
         id: determine_sdk_version

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -3,12 +3,17 @@ import sbt.Keys._
 import akka.grpc.sbt.AkkaGrpcPlugin
 import com.lightbend.sbt.JavaFormatterPlugin.autoImport.javafmtOnCompile
 import de.heikoseeberger.sbtheader.{ AutomateHeaderPlugin, HeaderPlugin }
+import _root_.io.akka.sbt.ArtifactBomPlugin.autoImport.makeBomOnCompile
 import org.scalafmt.sbt.ScalafmtPlugin
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import sbtprotoc.ProtocPlugin
 import scala.collection.breakOut
 
 object CommonSettings extends AutoPlugin {
+
+  // set via `-Dkalix.release=true` when publishing, so artifact BOMs are not regenerated on compile
+  // and don't dirty the working tree (which would taint the dynver version with a `-dev` snapshot suffix)
+  val isRelease = sys.props.contains("kalix.release")
 
   override def requires = plugins.JvmPlugin && ScalafmtPlugin
   override def trigger = allRequirements
@@ -51,6 +56,14 @@ object CommonSettings extends AutoPlugin {
     )
 
   override def projectSettings = Seq(run / fork := true, Test / fork := true, Test / javaOptions ++= Seq("-Xms1G"))
+}
+
+object CommonArtifactBomSettings extends AutoPlugin {
+
+  override def requires = _root_.io.akka.sbt.ArtifactBomPlugin
+  override def trigger = allRequirements
+
+  override def projectSettings = Seq(makeBomOnCompile := !CommonSettings.isRelease)
 }
 
 object CommonHeaderSettings extends AutoPlugin {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 // force bumped because of CI not finding 1.0.0 which was the transitive version
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.2")
 
-addSbtPlugin("io.akka.sbt" % "sbt-artifact-bom" % "0.0.3")
+addSbtPlugin("io.akka.sbt" % "sbt-artifact-bom" % "0.1.0")


### PR DESCRIPTION
Release was broken after #2420, working copy would get changes, making the release do a snapshot instead of actual release. Also including a bump of the bom plugin with the opt-out of touching any files through a system property in the build.

References
 - #2309
 - #2424 

We'll have to drop 1.5.25 and do a 1.5.26 because snapshots already got published.